### PR TITLE
feat: Support Codex CLI remote compaction V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Add a provider to `~/.codex/config.toml`:
 
 ```toml
 [model_providers.agentic-api]
-name = "agentic-api"
+name = "OpenAI"
 base_url = "http://localhost:9000/v1"
 wire_api = "responses"
 requires_openai_auth = false
@@ -129,7 +129,7 @@ If the gateway enables OIDC, configure Codex's supported command-backed bearer a
 
 ```toml
 [model_providers.agentic-api]
-name = "agentic-api"
+name = "OpenAI"
 base_url = "http://localhost:9000/v1"
 wire_api = "responses"
 supports_websockets = true

--- a/crates/agentic-server-core/src/events/types.rs
+++ b/crates/agentic-server-core/src/events/types.rs
@@ -12,6 +12,7 @@ pub enum SSEItemType {
     WebSearchCall,
     McpCall,
     McpListTools,
+    Compaction,
     Message,
 }
 
@@ -25,6 +26,7 @@ impl SSEItemType {
             Self::WebSearchCall => "web_search_call",
             Self::McpCall => "mcp_call",
             Self::McpListTools => "mcp_list_tools",
+            Self::Compaction => "compaction",
             Self::Message => "message",
         }
     }
@@ -39,6 +41,7 @@ impl From<&str> for SSEItemType {
             "web_search_call" => Self::WebSearchCall,
             "mcp_call" => Self::McpCall,
             "mcp_list_tools" => Self::McpListTools,
+            "compaction" => Self::Compaction,
             _ => Self::Message,
         }
     }

--- a/crates/agentic-server-core/src/executor/accumulator.rs
+++ b/crates/agentic-server-core/src/executor/accumulator.rs
@@ -479,7 +479,7 @@ impl ResponseAccumulator {
                 text: String::with_capacity(256),
             }),
             SSEItemType::WebSearchCall if !item_id.is_empty() => Some(InFlight::WebSearchCall { item: None }),
-            SSEItemType::WebSearchCall => None,
+            SSEItemType::Compaction | SSEItemType::WebSearchCall => None,
             SSEItemType::McpCall => McpCall::try_from(payload).ok().map(|item| InFlight::McpCall { item }),
             SSEItemType::McpListTools => McpListTools::try_from(payload)
                 .ok()

--- a/crates/agentic-server-core/src/executor/accumulator.rs
+++ b/crates/agentic-server-core/src/executor/accumulator.rs
@@ -20,8 +20,8 @@ use crate::executor::function_sse::{FunctionSseTranslation, FunctionSseTranslato
 use crate::types::event::{MessageStatus, ResponseStatus};
 use crate::types::io::output::McpListTools;
 use crate::types::io::{
-    ApplyDone, CustomToolCall, FunctionToolCall, OutputItem, OutputMessage, OutputTextContent, ReasoningOutput,
-    ReasoningTextContent, ResponseUsage,
+    ApplyDone, CompactionItem, CustomToolCall, FunctionToolCall, OutputItem, OutputMessage, OutputTextContent,
+    ReasoningOutput, ReasoningTextContent, ResponseUsage,
 };
 use crate::types::io::{McpCall, WebSearchCall};
 use crate::types::request_response::{IncompleteDetails, ResponsePayload};
@@ -38,6 +38,7 @@ enum InFlight {
     WebSearchCall { item: Option<WebSearchCall> },
     McpCall { item: McpCall },
     McpListTools { item: McpListTools },
+    Compaction { item: CompactionItem },
 }
 
 impl std::fmt::Debug for InFlight {
@@ -50,6 +51,7 @@ impl std::fmt::Debug for InFlight {
             Self::WebSearchCall { .. } => write!(f, "InFlight::WebSearchCall {{ .. }}"),
             Self::McpCall { .. } => write!(f, "InFlight::McpCall {{ .. }}"),
             Self::McpListTools { .. } => write!(f, "InFlight::McpListTools {{ .. }}"),
+            Self::Compaction { .. } => write!(f, "InFlight::Compaction {{ .. }}"),
         }
     }
 }
@@ -87,6 +89,7 @@ impl InFlight {
             Self::WebSearchCall { item } => item.map(OutputItem::WebSearchCall),
             Self::McpCall { item } => Some(OutputItem::McpCall(item)),
             Self::McpListTools { item } => Some(OutputItem::McpListTools(item)),
+            Self::Compaction { item } => Some(OutputItem::Compaction(item)),
         }
     }
 }
@@ -479,7 +482,10 @@ impl ResponseAccumulator {
                 text: String::with_capacity(256),
             }),
             SSEItemType::WebSearchCall if !item_id.is_empty() => Some(InFlight::WebSearchCall { item: None }),
-            SSEItemType::Compaction | SSEItemType::WebSearchCall => None,
+            SSEItemType::Compaction => CompactionItem::try_from(payload)
+                .ok()
+                .map(|item| InFlight::Compaction { item }),
+            SSEItemType::WebSearchCall => None,
             SSEItemType::McpCall => McpCall::try_from(payload).ok().map(|item| InFlight::McpCall { item }),
             SSEItemType::McpListTools => McpListTools::try_from(payload)
                 .ok()
@@ -532,6 +538,7 @@ impl ResponseAccumulator {
                 (InFlight::CustomToolCall { item, input }, _) => item.apply_done(payload, input),
                 (InFlight::McpCall { item }, _) => item.apply_done(payload, &mut String::new()),
                 (InFlight::McpListTools { item }, _) => item.apply_done(payload, &mut String::new()),
+                (InFlight::Compaction { item }, _) => item.apply_done(payload, &mut String::new()),
                 (InFlight::WebSearchCall { item }, Some(OutputItem::WebSearchCall(mut call))) => {
                     if call.id.is_empty() {
                         call.id = in_flight_key
@@ -551,7 +558,8 @@ impl ResponseAccumulator {
             | OutputItem::CustomToolCall(_)
             | OutputItem::WebSearchCall(_)
             | OutputItem::McpCall(_)
-            | OutputItem::McpListTools(_)),
+            | OutputItem::McpListTools(_)
+            | OutputItem::Compaction(_)),
         ) = done_item
         {
             let OutputItem::WebSearchCall(call) = &mut output_item else {
@@ -622,6 +630,7 @@ fn in_flight_matches_call_type(item: &InFlight, item_type: SSEItemType) -> bool 
             | (InFlight::WebSearchCall { .. }, SSEItemType::WebSearchCall)
             | (InFlight::McpCall { .. }, SSEItemType::McpCall)
             | (InFlight::McpListTools { .. }, SSEItemType::McpListTools)
+            | (InFlight::Compaction { .. }, SSEItemType::Compaction)
     )
 }
 
@@ -882,6 +891,31 @@ mod tests {
         assert_eq!(item.tools.len(), 1);
         assert_eq!(item.tools[0].name, "increment");
         assert_eq!(item.tools[0].annotations, Some(serde_json::json!({"read_only": false})));
+    }
+
+    #[test]
+    fn compaction_added_and_done_accumulate_typed_output() {
+        let done = r#"data: {"type":"response.output_item.done","output_index":0,"item":{"type":"compaction","id":"cmp_1","encrypted_content":"durable summary"}}"#;
+        let lines = [
+            r#"data: {"type":"response.output_item.added","output_index":0,"item":{"type":"compaction","id":"cmp_1","encrypted_content":"durable summary"}}"#.to_owned(),
+            done.to_owned(),
+            r#"data: {"type":"response.completed","response":{"id":"resp_1","status":"completed"}}"#.to_owned(),
+        ];
+
+        let acc = ResponseAccumulator::from_sse_lines(lines, None);
+        assert_compaction_output(&acc.output);
+
+        let done_only = ResponseAccumulator::from_sse_lines([done.to_owned()], None);
+        assert_compaction_output(&done_only.output);
+    }
+
+    fn assert_compaction_output(output: &[OutputItem]) {
+        assert_eq!(output.len(), 1);
+        let OutputItem::Compaction(item) = &output[0] else {
+            panic!("expected compaction output");
+        };
+        assert_eq!(item.id.as_deref(), Some("cmp_1"));
+        assert_eq!(item.encrypted_content, "durable summary");
     }
 
     #[test]

--- a/crates/agentic-server-core/src/executor/compaction.rs
+++ b/crates/agentic-server-core/src/executor/compaction.rs
@@ -95,7 +95,7 @@ fn item_has_meaningful_context(item: &InputItem) -> bool {
                 || reasoning.encrypted_content.as_ref().is_some_and(value_has_content)
         }
         InputItem::Compaction(compaction) => !compaction.encrypted_content.trim().is_empty(),
-        InputItem::Unknown => false,
+        InputItem::CompactionTrigger | InputItem::Unknown => false,
     }
 }
 
