### PR TITLE
fix: stop feeding prior-turn reasoning back into the Responses gateway tool loop

### DIFF
--- a/crates/agentic-server-core/src/executor/gateway.rs
+++ b/crates/agentic-server-core/src/executor/gateway.rs
@@ -392,8 +392,18 @@ pub(super) fn append_input_item(input: &mut ResponsesInput, item: InputItem) {
 }
 
 pub(super) fn append_output_items_to_input(input: &mut ResponsesInput, output_items: &[OutputItem]) {
-    for input_item in output_items.iter().filter_map(OutputItem::to_input_item) {
-        append_input_item(input, input_item);
+    for item in output_items {
+        // Reasoning items are ephemeral to the turn that produced them. Feeding a
+        // prior round's reasoning back into the next inference round causes some
+        // reasoning parsers (e.g. Qwen3) to re-emit that content wrapped in
+        // `<think>` tags on the visible text channel, leaking it into the answer.
+        // Carry forward only messages and tool calls; reasoning stays out of the loop.
+        if matches!(item, OutputItem::Reasoning(_)) {
+            continue;
+        }
+        if let Some(input_item) = item.to_input_item() {
+            append_input_item(input, input_item);
+        }
     }
 }
 
@@ -483,6 +493,50 @@ mod tests {
         // cap only matters when the model is still requesting tools.
         let decision = classify_round(false, &[], MAX - 1, MAX);
         assert!(matches!(decision, LoopDecision::Done));
+    }
+
+    #[test]
+    fn carry_forward_drops_reasoning_keeps_messages_and_calls() {
+        // A prior round's reasoning must NOT be fed back into the next inference
+        // round: some reasoning parsers re-emit it as `<think>` on the visible
+        // text channel, leaking it into the answer. Messages and function calls
+        // still carry forward so the loop keeps full non-reasoning context.
+        use super::append_output_items_to_input;
+        use crate::types::event::MessageStatus;
+        use crate::types::io::ResponsesInput;
+        use crate::types::io::output::{OutputItem, OutputMessage, ReasoningOutput};
+
+        let output = vec![
+            OutputItem::Reasoning(ReasoningOutput::new("rs_1")),
+            OutputItem::Message(OutputMessage::new("msg_1", MessageStatus::Completed)),
+            OutputItem::FunctionCall(FunctionToolCall {
+                id: "fc_1".to_owned(),
+                call_id: "call_1".to_owned(),
+                name: "web_search".to_owned(),
+                arguments: "{}".to_owned(),
+                status: MessageStatus::Completed,
+                namespace: None,
+            }),
+        ];
+
+        let mut input = ResponsesInput::Items(vec![]);
+        append_output_items_to_input(&mut input, &output);
+
+        let ResponsesInput::Items(items) = input else {
+            panic!("expected items input");
+        };
+        assert!(
+            !items.iter().any(|i| matches!(i, InputItem::Reasoning(_))),
+            "reasoning must not be carried back into the loop"
+        );
+        assert!(
+            items.iter().any(|i| matches!(i, InputItem::Message(_))),
+            "message should carry forward"
+        );
+        assert!(
+            items.iter().any(|i| matches!(i, InputItem::FunctionCall(_))),
+            "function call should carry forward"
+        );
     }
 
     use std::pin::Pin;


### PR DESCRIPTION
## Summary

Fixes #120.

In a multi-round **gateway tool loop** (`/v1/responses`, HTTP or WebSocket), raw `<think>...</think>` reasoning markup leaks into the client's visible `output_text` channel — reasoning also streams correctly on its own `reasoning_text` channel, so it effectively appears twice, once as markup inside the answer.

This affects **any client** driving the Responses gateway loop with gateway-owned tools (web_search / MCP) over more than one round — Codex, or any `/v1/responses` caller. It's not client-specific; the trigger is the model's reasoning parser, not the caller. (Note: the `/v1/messages` path is currently a transparent proxy and does not go through this loop, so it is not affected.)

Root cause: the loop's `Continue` branch (`executor/engine.rs`) calls `append_output_items_to_input(&mut ctx.enriched_request.input, &current_output)`, which fed each round's **reasoning** item back into the next inference round (`OutputItem::to_input_item` maps `Reasoning → InputItem::Reasoning`). Reasoning parsers (e.g. Qwen3) then re-emit that prior-turn reasoning wrapped in `<think>` on the visible text channel.

Reasoning is ephemeral to the turn that produced it — there's no reason to feed it back into subsequent inference rounds. This scopes the fix to the loop carry-forward: `append_output_items_to_input` now skips `Reasoning`, carrying forward only messages and tool calls.

**Deliberately scoped:** `to_input_item` is also used by the `previous_response_id` rehydration path (`storage/types/item.rs::into_input_items`), where reasoning *should* be preserved. That path is untouched — its `test_into_input_items_includes_reasoning` still passes. The client-visible/persisted output path (`public_output_items` → `payload.output`) is also untouched, so **reasoning is still shown to the client**; only what's fed back into inference changes.

## Test Plan

- New unit test `carry_forward_drops_reasoning_keeps_messages_and_calls`: feeds reasoning + message + function_call through `append_output_items_to_input` and asserts reasoning is dropped while message/function_call carry forward. Verified it **fails on the pre-fix code and passes with the fix**.
- `cargo test -p agentic-server-core` — 174/174 lib tests pass, including `test_into_input_items_includes_reasoning` (rehydration still preserves reasoning — no regression).
- `cargo fmt -- --check` clean; `cargo clippy -p agentic-server-core --all-targets -- -D warnings` clean.
- Root cause localized live (gateway → vLLM Qwen3 on GPU) with layered vLLM-direct tests: vLLM is clean unless a prior `reasoning` item is present in the input history (single-turn: clean; round-2 with function_call + output but no reasoning: clean; round-2 **with** reasoning fed back: leaks; round-2 with reasoning excluded: clean — this fix). The committed unit test is the regression guard.