@@ -178,7 +178,10 @@ pub(crate) async fn compact_items(
     }
 
     let compacted = retained_user_window(&original_items);
-    let mut summary_items = original_items;
+    let mut summary_items: Vec<InputItem> = original_items
+        .into_iter()
+        .filter(|item| !item.is_compaction_trigger())
+        .collect();
     summary_items.push(InputItem::Message(InputMessage {
         id: None,
         role: "user".to_owned(),

--- a/crates/agentic-server-core/src/executor/engine.rs
+++ b/crates/agentic-server-core/src/executor/engine.rs
@@ -12,24 +12,27 @@ use either::Either;
 use tokio::sync::mpsc;
 use tracing::debug;
 
-use super::compaction::maybe_compact_context;
+use super::compaction::{compact_items, maybe_compact_context};
 use super::gateway::{
     GatewayCallResult, LoopDecision, append_gateway_calls_to_new_input, append_output_items_to_input,
     append_tool_outputs, classify_round, complete_gateway_event_plans, emit_gateway_completed_events,
     emit_gateway_start_events, execute_and_emit_output_calls, execute_output_calls, gateway_event_plans,
     has_client_owned_calls, is_client_custom_call, is_gateway_owned_call, public_output_items,
 };
-use super::gateway_accumulator::{GatewayStreamAccumulator, StreamEvent, error_sse_chunk};
-use crate::events::EventFrame;
-use crate::executor::error::ExecutorResult;
+use super::gateway_accumulator::{
+    GatewayStreamAccumulator, StreamEvent, emit_sse_frame, error_sse_chunk, synthetic_event,
+};
+use crate::events::{EventFrame, SSEEventType};
+use crate::executor::error::{ExecutorError, ExecutorResult};
 use crate::executor::inference::DONE_MARKER;
 use crate::executor::persist::persist_if_needed;
 use crate::executor::rehydrate::rehydrate_conversation;
 use crate::executor::request::{ExecutionContext, RequestContext};
 use crate::executor::upstream::{emit_deferred_stream_events, fetch_blocking_payload, fetch_stream_payload};
 use crate::tool::{ToolRegistry, mcp};
-use crate::types::io::{OutputItem, ResponseUsage, ToolChoice};
+use crate::types::io::{InputItem, OutputItem, ResponseUsage, ResponsesInput, ToolChoice};
 use crate::types::request_response::{IncompleteDetails, RequestPayload, ResponsePayload};
+use crate::utils::common::{serialize_to_value, utcnow_str};
 
 pub use crate::executor::inference::BoxStream;
 
@@ -93,6 +96,10 @@ impl<T> Drop for AbortOnDrop<T> {
     }
 }
 
+#[allow(
+    clippy::too_many_lines,
+    reason = "round-loop orchestrator keeps the full gateway tool lifecycle in one function"
+)]
 async fn run_until_gateway_tools_complete(
     mut ctx: RequestContext,
     exec_ctx: &ExecutionContext,
@@ -100,6 +107,9 @@ async fn run_until_gateway_tools_complete(
     stream_upstream: bool,
     mut stream: Option<(&mut GatewayStreamAccumulator, &mpsc::UnboundedSender<StreamEvent>)>,
 ) -> ExecutorResult<(ResponsePayload, RequestContext)> {
+    if ctx.enriched_request.input.has_compaction_trigger() {
+        return run_compaction_trigger(ctx, exec_ctx, auth, stream).await;
+    }
     let mut executors = exec_ctx.gateway_executors.request_scoped();
     let registry: ToolRegistry = match ctx.enriched_request.tools.as_mut() {
         Some(tools) => ToolRegistry::build_with_handlers(tools, &mut executors).await?,
@@ -209,6 +219,93 @@ async fn run_until_gateway_tools_complete(
     }
 
     unreachable!("the final round returns Done, RequiresClientAction, or Incomplete");
+}
+
+/// Codex CLI remote-compaction V2: the client appends a `compaction_trigger`
+/// item to the input and expects the server to run its own summarization turn
+/// and stream back exactly one `compaction` output item plus `response.completed`.
+/// The trigger never reaches the upstream model; the summary inference is a
+/// normal blocking call against the same backend as standalone compaction.
+async fn run_compaction_trigger(
+    mut ctx: RequestContext,
+    exec_ctx: &ExecutionContext,
+    auth: Option<&str>,
+    mut stream: Option<(&mut GatewayStreamAccumulator, &mpsc::UnboundedSender<StreamEvent>)>,
+) -> ExecutorResult<(ResponsePayload, RequestContext)> {
+    let model = ctx.enriched_request.model.clone();
+    let instructions = ctx.enriched_request.instructions.clone();
+    let input = std::mem::replace(&mut ctx.enriched_request.input, ResponsesInput::Items(Vec::new()));
+    let (compacted, usage) = compact_items(&model, input, instructions.as_deref(), exec_ctx, auth).await?;
+    let compaction = compacted
+        .iter()
+        .rev()
+        .find_map(|item| match item {
+            InputItem::Compaction(item) => Some(item.clone()),
+            _ => None,
+        })
+        .ok_or_else(|| ExecutorError::CompactionFailed {
+            status: "completed".to_owned(),
+            details: "compaction produced no checkpoint item".to_owned(),
+        })?;
+    ctx.new_input_items = compacted;
+    let mut payload = ResponsePayload {
+        id: ctx.response_id.clone(),
+        object: "response".to_owned(),
+        created_at: utcnow_str(),
+        model,
+        status: "completed".to_owned(),
+        output: vec![OutputItem::Compaction(compaction)],
+        usage: Some(usage),
+        incomplete_details: None,
+        error: None,
+        previous_response_id: ctx.original_request.previous_response_id.clone(),
+        conversation_id: ctx.conversation_id.clone(),
+        instructions,
+    };
+    ctx.inject_ids(&mut payload);
+    if let Some((accumulator, sender)) = stream.as_mut() {
+        emit_compaction_stream_events(accumulator, sender, &payload)?;
+    }
+    Ok((payload, ctx))
+}
+
+/// Emit the lifecycle and compaction-item events codex's V2 collector consumes:
+/// `response.created`/`response.in_progress`, then one `output_item.added` and
+/// `output_item.done` pair carrying the `compaction` item. `response.completed`
+/// is produced by the normal terminal framing from the returned payload.
+fn emit_compaction_stream_events(
+    accumulator: &mut GatewayStreamAccumulator,
+    sender: &mpsc::UnboundedSender<StreamEvent>,
+    payload: &ResponsePayload,
+) -> ExecutorResult<()> {
+    let mut created = payload.clone();
+    "in_progress".clone_into(&mut created.status);
+    let response_value = serialize_to_value(&created).map_err(ExecutorError::JsonError)?;
+    for event_type in [SSEEventType::ResponseCreated, SSEEventType::ResponseInProgress] {
+        let mut frame = synthetic_event(event_type, [("response".to_owned(), response_value.clone())])?;
+        if accumulator.process_event(&mut frame, 0) {
+            emit_sse_frame(sender, &frame)?;
+        }
+    }
+    let item = payload
+        .output
+        .iter()
+        .find(|item| matches!(item, OutputItem::Compaction(_)))
+        .expect("compaction payload always carries its compaction item");
+    let item_value = serialize_to_value(item).map_err(ExecutorError::JsonError)?;
+    for event_type in [SSEEventType::OutputItemAdded, SSEEventType::OutputItemDone] {
+        let mut frame = synthetic_event(
+            event_type,
+            [
+                ("output_index".to_owned(), serde_json::json!(0)),
+                ("item".to_owned(), item_value.clone()),
+            ],
+        )?;
+        if accumulator.process_event(&mut frame, 0) {
+            emit_sse_frame(sender, &frame)?;
+        }
+    }
+    Ok(())
 }
 
 async fn execute_and_emit_round_output_calls(
@@ -530,6 +627,178 @@ pub async fn execute(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::executor::modes::{ConversationHandler, ResponseHandler};
+    use crate::storage::{ConversationStore, ResponseStore};
+    use futures::StreamExt;
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+
+    fn summary_upstream_response() -> serde_json::Value {
+        serde_json::json!({
+            "id": "resp_upstream",
+            "object": "response",
+            "created_at": 0,
+            "model": "test-model",
+            "status": "completed",
+            "output": [{
+                "id": "msg_upstream",
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{
+                    "type": "output_text",
+                    "text": "durable summary",
+                    "annotations": []
+                }]
+            }],
+            "usage": {
+                "input_tokens": 12,
+                "output_tokens": 3,
+                "total_tokens": 15
+            },
+            "incomplete_details": null,
+            "error": null,
+            "previous_response_id": null,
+            "conversation_id": null,
+            "instructions": null
+        })
+    }
+
+    async fn trigger_execution_context(
+        captured: Arc<Mutex<Option<serde_json::Value>>>,
+    ) -> (ExecutionContext, tokio::task::JoinHandle<()>) {
+        let captured_for_route = Arc::clone(&captured);
+        let app = axum::Router::new().route(
+            "/v1/responses",
+            axum::routing::post(move |body: axum::body::Bytes| async move {
+                let value =
+                    serde_json::from_slice::<serde_json::Value>(&body).expect("captured upstream body must be JSON");
+                *captured_for_route.lock().await = Some(value);
+                axum::Json(summary_upstream_response())
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind mock inference server");
+        let address = listener.local_addr().expect("mock server address");
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.ok();
+        });
+        let exec_ctx = ExecutionContext::new(
+            ConversationHandler::new(ConversationStore::disabled()),
+            ResponseHandler::new(ResponseStore::disabled()),
+            Arc::new(reqwest::Client::new()),
+            format!("http://{address}"),
+        );
+        (exec_ctx, server)
+    }
+
+    #[tokio::test]
+    async fn compaction_trigger_returns_single_compaction_item_without_upstream_trigger() {
+        let captured = Arc::new(Mutex::new(None));
+        let (exec_ctx, server) = trigger_execution_context(Arc::clone(&captured)).await;
+
+        let payload: RequestPayload = serde_json::from_value(serde_json::json!({
+            "model": "test-model",
+            "stream": false,
+            "store": false,
+            "input": [
+                {"role": "user", "content": "remember banana"},
+                {"type": "compaction_trigger"}
+            ]
+        }))
+        .expect("valid trigger request");
+        let Either::Left(response) = ExecuteRequest::new(payload, Arc::new(exec_ctx))
+            .run()
+            .await
+            .expect("trigger request succeeds")
+        else {
+            panic!("non-streaming trigger request must return a payload");
+        };
+
+        assert_eq!(response.status, "completed");
+        assert_eq!(response.output.len(), 1);
+        let OutputItem::Compaction(item) = &response.output[0] else {
+            panic!("expected exactly one compaction output item");
+        };
+        assert_eq!(item.encrypted_content, "durable summary");
+        assert!(item.id.as_deref().is_some_and(|id| id.starts_with("cmp_")));
+        assert_eq!(response.usage.as_ref().map(|usage| usage.total_tokens), Some(15));
+
+        let upstream = captured.lock().await.take().expect("summary inference ran");
+        assert!(
+            !upstream.to_string().contains("compaction_trigger"),
+            "trigger must never reach the upstream model"
+        );
+        assert!(upstream.to_string().contains("CONTEXT CHECKPOINT COMPACTION"));
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn compaction_trigger_streams_one_compaction_item_then_completed() {
+        let captured = Arc::new(Mutex::new(None));
+        let (exec_ctx, server) = trigger_execution_context(Arc::clone(&captured)).await;
+
+        let payload: RequestPayload = serde_json::from_value(serde_json::json!({
+            "model": "test-model",
+            "stream": true,
+            "store": false,
+            "input": [
+                {"role": "user", "content": "remember banana"},
+                {"type": "compaction_trigger"}
+            ]
+        }))
+        .expect("valid trigger request");
+        let Either::Right(stream) = ExecuteRequest::new(payload, Arc::new(exec_ctx))
+            .run()
+            .await
+            .expect("trigger request succeeds")
+        else {
+            panic!("streaming trigger request must return a stream");
+        };
+
+        let chunks: Vec<String> = stream.collect().await;
+        let mut event_types = Vec::new();
+        let mut compaction_done_count = 0;
+        for chunk in chunks {
+            let body = chunk.strip_suffix("\n\n").expect("SSE frame terminator");
+            let data = body
+                .lines()
+                .find_map(|line| line.strip_prefix("data: "))
+                .expect("SSE data line");
+            let Ok(event) = serde_json::from_str::<serde_json::Value>(data) else {
+                continue; // terminal [DONE] marker
+            };
+            let event_type = event["type"].as_str().expect("event type");
+            event_types.push(event_type.to_owned());
+            if event_type == "response.output_item.done" && event["item"]["type"] == "compaction" {
+                compaction_done_count += 1;
+                assert_eq!(event["item"]["encrypted_content"], "durable summary");
+            }
+        }
+
+        assert_eq!(
+            event_types,
+            [
+                "response.created",
+                "response.in_progress",
+                "response.output_item.added",
+                "response.output_item.done",
+                "response.completed",
+            ]
+        );
+        assert_eq!(compaction_done_count, 1);
+        assert!(
+            !captured
+                .lock()
+                .await
+                .take()
+                .expect("summary inference ran")
+                .to_string()
+                .contains("compaction_trigger")
+        );
+        server.abort();
+    }
 
     #[tokio::test]
     async fn stream_task_panic_after_event_uses_next_sequence_number_for_error() {

--- a/crates/agentic-server-core/src/executor/engine.rs
+++ b/crates/agentic-server-core/src/executor/engine.rs
@@ -15,15 +15,14 @@ use tracing::debug;
 use super::compaction::{compact_items, maybe_compact_context};
 use super::gateway::{
     GatewayCallResult, LoopDecision, append_gateway_calls_to_new_input, append_output_items_to_input,
-    append_tool_outputs, classify_round, complete_gateway_event_plans, emit_gateway_completed_events,
-    emit_gateway_start_events, execute_and_emit_output_calls, execute_output_calls, gateway_event_plans,
-    has_client_owned_calls, is_client_custom_call, is_gateway_owned_call, public_output_items,
+    append_tool_outputs, classify_round, compaction_event_plans, complete_gateway_event_plans,
+    emit_gateway_completed_events, emit_gateway_start_events, emit_response_start_events,
+    execute_and_emit_output_calls, execute_output_calls, gateway_event_plans, has_client_owned_calls,
+    is_client_custom_call, is_gateway_owned_call, public_output_items,
 };
-use super::gateway_accumulator::{
-    GatewayStreamAccumulator, StreamEvent, emit_sse_frame, error_sse_chunk, synthetic_event,
-};
-use crate::events::{EventFrame, SSEEventType};
-use crate::executor::error::{ExecutorError, ExecutorResult};
+use super::gateway_accumulator::{GatewayStreamAccumulator, StreamEvent, error_sse_chunk};
+use crate::events::EventFrame;
+use crate::executor::error::ExecutorResult;
 use crate::executor::inference::DONE_MARKER;
 use crate::executor::persist::persist_if_needed;
 use crate::executor::rehydrate::rehydrate_conversation;
@@ -32,7 +31,7 @@ use crate::executor::upstream::{emit_deferred_stream_events, fetch_blocking_payl
 use crate::tool::{ToolRegistry, mcp};
 use crate::types::io::{InputItem, OutputItem, ResponseUsage, ResponsesInput, ToolChoice};
 use crate::types::request_response::{IncompleteDetails, RequestPayload, ResponsePayload};
-use crate::utils::common::{serialize_to_value, utcnow_str};
+use crate::utils::common::utcnow_str;
 
 pub use crate::executor::inference::BoxStream;
 
@@ -96,20 +95,34 @@ impl<T> Drop for AbortOnDrop<T> {
     }
 }
 
-#[allow(
-    clippy::too_many_lines,
-    reason = "round-loop orchestrator keeps the full gateway tool lifecycle in one function"
-)]
 async fn run_until_gateway_tools_complete(
-    mut ctx: RequestContext,
+    ctx: RequestContext,
     exec_ctx: &ExecutionContext,
     auth: Option<&str>,
     stream_upstream: bool,
     mut stream: Option<(&mut GatewayStreamAccumulator, &mpsc::UnboundedSender<StreamEvent>)>,
 ) -> ExecutorResult<(ResponsePayload, RequestContext)> {
     if ctx.enriched_request.input.has_compaction_trigger() {
-        return run_compaction_trigger(ctx, exec_ctx, auth, stream).await;
+        let (payload, ctx) = run_compaction_trigger(ctx, exec_ctx, auth).await?;
+        if let Some((stream_accumulator, stream_sender)) = stream.as_mut() {
+            emit_response_start_events(&payload, stream_accumulator, stream_sender)?;
+            let event_plans = compaction_event_plans(&payload.output, 0);
+            emit_gateway_start_events(&event_plans, stream_accumulator, stream_sender)?;
+            emit_gateway_completed_events(&payload.output, &event_plans, stream_accumulator, stream_sender)?;
+        }
+        return Ok((payload, ctx));
     }
+
+    run_gateway_tool_loop(ctx, exec_ctx, auth, stream_upstream, stream).await
+}
+
+async fn run_gateway_tool_loop(
+    mut ctx: RequestContext,
+    exec_ctx: &ExecutionContext,
+    auth: Option<&str>,
+    stream_upstream: bool,
+    mut stream: Option<(&mut GatewayStreamAccumulator, &mpsc::UnboundedSender<StreamEvent>)>,
+) -> ExecutorResult<(ResponsePayload, RequestContext)> {
     let mut executors = exec_ctx.gateway_executors.request_scoped();
     let registry: ToolRegistry = match ctx.enriched_request.tools.as_mut() {
         Some(tools) => ToolRegistry::build_with_handlers(tools, &mut executors).await?,
@@ -230,7 +243,6 @@ async fn run_compaction_trigger(
     mut ctx: RequestContext,
     exec_ctx: &ExecutionContext,
     auth: Option<&str>,
-    mut stream: Option<(&mut GatewayStreamAccumulator, &mpsc::UnboundedSender<StreamEvent>)>,
 ) -> ExecutorResult<(ResponsePayload, RequestContext)> {
     let model = ctx.enriched_request.model.clone();
     let instructions = ctx.enriched_request.instructions.clone();
@@ -255,51 +267,7 @@ async fn run_compaction_trigger(
         instructions,
     };
     ctx.inject_ids(&mut payload);
-    if let Some((accumulator, sender)) = stream.as_mut() {
-        emit_compaction_stream_events(accumulator, sender, &payload)?;
-    }
     Ok((payload, ctx))
-}
-
-/// Emit the lifecycle and compaction-item events codex's V2 collector consumes:
-/// `response.created`/`response.in_progress`, then one `output_item.added` and
-/// `output_item.done` pair carrying the `compaction` item. `response.completed`
-/// is produced by the normal terminal framing from the returned payload.
-fn emit_compaction_stream_events(
-    accumulator: &mut GatewayStreamAccumulator,
-    sender: &mpsc::UnboundedSender<StreamEvent>,
-    payload: &ResponsePayload,
-) -> ExecutorResult<()> {
-    let mut created = payload.clone();
-    "in_progress".clone_into(&mut created.status);
-    created.output.clear();
-    created.usage = None;
-    let response_value = serialize_to_value(&created).map_err(ExecutorError::JsonError)?;
-    for event_type in [SSEEventType::ResponseCreated, SSEEventType::ResponseInProgress] {
-        let mut frame = synthetic_event(event_type, [("response".to_owned(), response_value.clone())])?;
-        if accumulator.process_event(&mut frame, 0) {
-            emit_sse_frame(sender, &frame)?;
-        }
-    }
-    let item = payload
-        .output
-        .iter()
-        .find(|item| matches!(item, OutputItem::Compaction(_)))
-        .expect("compaction payload always carries its compaction item");
-    let item_value = serialize_to_value(item).map_err(ExecutorError::JsonError)?;
-    for event_type in [SSEEventType::OutputItemAdded, SSEEventType::OutputItemDone] {
-        let mut frame = synthetic_event(
-            event_type,
-            [
-                ("output_index".to_owned(), serde_json::json!(0)),
-                ("item".to_owned(), item_value.clone()),
-            ],
-        )?;
-        if accumulator.process_event(&mut frame, 0) {
-            emit_sse_frame(sender, &frame)?;
-        }
-    }
-    Ok(())
 }
 
 async fn execute_and_emit_round_output_calls(

--- a/crates/agentic-server-core/src/executor/engine.rs
+++ b/crates/agentic-server-core/src/executor/engine.rs
@@ -235,18 +235,10 @@ async fn run_compaction_trigger(
     let model = ctx.enriched_request.model.clone();
     let instructions = ctx.enriched_request.instructions.clone();
     let input = std::mem::replace(&mut ctx.enriched_request.input, ResponsesInput::Items(Vec::new()));
-    let (compacted, usage) = compact_items(&model, input, instructions.as_deref(), exec_ctx, auth).await?;
-    let compaction = compacted
-        .iter()
-        .rev()
-        .find_map(|item| match item {
-            InputItem::Compaction(item) => Some(item.clone()),
-            _ => None,
-        })
-        .ok_or_else(|| ExecutorError::CompactionFailed {
-            status: "completed".to_owned(),
-            details: "compaction produced no checkpoint item".to_owned(),
-        })?;
+    let (mut compacted, usage) = compact_items(&model, input, instructions.as_deref(), exec_ctx, auth).await?;
+    let Some(InputItem::Compaction(compaction)) = compacted.pop() else {
+        unreachable!("compact_items always appends a compaction item");
+    };
     ctx.new_input_items = compacted;
     let mut payload = ResponsePayload {
         id: ctx.response_id.clone(),
@@ -280,6 +272,8 @@ fn emit_compaction_stream_events(
 ) -> ExecutorResult<()> {
     let mut created = payload.clone();
     "in_progress".clone_into(&mut created.status);
+    created.output.clear();
+    created.usage = None;
     let response_value = serialize_to_value(&created).map_err(ExecutorError::JsonError)?;
     for event_type in [SSEEventType::ResponseCreated, SSEEventType::ResponseInProgress] {
         let mut frame = synthetic_event(event_type, [("response".to_owned(), response_value.clone())])?;
@@ -628,7 +622,7 @@ pub async fn execute(
 mod tests {
     use super::*;
     use crate::executor::modes::{ConversationHandler, ResponseHandler};
-    use crate::storage::{ConversationStore, ResponseStore};
+    use crate::storage::{ConversationStore, InOutItem, ResponseStore, create_pool_with_schema};
     use futures::StreamExt;
     use std::sync::Arc;
     use tokio::sync::Mutex;
@@ -735,6 +729,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn compaction_trigger_persists_checkpoint_only_as_output() {
+        let captured = Arc::new(Mutex::new(None));
+        let (mut exec_ctx, server) = trigger_execution_context(Arc::clone(&captured)).await;
+        let pool = create_pool_with_schema(Some("sqlite::memory:"))
+            .await
+            .expect("create response store");
+        let response_store = ResponseStore::new(pool);
+        exec_ctx.resp_handler = ResponseHandler::new(response_store.clone());
+
+        let payload: RequestPayload = serde_json::from_value(serde_json::json!({
+            "model": "test-model",
+            "store": true,
+            "input": [
+                {"role": "user", "content": "remember banana"},
+                {"type": "compaction_trigger"}
+            ]
+        }))
+        .expect("valid trigger request");
+        let Either::Left(response) = ExecuteRequest::new(payload, Arc::new(exec_ctx))
+            .run()
+            .await
+            .expect("trigger request succeeds")
+        else {
+            panic!("non-streaming trigger request must return a payload");
+        };
+
+        let history = response_store
+            .rehydrate(&response.id)
+            .await
+            .expect("compaction trigger response rehydrates");
+        assert_eq!(history.len(), 2);
+        assert!(matches!(history[0], InOutItem::Input(InputItem::Message(_))));
+        assert!(matches!(history[1], InOutItem::Output(OutputItem::Compaction(_))));
+
+        let model_input = ResponsesInput::Items(InOutItem::into_input_items(history));
+        let serialized = serde_json::to_value(model_input.model_input()).expect("model input serializes");
+        assert_eq!(serialized.as_array().map(Vec::len), Some(2));
+        assert_eq!(serialized[0]["content"], "remember banana");
+        assert_eq!(serialized[1]["role"], "assistant");
+        assert_eq!(serialized[1]["content"][0]["text"], "durable summary");
+        server.abort();
+    }
+
+    #[tokio::test]
     async fn compaction_trigger_streams_one_compaction_item_then_completed() {
         let captured = Arc::new(Mutex::new(None));
         let (exec_ctx, server) = trigger_execution_context(Arc::clone(&captured)).await;
@@ -771,6 +809,10 @@ mod tests {
             };
             let event_type = event["type"].as_str().expect("event type");
             event_types.push(event_type.to_owned());
+            if matches!(event_type, "response.created" | "response.in_progress") {
+                assert_eq!(event["response"]["output"], serde_json::json!([]));
+                assert!(event["response"]["usage"].is_null());
+            }
             if event_type == "response.output_item.done" && event["item"]["type"] == "compaction" {
                 compaction_done_count += 1;
                 assert_eq!(event["item"]["encrypted_content"], "durable summary");

--- a/crates/agentic-server-core/src/executor/gateway.rs
+++ b/crates/agentic-server-core/src/executor/gateway.rs
@@ -10,7 +10,8 @@ use crate::executor::request::RequestContext;
 use crate::tool::{GatewayDispatchResult, ToolError, ToolOutput, ToolRegistry, ToolType};
 use crate::types::io::output::{FunctionToolCall, GatewayCallStatus, McpCallStatus};
 use crate::types::io::{InputItem, OutputItem, ResponsesInput};
-use crate::utils::common::serialize_to_string;
+use crate::types::request_response::ResponsePayload;
+use crate::utils::common::{serialize_to_string, serialize_to_value};
 
 /// Max gateway tool calls executing at once within a round. A sliding window:
 /// as one call finishes, the next is admitted, so a round with N calls never
@@ -329,8 +330,42 @@ pub(super) fn mcp_list_tools_event_plans(
         .collect()
 }
 
+pub(super) fn compaction_event_plans(
+    public_output_items: &[OutputItem],
+    output_offset: usize,
+) -> Vec<GatewayEventPlan> {
+    public_output_items
+        .iter()
+        .enumerate()
+        .filter(|(_, item)| matches!(item, OutputItem::Compaction(_)))
+        .map(|(index, item)| GatewayEventPlan {
+            output_index: u32::try_from(output_offset.saturating_add(index)).unwrap_or(u32::MAX),
+            started_output: Some(item.clone()),
+            completed_output: Some(item.clone()),
+            arguments: None,
+        })
+        .collect()
+}
+
 fn output_item_value(item: &OutputItem) -> ExecutorResult<serde_json::Value> {
     serde_json::to_value(item).map_err(ExecutorError::JsonError)
+}
+
+pub(super) fn emit_response_start_events(
+    payload: &ResponsePayload,
+    stream_accumulator: &mut GatewayStreamAccumulator,
+    stream_sender: &tokio::sync::mpsc::UnboundedSender<StreamEvent>,
+) -> ExecutorResult<()> {
+    let mut response = payload.clone();
+    "in_progress".clone_into(&mut response.status);
+    response.output.clear();
+    response.usage = None;
+    let response = serialize_to_value(&response).map_err(ExecutorError::JsonError)?;
+    for event_type in [SSEEventType::ResponseCreated, SSEEventType::ResponseInProgress] {
+        let mut event = synthetic_event(event_type, [("response".to_owned(), response.clone())])?;
+        emit_gateway_event(&mut event, stream_accumulator, stream_sender)?;
+    }
+    Ok(())
 }
 
 pub(super) fn complete_gateway_event_plans<T: GatewayPublicOutputSource>(
@@ -444,43 +479,45 @@ pub(super) fn emit_gateway_completed_events<T: GatewayPublicOutputSource>(
             continue;
         };
         let output_index = plan.output_index;
-        let (event_type, item_id) = match public_output {
+        let completed_event = match public_output {
             OutputItem::WebSearchCall(web_search_call) => {
-                (SSEEventType::WebSearchCallCompleted, web_search_call.id.as_str())
+                Some((SSEEventType::WebSearchCallCompleted, web_search_call.id.as_str()))
             }
-            OutputItem::McpCall(mcp_call) => (
+            OutputItem::McpCall(mcp_call) => Some((
                 if mcp_call.status == Some(McpCallStatus::Failed) {
                     SSEEventType::McpCallFailed
                 } else {
                     SSEEventType::McpCallCompleted
                 },
                 mcp_call.id.as_str(),
-            ),
-            OutputItem::McpListTools(list_tools) => (
+            )),
+            OutputItem::McpListTools(list_tools) => Some((
                 if list_tools.error.is_some() {
                     SSEEventType::McpListToolsFailed
                 } else {
                     SSEEventType::McpListToolsCompleted
                 },
                 list_tools.id.as_str(),
-            ),
+            )),
+            OutputItem::Compaction(_) => None,
             OutputItem::Message(_)
             | OutputItem::FunctionCall(_)
             | OutputItem::CustomToolCall(_)
             | OutputItem::Reasoning(_)
-            | OutputItem::Compaction(_)
             | OutputItem::Unknown => continue,
         };
         let item = output_item_value(public_output)?;
-        let mut completed_fields = serde_json::Map::from_iter([
-            ("item_id".to_owned(), serde_json::json!(item_id)),
-            ("output_index".to_owned(), serde_json::json!(output_index)),
-        ]);
-        if matches!(public_output, OutputItem::WebSearchCall(_)) {
-            completed_fields.insert("item".to_owned(), item.clone());
+        if let Some((event_type, item_id)) = completed_event {
+            let mut completed_fields = serde_json::Map::from_iter([
+                ("item_id".to_owned(), serde_json::json!(item_id)),
+                ("output_index".to_owned(), serde_json::json!(output_index)),
+            ]);
+            if matches!(public_output, OutputItem::WebSearchCall(_)) {
+                completed_fields.insert("item".to_owned(), item.clone());
+            }
+            let mut completed_event = synthetic_event(event_type, completed_fields)?;
+            emit_gateway_event(&mut completed_event, stream_accumulator, stream_sender)?;
         }
-        let mut completed_event = synthetic_event(event_type, completed_fields)?;
-        emit_gateway_event(&mut completed_event, stream_accumulator, stream_sender)?;
         let mut done_event = synthetic_event(
             SSEEventType::OutputItemDone,
             [
@@ -566,8 +603,9 @@ pub(super) fn append_gateway_calls_to_new_input(
 #[cfg(test)]
 mod tests {
     use super::{GatewayCallResult, LoopDecision, classify_round};
+    use crate::executor::accumulator::ResponseAccumulator;
     use crate::types::io::output::{FunctionToolCall, McpListTool, McpListTools};
-    use crate::types::io::{InputItem, McpCallStatus};
+    use crate::types::io::{CompactionItem, InputItem, McpCallStatus};
     use tokio::sync::mpsc;
 
     const MAX: usize = 10;
@@ -817,6 +855,45 @@ mod tests {
         );
         assert_eq!(events[0]["item"]["tools"], serde_json::json!([]));
         assert_eq!(events[3]["item"]["tools"][0]["name"], "increment");
+    }
+
+    #[test]
+    fn compaction_uses_shared_gateway_event_lifecycle_without_intermediate_event() {
+        let public_output = [OutputItem::Compaction(CompactionItem {
+            id: Some("cmp_1".to_owned()),
+            encrypted_content: "durable summary".to_owned(),
+        })];
+        let plans = super::compaction_event_plans(&public_output, 0);
+        let (sender, mut receiver) = mpsc::unbounded_channel();
+        let mut stream_accumulator = crate::executor::gateway_accumulator::GatewayStreamAccumulator::new();
+
+        super::emit_gateway_start_events(&plans, &mut stream_accumulator, &sender).expect("start events");
+        super::emit_gateway_completed_events(&public_output, &plans, &mut stream_accumulator, &sender)
+            .expect("completed events");
+
+        let chunks = std::iter::from_fn(|| receiver.try_recv().ok())
+            .map(|event| event.content)
+            .collect::<Vec<_>>();
+        let events = chunks
+            .iter()
+            .map(|chunk| parse_named_sse_event(chunk))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            events
+                .iter()
+                .map(|event| event["type"].as_str().unwrap())
+                .collect::<Vec<_>>(),
+            vec!["response.output_item.added", "response.output_item.done"]
+        );
+        assert_eq!(events[0]["item"], events[1]["item"]);
+        assert_eq!(events[1]["item"]["encrypted_content"], "durable summary");
+
+        let data_lines = chunks
+            .iter()
+            .filter_map(|chunk| chunk.lines().find(|line| line.starts_with("data: ")).map(str::to_owned));
+        let response = ResponseAccumulator::from_sse_lines(data_lines, None).finalize("test-model", None, None);
+        assert_eq!(response.output.len(), 1);
+        assert!(matches!(response.output[0], OutputItem::Compaction(_)));
     }
 
     #[test]

--- a/crates/agentic-server-core/src/executor/gateway.rs
+++ b/crates/agentic-server-core/src/executor/gateway.rs
@@ -422,6 +422,7 @@ pub(super) fn emit_gateway_start_events(
             | OutputItem::FunctionCall(_)
             | OutputItem::CustomToolCall(_)
             | OutputItem::Reasoning(_)
+            | OutputItem::Compaction(_)
             | OutputItem::Unknown => {}
         }
     }
@@ -467,6 +468,7 @@ pub(super) fn emit_gateway_completed_events<T: GatewayPublicOutputSource>(
             | OutputItem::FunctionCall(_)
             | OutputItem::CustomToolCall(_)
             | OutputItem::Reasoning(_)
+            | OutputItem::Compaction(_)
             | OutputItem::Unknown => continue,
         };
         let item = output_item_value(public_output)?;

--- a/crates/agentic-server-core/src/types/io/input.rs
+++ b/crates/agentic-server-core/src/types/io/input.rs
@@ -250,7 +250,7 @@ impl InputItem {
     }
 
     #[must_use]
-    pub fn is_compaction_trigger(&self) -> bool {
+    pub(crate) fn is_compaction_trigger(&self) -> bool {
         matches!(self, Self::CompactionTrigger)
     }
 }

--- a/crates/agentic-server-core/src/types/io/input.rs
+++ b/crates/agentic-server-core/src/types/io/input.rs
@@ -213,6 +213,11 @@ pub enum InputItem {
     Reasoning(ReasoningOutput),
     #[serde(rename = "compaction")]
     Compaction(CompactionItem),
+    /// Codex CLI's remote-compaction V2 marker. Signals the server to run its
+    /// own summarization turn and return exactly one `compaction` output item.
+    /// Carries no payload; it is never forwarded to the upstream model.
+    #[serde(rename = "compaction_trigger")]
+    CompactionTrigger,
     #[serde(other)]
     Unknown,
 }
@@ -231,6 +236,7 @@ impl<'de> Deserialize<'de> for InputItem {
             Some("custom_tool_call_output") => deserialize_from_value(value).map(Self::CustomToolCallOutput),
             Some("reasoning") => deserialize_from_value(value).map(Self::Reasoning),
             Some("compaction") => deserialize_from_value(value).map(Self::Compaction),
+            Some("compaction_trigger") => Ok(Self::CompactionTrigger),
             Some(_) => return Ok(Self::Unknown),
         };
         item.map_err(serde::de::Error::custom)
@@ -241,6 +247,11 @@ impl InputItem {
     #[must_use]
     pub(crate) fn is_unknown(&self) -> bool {
         matches!(self, Self::Unknown)
+    }
+
+    #[must_use]
+    pub fn is_compaction_trigger(&self) -> bool {
+        matches!(self, Self::CompactionTrigger)
     }
 }
 
@@ -303,11 +314,17 @@ impl ResponsesInput {
         matches!(self, Self::Items(items) if items.iter().any(|item| matches!(item, InputItem::Compaction(_))))
     }
 
+    #[must_use]
+    pub fn has_compaction_trigger(&self) -> bool {
+        matches!(self, Self::Items(items) if items.iter().any(InputItem::is_compaction_trigger))
+    }
+
     /// Return the canonical context sent to vLLM.
     ///
     /// vLLM does not understand public `compaction` items, so the latest item
     /// becomes an assistant message containing the locally generated summary.
     /// Items before that checkpoint are superseded and are omitted.
+    /// `compaction_trigger` markers are stripped and never reach the model.
     #[must_use]
     pub fn model_input(&self) -> Cow<'_, Self> {
         let Self::Items(items) = self else {
@@ -315,12 +332,21 @@ impl ResponsesInput {
         };
 
         let Some(window) = latest_compaction_window(items) else {
+            if items.iter().any(InputItem::is_compaction_trigger) {
+                let stripped = items
+                    .iter()
+                    .filter(|item| !item.is_compaction_trigger())
+                    .cloned()
+                    .collect();
+                return Cow::Owned(Self::Items(stripped));
+            }
             return Cow::Borrowed(self);
         };
 
         let model_items = window
             .retained_user_items(items)
             .chain(items[window.latest_index()..].iter())
+            .filter(|item| !item.is_compaction_trigger())
             .map(|item| match item {
                 InputItem::Compaction(compaction) => InputItem::Message(InputMessage {
                     id: None,
@@ -433,6 +459,57 @@ mod tests {
         assert_eq!(serialized[0]["role"], "assistant");
         assert_eq!(serialized[0]["content"][0]["type"], "output_text");
         assert_eq!(serialized[0]["content"][0]["text"], "summary");
+    }
+
+    #[test]
+    fn compaction_trigger_parses_as_dedicated_variant() {
+        let item: InputItem = serde_json::from_value(serde_json::json!({"type": "compaction_trigger"}))
+            .expect("compaction_trigger parses");
+        assert!(item.is_compaction_trigger());
+
+        let input: ResponsesInput = serde_json::from_value(serde_json::json!([
+            {"role": "user", "content": "history"},
+            {"type": "compaction_trigger"}
+        ]))
+        .expect("trigger input parses");
+        assert!(input.has_compaction_trigger());
+        assert!(!input.contains_compaction());
+    }
+
+    #[test]
+    fn model_input_strips_compaction_trigger_without_window() {
+        let input: ResponsesInput = serde_json::from_value(serde_json::json!([
+            {"role": "user", "content": "history"},
+            {"type": "compaction_trigger"}
+        ]))
+        .expect("trigger input parses");
+
+        let serialized = serde_json::to_value(input.model_input()).expect("model input serializes");
+        assert_eq!(serialized.as_array().map(Vec::len), Some(1));
+        assert_eq!(serialized[0]["type"], "message");
+        assert_eq!(serialized[0]["content"], "history");
+    }
+
+    #[test]
+    fn model_input_strips_compaction_trigger_after_window() {
+        let input: ResponsesInput = serde_json::from_value(serde_json::json!([
+            {"role": "user", "content": "discard me"},
+            {"type": "compaction", "encrypted_content": "summary"},
+            {"type": "message", "id": "msg_keep", "role": "user", "status": "completed", "content": "retained"},
+            {"type": "compaction_trigger"}
+        ]))
+        .expect("trigger input parses");
+
+        let serialized = serde_json::to_value(input.model_input()).expect("model input serializes");
+        assert_eq!(serialized.as_array().map(Vec::len), Some(2));
+        assert_eq!(serialized[0]["role"], "assistant");
+        assert_eq!(serialized[0]["content"][0]["text"], "summary");
+        assert_eq!(serialized[1]["content"], "retained");
+        assert!(
+            serialized
+                .as_array()
+                .is_some_and(|items| items.iter().all(|item| item["type"] != "compaction_trigger"))
+        );
     }
 
     #[test]

--- a/crates/agentic-server-core/src/types/io/output.rs
+++ b/crates/agentic-server-core/src/types/io/output.rs
@@ -9,7 +9,7 @@ use crate::utils::common::deserialize_from_value_opt;
 use crate::utils::uuid7_str;
 
 use super::input::{
-    InputContent, InputFunctionToolCall, InputItem, InputMessage, InputMessageContent, InputTextContent,
+    CompactionItem, InputContent, InputFunctionToolCall, InputItem, InputMessage, InputMessageContent, InputTextContent,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -707,6 +707,8 @@ pub enum OutputItem {
     McpListTools(McpListTools),
     #[serde(rename = "reasoning")]
     Reasoning(ReasoningOutput),
+    #[serde(rename = "compaction")]
+    Compaction(CompactionItem),
     #[serde(other)]
     Unknown,
 }
@@ -724,6 +726,7 @@ impl OutputItem {
             | Self::McpCall(_)
             | Self::McpListTools(_)
             | Self::Reasoning(_)
+            | Self::Compaction(_)
             | Self::Unknown => false,
         }
     }
@@ -735,6 +738,7 @@ impl OutputItem {
             Self::Reasoning(reasoning) => Some(InputItem::Reasoning(reasoning.clone())),
             Self::FunctionCall(call) => Some(InputItem::FunctionCall(InputFunctionToolCall::from(call.clone()))),
             Self::CustomToolCall(call) => Some(InputItem::FunctionCall(call.clone().into())),
+            Self::Compaction(item) => Some(InputItem::Compaction(item.clone())),
             Self::WebSearchCall(_) | Self::McpCall(_) | Self::McpListTools(_) | Self::Unknown => None,
         }
     }
@@ -744,6 +748,29 @@ impl OutputItem {
 mod tests {
     use super::*;
     use crate::types::io::InputItem;
+
+    #[test]
+    fn compaction_output_item_round_trips_with_type_tag() {
+        let item: OutputItem = serde_json::from_value(serde_json::json!({
+            "id": "cmp_1",
+            "type": "compaction",
+            "encrypted_content": "durable summary"
+        }))
+        .unwrap();
+
+        assert!(!item.requires_client_action(&ToolRegistry::default()));
+        let Some(InputItem::Compaction(compaction)) = item.to_input_item() else {
+            panic!("compaction should rehydrate as a compaction input item");
+        };
+        assert_eq!(compaction.id.as_deref(), Some("cmp_1"));
+        assert_eq!(compaction.encrypted_content, "durable summary");
+
+        let serialized = serde_json::to_value(&item).unwrap();
+        assert_eq!(serialized["type"], "compaction");
+        assert_eq!(serialized["encrypted_content"], "durable summary");
+        let parsed: OutputItem = serde_json::from_value(serialized).unwrap();
+        assert!(matches!(parsed, OutputItem::Compaction(_)));
+    }
 
     #[test]
     fn custom_tool_call_preserves_freeform_input_and_requires_client_action() {

--- a/crates/agentic-server-core/src/types/io/output.rs
+++ b/crates/agentic-server-core/src/types/io/output.rs
@@ -199,6 +199,25 @@ impl TryFrom<&EventPayload> for CustomToolCall {
     }
 }
 
+impl TryFrom<&EventPayload> for CompactionItem {
+    type Error = ExecutorError;
+
+    fn try_from(payload: &EventPayload) -> Result<Self, Self::Error> {
+        let EventPayload::OutputItemAdded { item_id, .. } = payload else {
+            return Err(ExecutorError::ParseError("expected OutputItemAdded payload".into()));
+        };
+        let id = if item_id.is_empty() {
+            uuid7_str("cmp_")
+        } else {
+            item_id.clone()
+        };
+        Ok(Self {
+            id: Some(id),
+            encrypted_content: String::new(),
+        })
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum GatewayCallStatus {
@@ -687,6 +706,21 @@ impl ApplyDone for McpListTools {
         if let Some(list_tools) = deserialize_from_value_opt(item.clone()) {
             *self = list_tools;
         }
+    }
+}
+
+impl ApplyDone for CompactionItem {
+    fn apply_done(&mut self, payload: &EventPayload, _buffer: &mut String) {
+        let EventPayload::OutputItemDone { item, .. } = payload else {
+            return;
+        };
+        let Some(mut compaction) = deserialize_from_value_opt::<Self>(item.clone()) else {
+            return;
+        };
+        if compaction.id.as_deref().is_none_or(str::is_empty) {
+            compaction.id.clone_from(&self.id);
+        }
+        *self = compaction;
     }
 }
 

--- a/crates/agentic-server-core/tests/support/mod.rs
+++ b/crates/agentic-server-core/tests/support/mod.rs
@@ -475,6 +475,7 @@ pub fn output_text(payload: &ResponsePayload) -> String {
             | OutputItem::McpCall(_)
             | OutputItem::McpListTools(_)
             | OutputItem::Reasoning(_)
+            | OutputItem::Compaction(_)
             | OutputItem::Unknown => None,
         })
         .collect::<String>()

--- a/crates/agentic-server/src/handler/http/responses.rs
+++ b/crates/agentic-server/src/handler/http/responses.rs
@@ -57,6 +57,7 @@ pub async fn responses(State(state): State<AppState>, req: Request) -> Response 
         || payload.previous_response_id.is_some()
         || payload.conversation_id.is_some()
         || payload.input.contains_compaction()
+        || payload.input.has_compaction_trigger()
         || payload
             .context_management
             .as_ref()
@@ -69,6 +70,7 @@ pub async fn responses(State(state): State<AppState>, req: Request) -> Response 
         has_previous_response_id = payload.previous_response_id.is_some(),
         has_conversation_id = payload.conversation_id.is_some(),
         has_compaction = payload.input.contains_compaction(),
+        has_compaction_trigger = payload.input.has_compaction_trigger(),
         context_management = payload.context_management.as_ref().map_or(0, Vec::len),
         tools = payload.tools.as_ref().map_or(0, Vec::len),
         "routing HTTP responses request"


### PR DESCRIPTION
## Summary

This adds server-side support for Codex CLI's remote compaction V2 to the Responses API, so server side compaction of agentic-api works with codex out of the box instead of fall back to client-side (local) compaction. Addressed #163 

In codex CLI (tested v0.146.0) remote compaction V2 is the default path. The client appends a bare {"type":"compaction_trigger"} item to a streaming /v1/responses request.

What I changed:

- Added a compaction_trigger variant to InputItem; previously, it deserialized as Unknown. Also added ResponsesInput::has_compaction_trigger().
- Added an executor branch that detects the trigger, removes it from model input, and runs the existing compact_items pipeline the same summarization pipeline used by /v1/responses/compact.
- Added OutputItem::Compaction and the corresponding SSEItemType::Compaction mapping.
- Streamed the generated checkpoint through response.output_item.added and response.output_item.done, followed by response.completed.
- Routed trigger-bearing HTTP requests through the executor instead of directly proxying them upstream.
- Stored retained user messages as request inputs and the generated checkpoint exactly once as response output, preventing duplicate checkpoints from dropping retained context on later turns.

Note: on the codex side, remote compaction only activates when the provider is name = "OpenAI" (case-sensitive) — that check is config-only on their end, documented in #163.

## Test Plan

- Added seven unit tests.
- Full workspace test suite: 695 passed, 0 failed, 9 ignored.
- cargo clippy --all-targets -- -D warnings passed.
- cargo fmt -- --check passed.
- Live smoke test against vLLM using google/gemma-4-26B-A4B-it: a streaming request containing compaction_trigger returned:
  response.created
  → response.in_progress
  → response.output_item.added
  → response.output_item.done (compaction)
  → response.completed

  The compaction item contained a model-generated checkpoint summary.

- Manual Codex test: configured agentic-api as the model provider, ran /compact in the TUI, and verified both the remote V2 compaction flow and a subsequent turn using the checkpoint as context.

