### PR TITLE
test: exercise native Codex and Claude harnesses

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -83,6 +83,12 @@ jobs:
       - name: Run tests
         run: cargo test
 
+      - name: Test Codex and Claude launcher contracts
+        run: bash scripts/tests/agentic-launchers-test.sh
+
+      - name: Test agentic CLI end to end
+        run: python3 scripts/tests/agentic-cli-e2e-test.py
+
   postgres:
     runs-on: ubuntu-latest
     services:
@@ -122,7 +128,7 @@ jobs:
             cargo-${{ runner.os }}-
 
       - name: Verify PostgreSQL schema upgrades and validation
-        run: cargo test -p agentic-server-core --lib -- --ignored
+        run: cargo test -p agentic-server-core --lib -- --ignored --test-threads=1
 
       - name: Verify PostgreSQL migrations and restart persistence
-        run: cargo test -p agentic-server-core --test postgres_storage_integration -- --ignored
+        run: cargo test -p agentic-server-core --test postgres_storage_integration -- --ignored --test-threads=1

--- a/crates/agentic-server/src/agentic_harness.rs
+++ b/crates/agentic-server/src/agentic_harness.rs
@@ -103,6 +103,10 @@ wire_api = \"responses\"\nrequires_openai_auth = {requires_auth}\nsupports_webso
 
 #[must_use]
 pub fn prepare_claude_env(gateway_url: &str, model: &str, api_key: Option<&str>) -> HarnessEnv {
+    let auth_token = std::env::var("ANTHROPIC_AUTH_TOKEN")
+        .ok()
+        .or_else(|| api_key.map(str::to_owned))
+        .unwrap_or_else(|| "agentic-api-local".to_owned());
     let mut environment = BTreeMap::from([
         (
             "ANTHROPIC_BASE_URL".to_owned(),
@@ -110,10 +114,14 @@ pub fn prepare_claude_env(gateway_url: &str, model: &str, api_key: Option<&str>)
         ),
         ("ANTHROPIC_MODEL".to_owned(), model.to_owned()),
         ("ANTHROPIC_SMALL_FAST_MODEL".to_owned(), model.to_owned()),
+        ("ANTHROPIC_DEFAULT_OPUS_MODEL".to_owned(), model.to_owned()),
+        ("ANTHROPIC_DEFAULT_SONNET_MODEL".to_owned(), model.to_owned()),
+        ("ANTHROPIC_DEFAULT_HAIKU_MODEL".to_owned(), model.to_owned()),
         (
             "ANTHROPIC_API_KEY".to_owned(),
             api_key.unwrap_or("agentic-api-local").to_owned(),
         ),
+        ("ANTHROPIC_AUTH_TOKEN".to_owned(), auth_token),
     ]);
     if let Some(api_key) = api_key {
         environment.insert("OPENAI_API_KEY".to_owned(), api_key.to_owned());
@@ -126,6 +134,21 @@ pub fn prepare_claude_env(gateway_url: &str, model: &str, api_key: Option<&str>)
             gateway_url.trim_end_matches('/')
         ),
     }
+}
+
+/// Validates that a Claude Code model name is a slash-free served alias.
+///
+/// # Errors
+///
+/// Returns an error when the model name contains `/`, which Claude Code does not
+/// accept for custom model names.
+pub fn validate_claude_model(model: &str) -> Result<(), String> {
+    if model.contains('/') {
+        return Err(format!(
+            "Claude Code requires a slash-free served model alias; start vLLM with --served-model-name and set --model to that alias (received {model})"
+        ));
+    }
+    Ok(())
 }
 
 fn toml_escape(value: &str) -> String {
@@ -163,8 +186,30 @@ mod tests {
             Some(&"http://127.0.0.1:3000".to_owned())
         );
         assert_eq!(env.environment.get("ANTHROPIC_MODEL"), Some(&"Qwen/test".to_owned()));
+        assert_eq!(
+            env.environment.get("ANTHROPIC_DEFAULT_OPUS_MODEL"),
+            Some(&"Qwen/test".to_owned())
+        );
+        assert_eq!(
+            env.environment.get("ANTHROPIC_DEFAULT_SONNET_MODEL"),
+            Some(&"Qwen/test".to_owned())
+        );
+        assert_eq!(
+            env.environment.get("ANTHROPIC_DEFAULT_HAIKU_MODEL"),
+            Some(&"Qwen/test".to_owned())
+        );
         assert_eq!(env.environment.get("ANTHROPIC_API_KEY"), Some(&"secret-key".to_owned()));
+        assert_eq!(
+            env.environment.get("ANTHROPIC_AUTH_TOKEN"),
+            Some(&"secret-key".to_owned())
+        );
         assert!(!env.summary.contains("secret-key"));
+    }
+
+    #[test]
+    fn claude_model_requires_a_served_alias() {
+        assert!(super::validate_claude_model("Qwen/test").is_err());
+        assert!(super::validate_claude_model("Qwen-test").is_ok());
     }
 
     fn unique_temp_dir(name: &str) -> std::path::PathBuf {

--- a/crates/agentic-server/src/agentic_process.rs
+++ b/crates/agentic-server/src/agentic_process.rs
@@ -285,6 +285,9 @@ fn harness_environment(
     options: &crate::agentic_cli::HarnessOptions,
     session_root: &Path,
 ) -> Result<crate::agentic_harness::HarnessEnv, Error> {
+    if matches!(harness, crate::agentic_cli::Harness::Claude) {
+        crate::agentic_harness::validate_claude_model(model).map_err(Error::Config)?;
+    }
     let mut environment = match harness {
         crate::agentic_cli::Harness::Codex => crate::agentic_harness::prepare_codex_home(
             session_root,
@@ -447,7 +450,7 @@ mod tests {
         let environment = super::harness_environment(
             Harness::Claude,
             "http://127.0.0.1:3000",
-            "Qwen/discovered",
+            "served-discovered",
             &options,
             &root,
         )
@@ -459,7 +462,7 @@ mod tests {
         );
         assert_eq!(
             environment.environment.get("ANTHROPIC_MODEL"),
-            Some(&"Qwen/discovered".to_owned())
+            Some(&"served-discovered".to_owned())
         );
     }
 
@@ -545,7 +548,7 @@ mod tests {
         let options = crate::agentic_cli::HarnessOptions {
             source: SourceOptions {
                 upstream: Some("http://127.0.0.1:8000".to_owned()),
-                model: Some("Qwen/test".to_owned()),
+                model: Some("served-test".to_owned()),
                 llm_port: 8000,
             },
             common: CommonOptions {
@@ -556,7 +559,7 @@ mod tests {
         };
         let root = std::env::temp_dir().join(format!("agentic-api-yolo-test-{}", std::process::id()));
         let environment =
-            super::harness_environment(Harness::Claude, "http://127.0.0.1:3000", "Qwen/test", &options, &root)
+            super::harness_environment(Harness::Claude, "http://127.0.0.1:3000", "served-test", &options, &root)
                 .expect("Claude environment");
 
         assert_eq!(

--- a/scripts/agentic-api.sh
+++ b/scripts/agentic-api.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+export V_API_BASE="${V_API_BASE:-http://127.0.0.1:8000/v1}"
+export V_API_KEY="${V_API_KEY:-demo}"
+export AGENTIC_MODEL="${AGENTIC_MODEL:-${V_MODEL:-agentic-api}}"
+export V_MODEL="$AGENTIC_MODEL"
+export MESSAGES_MODEL_OVERRIDE="${MESSAGES_MODEL_OVERRIDE:-$AGENTIC_MODEL}"
+export GATEWAY_HOST="${GATEWAY_HOST:-127.0.0.1}"
+export GATEWAY_PORT="${GATEWAY_PORT:-3020}"
+export DATABASE_URL="${DATABASE_URL:-sqlite:///tmp/agentic_api_3020.db}"
+export SKIP_LLM_READY_CHECK="${SKIP_LLM_READY_CHECK:-true}"
+export AGENTIC_DEBUG="${AGENTIC_DEBUG:-true}"
+
+if [[ "$AGENTIC_DEBUG" == "true" || "$AGENTIC_DEBUG" == "1" ]]; then
+  export RUST_LOG="${RUST_LOG:-agentic_server=debug,agentic_core=debug,agentic_core::proxy=trace}"
+fi
+export OPENAI_API_KEY="${OPENAI_API_KEY:-$V_API_KEY}"
+
+server_args=(
+  --gateway-host "$GATEWAY_HOST"
+  --gateway-port "$GATEWAY_PORT"
+  --llm-api-base "$V_API_BASE"
+)
+if [[ "$SKIP_LLM_READY_CHECK" == "true" || "$SKIP_LLM_READY_CHECK" == "1" ]]; then
+  server_args+=(--skip-llm-ready-check)
+fi
+
+echo "Starting agentic-api gateway on http://${GATEWAY_HOST}:${GATEWAY_PORT}"
+echo "Upstream base: ${V_API_BASE}"
+echo "Model: ${AGENTIC_MODEL}"
+
+exec cargo run -p agentic-server --bin agentic-server -- "${server_args[@]}"

--- a/scripts/agentic-claude.sh
+++ b/scripts/agentic-claude.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+gateway_url="${AGENTIC_GATEWAY_URL:-http://127.0.0.1:3020}"
+model="${AGENTIC_MODEL:-${V_MODEL:-agentic-api}}"
+claude_config_dir="${AGENTIC_CLAUDE_CONFIG_DIR:-/tmp/claude-agentic-3020}"
+claude_bin="${CLAUDE_BIN:-${AGENTIC_CLAUDE_BIN:-}}"
+
+if [[ -z "$claude_bin" ]]; then
+  claude_bin="$(command -v claude || true)"
+fi
+if [[ -z "$claude_bin" || ! -x "$claude_bin" ]]; then
+  echo 'error: Claude Code not found; set CLAUDE_BIN=/path/to/claude' >&2
+  exit 127
+fi
+if [[ "$model" == */* ]]; then
+  echo "error: Claude Code requires a slash-free served model alias; start vLLM with --served-model-name and set AGENTIC_MODEL to that alias" >&2
+  exit 2
+fi
+
+claude_args=(--bare --permission-mode manual --effort "${AGENTIC_CLAUDE_EFFORT:-medium}" --model "$model")
+if [[ "${AGENTIC_YOLO:-0}" == "1" || "${AGENTIC_YOLO:-}" == "true" ]]; then
+  claude_args+=(--dangerously-skip-permissions)
+fi
+
+exec env \
+  -u CLAUDE_CODE_USE_VERTEX \
+  -u ANTHROPIC_VERTEX_PROJECT_ID \
+  -u ANTHROPIC_MODEL \
+  CLAUDE_CONFIG_DIR="$claude_config_dir" \
+  CLAUDE_CODE_EFFORT_LEVEL="${AGENTIC_CLAUDE_EFFORT:-medium}" \
+  ANTHROPIC_BASE_URL="$gateway_url" \
+  ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-demo}" \
+  ANTHROPIC_AUTH_TOKEN="${ANTHROPIC_AUTH_TOKEN:-${ANTHROPIC_API_KEY:-demo}}" \
+  ANTHROPIC_MODEL="$model" \
+  ANTHROPIC_SMALL_FAST_MODEL="$model" \
+  ANTHROPIC_DEFAULT_OPUS_MODEL="$model" \
+  ANTHROPIC_DEFAULT_SONNET_MODEL="$model" \
+  ANTHROPIC_DEFAULT_HAIKU_MODEL="$model" \
+  "$claude_bin" \
+  "${claude_args[@]}" \
+  "$@"

--- a/scripts/agentic-codex.sh
+++ b/scripts/agentic-codex.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+gateway_url="${AGENTIC_GATEWAY_URL:-http://127.0.0.1:3020}"
+model="${AGENTIC_MODEL:-${V_MODEL:-agentic-api}}"
+codex_home="${AGENTIC_CODEX_HOME:-/tmp/codex-agentic-3020}"
+codex_bin="${CODEX_BIN:-}"
+
+if [[ -z "$codex_bin" ]]; then
+  codex_bin="$(command -v codex || true)"
+fi
+if [[ -z "$codex_bin" || ! -x "$codex_bin" ]]; then
+  echo 'error: Codex CLI not found; set CODEX_BIN=/path/to/codex' >&2
+  exit 127
+fi
+for required_command in curl jq; do
+  if ! command -v "$required_command" >/dev/null 2>&1; then
+    echo "error: $required_command is required to create the isolated Codex model catalog" >&2
+    exit 127
+  fi
+done
+
+managed_marker="$codex_home/.agentic-managed"
+if [[ -e "$codex_home" && ! -f "$managed_marker" ]]; then
+  echo "error: refusing to replace an unmanaged Codex home: $codex_home" >&2
+  echo 'set AGENTIC_CODEX_HOME to a new dedicated path and retry' >&2
+  exit 2
+fi
+mkdir -p "$codex_home"
+: >"$managed_marker"
+
+catalog_tmp="$(mktemp "$codex_home/model_catalog.json.tmp.XXXXXX")"
+config_tmp="$(mktemp "$codex_home/config.toml.tmp.XXXXXX")"
+trap 'rm -f "$catalog_tmp" "$config_tmp"' EXIT
+
+client_version="$($codex_bin --version | awk '{print $NF}')"
+if [[ -z "$client_version" ]]; then
+  echo 'error: unable to determine the Codex CLI version' >&2
+  exit 2
+fi
+models_url="${gateway_url%/}/v1/models?client_version=${client_version}"
+curl --fail --silent --show-error "$models_url" | jq --exit-status \
+  --arg model "$model" \
+  '{models: [.models[] | select(.slug == $model)]}
+  | if (.models | length) == 1
+    then .
+    else error("gateway model catalog must contain exactly one requested model")
+    end' >"$catalog_tmp"
+
+model_toml="$(jq --null-input --arg value "$model" '$value')"
+catalog_toml="$(jq --null-input --arg value "$codex_home/model_catalog.json" '$value')"
+base_url_toml="$(jq --null-input --arg value "${gateway_url%/}/v1" '$value')"
+{
+  printf 'model = %s\n' "$model_toml"
+  printf 'model_provider = "agentic-api"\n'
+  printf 'model_catalog_json = %s\n\n' "$catalog_toml"
+  printf '[model_providers.agentic-api]\n'
+  printf 'name = "Agentic API"\n'
+  printf 'base_url = %s\n' "$base_url_toml"
+  printf 'wire_api = "responses"\n'
+  printf 'requires_openai_auth = false\n'
+  printf 'supports_websockets = true\n'
+} >"$config_tmp"
+
+mv "$catalog_tmp" "$codex_home/model_catalog.json"
+mv "$config_tmp" "$codex_home/config.toml"
+trap - EXIT
+
+export CODEX_HOME="$codex_home"
+codex_command=("$codex_bin" -C "$repo_root" --search --disable image_generation)
+if [[ "${AGENTIC_YOLO:-0}" == "1" || "${AGENTIC_YOLO:-}" == "true" ]]; then
+  codex_command+=(--dangerously-bypass-approvals-and-sandbox)
+fi
+exec "${codex_command[@]}" "$@"

--- a/scripts/tests/agentic-cli-e2e-test.py
+++ b/scripts/tests/agentic-cli-e2e-test.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Exercise `agentic run` with local vLLM-shaped and harness-shaped processes."""
+
+from __future__ import annotations
+
+import http.server
+import json
+import os
+from pathlib import Path
+import re
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import urllib.request
+
+
+class MockVllm(http.server.ThreadingHTTPServer):
+    def __init__(self) -> None:
+        super().__init__(("127.0.0.1", 0), MockVllmHandler)
+        self.responses: list[dict] = []
+        self.messages: list[dict] = []
+
+
+class MockVllmHandler(http.server.BaseHTTPRequestHandler):
+    server: MockVllm
+
+    def log_message(self, *_args: object) -> None:
+        pass
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path == "/health":
+            self.send_response(200)
+            self.end_headers()
+            return
+        if self.path == "/v1/models":
+            self._json(
+                {
+                    "object": "list",
+                    "data": [
+                        {
+                            "id": "test-model",
+                            "object": "model",
+                            "owned_by": "mock-vllm",
+                        }
+                    ],
+                }
+            )
+            return
+        self.send_error(404)
+
+    def do_POST(self) -> None:  # noqa: N802
+        length = int(self.headers["Content-Length"])
+        body = json.loads(self.rfile.read(length))
+        if self.path == "/v1/responses":
+            self.server.responses.append(body)
+            number = len(self.server.responses)
+            response = {
+                "id": f"resp_vllm_{number}",
+                "object": "response",
+                "created_at": 0,
+                "status": "completed",
+                "model": body.get("model", "test-model"),
+                "output": [
+                    {
+                        "type": "message",
+                        "id": f"msg_{number}",
+                        "role": "assistant",
+                        "status": "completed",
+                        "content": [{"type": "output_text", "text": "OK"}],
+                    }
+                ],
+                "previous_response_id": body.get("previous_response_id"),
+                "store": True,
+            }
+            self._json(response)
+            return
+        if self.path == "/v1/messages":
+            self.server.messages.append(body)
+            self._json(
+                {
+                    "id": "msg_vllm_1",
+                    "type": "message",
+                    "role": "assistant",
+                    "model": body.get("model", "test-model"),
+                    "content": [{"type": "text", "text": "OK"}],
+                    "stop_reason": "end_turn",
+                    "stop_sequence": None,
+                    "usage": {"input_tokens": 1, "output_tokens": 1},
+                }
+            )
+            return
+        self.send_error(404)
+
+    def _json(self, value: dict) -> None:
+        encoded = json.dumps(value).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+
+HARNESS = r'''#!/usr/bin/env python3
+import json
+import os
+import re
+import sys
+import urllib.request
+
+def post(url, body):
+    request = urllib.request.Request(url, json.dumps(body).encode(), {"Content-Type": "application/json"})
+    with urllib.request.urlopen(request) as response:
+        if response.status != 200:
+            raise RuntimeError(f"unexpected status {response.status}")
+        return json.loads(response.read())
+
+mode = os.environ["E2E_HARNESS_MODE"]
+result = os.environ["E2E_RESULT"]
+model = "test-model"
+if mode == "codex":
+    config = open(os.path.join(os.environ["CODEX_HOME"], "config.toml")).read()
+    base = re.search(r'base_url = "([^"]+)"', config).group(1)
+    first = post(base + "/responses", {"model": model, "input": "Remember APPLE", "store": True, "stream": False})
+    second = post(base + "/responses", {"model": model, "input": "What word?", "previous_response_id": first["id"], "store": True, "stream": False})
+    assert second["id"], second
+else:
+    base = os.environ["ANTHROPIC_BASE_URL"]
+    response = post(base + "/v1/messages", {"model": model, "max_tokens": 32, "stream": False, "messages": [{"role": "user", "content": "Remember APPLE"}, {"role": "assistant", "content": "OK"}, {"role": "user", "content": "What word?"}]})
+    assert response["content"][0]["text"] == "OK", response
+open(result, "w").write(mode + " passed\n")
+'''
+
+
+def free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def run_harness(agentic: Path, mode: str, upstream: str, temp: Path, harness: Path) -> None:
+    gateway_port = free_port()
+    database = temp / f"{mode}.db"
+    result = temp / f"{mode}.result"
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "AGENTIC_CODEX_BIN": str(harness),
+            "AGENTIC_CLAUDE_BIN": str(harness),
+            "E2E_HARNESS_MODE": mode,
+            "E2E_RESULT": str(result),
+        }
+    )
+    command = [
+        str(agentic),
+        "run",
+        mode,
+        "--upstream",
+        upstream,
+        "--gateway-host",
+        "127.0.0.1",
+        "--gateway-port",
+        str(gateway_port),
+        "--database-url",
+        f"sqlite://{database}",
+        "--skip-llm-ready-check",
+        "--",
+        "e2e",
+    ]
+    completed = subprocess.run(command, env=environment, capture_output=True, text=True, timeout=30)
+    if completed.returncode != 0:
+        raise AssertionError(f"{mode} CLI failed ({completed.returncode})\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}")
+    assert result.read_text() == f"{mode} passed\n"
+
+
+def main() -> None:
+    repo = Path(__file__).resolve().parents[2]
+    agentic = Path(os.environ.get("AGENTIC_BIN", repo / "target/debug/agentic"))
+    if not agentic.is_file():
+        raise SystemExit(f"missing {agentic}; run cargo build --bins first")
+    with tempfile.TemporaryDirectory(prefix="agentic-cli-e2e-") as directory:
+        temp = Path(directory)
+        harness = temp / "fake-harness"
+        harness.write_text(HARNESS)
+        harness.chmod(0o755)
+        server = MockVllm()
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            upstream = f"http://127.0.0.1:{server.server_address[1]}"
+            run_harness(agentic, "codex", upstream, temp, harness)
+            run_harness(agentic, "claude", upstream, temp, harness)
+            assert len(server.responses) == 2, server.responses
+            assert len(server.messages) == 1, server.messages
+            assert len(server.messages[0]["messages"]) == 3, server.messages[0]
+            print("agentic CLI end-to-end tests passed")
+        finally:
+            server.shutdown()
+            thread.join(timeout=5)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/agentic-launchers-test.sh
+++ b/scripts/tests/agentic-launchers-test.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+real_codex="$(command -v codex || true)"
+test_root="$(mktemp -d)"
+trap 'rm -rf "$test_root"' EXIT
+
+fake_bin="$test_root/bin"
+capture_dir="$test_root/captures"
+mkdir -p "$fake_bin" "$capture_dir"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_file_contains() {
+  local file="$1"
+  local expected="$2"
+  grep -F -- "$expected" "$file" >/dev/null || fail "$file does not contain: $expected"
+}
+
+assert_file_excludes() {
+  local file="$1"
+  local unexpected="$2"
+  if grep -F -- "$unexpected" "$file" >/dev/null; then
+    fail "$file unexpectedly contains: $unexpected"
+  fi
+}
+
+cat >"$fake_bin/cargo" <<'EOF'
+#!/usr/bin/env bash
+{
+  printf 'V_API_BASE=%s\n' "${V_API_BASE:-}"
+  printf 'V_MODEL=%s\n' "${V_MODEL:-}"
+  printf 'MESSAGES_MODEL_OVERRIDE=%s\n' "${MESSAGES_MODEL_OVERRIDE:-}"
+  printf 'GATEWAY_PORT=%s\n' "${GATEWAY_PORT:-}"
+  printf 'DATABASE_URL=%s\n' "${DATABASE_URL:-}"
+  printf '%s\n' '--- args ---'
+  printf '%s\n' "$@"
+} >"$CAPTURE_DIR/gateway.txt"
+EOF
+
+cat >"$fake_bin/claude" <<'EOF'
+#!/usr/bin/env bash
+{
+  printf 'ANTHROPIC_BASE_URL=%s\n' "${ANTHROPIC_BASE_URL:-}"
+  printf 'ANTHROPIC_MODEL=%s\n' "${ANTHROPIC_MODEL:-}"
+  printf 'ANTHROPIC_DEFAULT_OPUS_MODEL=%s\n' "${ANTHROPIC_DEFAULT_OPUS_MODEL:-}"
+  printf 'CLAUDE_CODE_EFFORT_LEVEL=%s\n' "${CLAUDE_CODE_EFFORT_LEVEL:-}"
+  printf 'ANTHROPIC_API_KEY=%s\n' "${ANTHROPIC_API_KEY:-}"
+  printf 'ANTHROPIC_AUTH_TOKEN=%s\n' "${ANTHROPIC_AUTH_TOKEN:-}"
+  if [[ -n "${CLAUDE_CODE_USE_VERTEX+x}" ]]; then printf 'CLAUDE_CODE_USE_VERTEX=set\n'; fi
+  if [[ -n "${ANTHROPIC_VERTEX_PROJECT_ID+x}" ]]; then printf 'ANTHROPIC_VERTEX_PROJECT_ID=set\n'; fi
+  printf '%s\n' '--- args ---'
+  printf '%s\n' "$@"
+} >"$CAPTURE_DIR/claude.txt"
+EOF
+
+cat >"$fake_bin/codex" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+  echo 'codex-cli 0.148.0'
+  exit 0
+fi
+{
+  printf 'CODEX_HOME=%s\n' "${CODEX_HOME:-}"
+  printf '%s\n' '--- args ---'
+  printf '%s\n' "$@"
+} >"$CAPTURE_DIR/codex.txt"
+EOF
+
+cat >"$fake_bin/curl" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" >"$CAPTURE_DIR/curl.txt"
+cat <<'JSON'
+{
+  "models": [{
+    "slug": "agentic-api",
+    "display_name": "agentic-api",
+    "auto_review_model_override": "agentic-api",
+    "supported_in_api": true,
+    "priority": 1,
+    "shell_type": "shell_command",
+    "visibility": "list",
+    "base_instructions": "",
+    "supported_reasoning_levels": [
+      {"effort": "low", "description": "Fast responses with lighter reasoning"},
+      {"effort": "medium", "description": "Balances speed and reasoning depth"},
+      {"effort": "high", "description": "Greater reasoning depth for complex problems"}
+    ],
+    "default_reasoning_summary": "auto",
+    "supports_reasoning_summaries": false,
+    "support_verbosity": false,
+    "default_verbosity": null,
+    "apply_patch_tool_type": "freeform",
+    "web_search_tool_type": "text",
+    "truncation_policy": {"mode": "bytes", "limit": 100000},
+    "supports_parallel_tool_calls": true,
+    "supports_image_detail_original": false,
+    "effective_context_window_percent": 95,
+    "experimental_supported_tools": [],
+    "supports_search_tool": true,
+    "use_responses_lite": false,
+    "tool_mode": null,
+    "multi_agent_version": null,
+    "input_modalities": ["text"]
+  }]
+}
+JSON
+EOF
+
+chmod +x "$fake_bin/cargo" "$fake_bin/claude" "$fake_bin/codex" "$fake_bin/curl"
+
+PATH="$fake_bin:$PATH" CAPTURE_DIR="$capture_dir" \
+  "$repo_root/scripts/agentic-api.sh" >/dev/null
+
+assert_file_contains "$capture_dir/gateway.txt" 'V_API_BASE=http://127.0.0.1:8000/v1'
+assert_file_contains "$capture_dir/gateway.txt" 'V_MODEL=agentic-api'
+assert_file_contains "$capture_dir/gateway.txt" 'MESSAGES_MODEL_OVERRIDE=agentic-api'
+assert_file_contains "$capture_dir/gateway.txt" 'GATEWAY_PORT=3020'
+assert_file_contains "$capture_dir/gateway.txt" 'sqlite:///tmp/agentic_api_3020.db'
+assert_file_contains "$capture_dir/gateway.txt" '--bin'
+assert_file_contains "$capture_dir/gateway.txt" 'agentic-server'
+assert_file_contains "$capture_dir/gateway.txt" 'http://127.0.0.1:8000/v1'
+
+PATH="$fake_bin:$PATH" CAPTURE_DIR="$capture_dir" CLAUDE_BIN="$fake_bin/claude" \
+  CLAUDE_CODE_USE_VERTEX=1 ANTHROPIC_VERTEX_PROJECT_ID=test-project ANTHROPIC_API_KEY= \
+  "$repo_root/scripts/agentic-claude.sh" >/dev/null
+
+assert_file_contains "$capture_dir/claude.txt" 'ANTHROPIC_BASE_URL=http://127.0.0.1:3020'
+assert_file_contains "$capture_dir/claude.txt" 'ANTHROPIC_MODEL=agentic-api'
+assert_file_contains "$capture_dir/claude.txt" 'ANTHROPIC_DEFAULT_OPUS_MODEL=agentic-api'
+assert_file_contains "$capture_dir/claude.txt" 'CLAUDE_CODE_EFFORT_LEVEL=medium'
+assert_file_contains "$capture_dir/claude.txt" 'ANTHROPIC_API_KEY=demo'
+assert_file_contains "$capture_dir/claude.txt" 'ANTHROPIC_AUTH_TOKEN=demo'
+assert_file_contains "$capture_dir/claude.txt" '--bare'
+assert_file_excludes "$capture_dir/claude.txt" '--dangerously-skip-permissions'
+assert_file_contains "$capture_dir/claude.txt" '--effort'
+assert_file_contains "$capture_dir/claude.txt" 'medium'
+assert_file_contains "$capture_dir/claude.txt" 'manual'
+assert_file_excludes "$capture_dir/claude.txt" 'CLAUDE_CODE_USE_VERTEX='
+assert_file_excludes "$capture_dir/claude.txt" 'ANTHROPIC_VERTEX_PROJECT_ID='
+
+codex_home="$test_root/codex-home"
+PATH="$fake_bin:$PATH" CAPTURE_DIR="$capture_dir" CODEX_BIN="$fake_bin/codex" \
+  AGENTIC_CODEX_HOME="$codex_home" CODEX_HOME="$test_root/must-not-be-used" \
+  "$repo_root/scripts/agentic-codex.sh" >/dev/null
+
+assert_file_contains "$capture_dir/codex.txt" 'CODEX_HOME='
+assert_file_contains "$capture_dir/codex.txt" '--search'
+assert_file_excludes "$capture_dir/codex.txt" '--dangerously-bypass-approvals-and-sandbox'
+assert_file_excludes "$capture_dir/codex.txt" 'workspace-write'
+assert_file_excludes "$capture_dir/codex.txt" 'on-request'
+assert_file_excludes "$capture_dir/codex.txt" 'must-not-be-used'
+assert_file_contains "$codex_home/config.toml" 'model_provider = "agentic-api"'
+assert_file_contains "$codex_home/config.toml" 'base_url = "http://127.0.0.1:3020/v1"'
+assert_file_contains "$codex_home/config.toml" 'model = "agentic-api"'
+assert_file_contains "$codex_home/config.toml" 'supports_websockets = true'
+assert_file_contains "$codex_home/model_catalog.json" '"web_search_tool_type": "text"'
+assert_file_contains "$codex_home/model_catalog.json" '"shell_type": "shell_command"'
+assert_file_contains "$capture_dir/curl.txt" 'http://127.0.0.1:3020/v1/models?client_version=0.148.0'
+
+PATH="$fake_bin:$PATH" CAPTURE_DIR="$capture_dir" AGENTIC_YOLO=1 CLAUDE_BIN="$fake_bin/claude" \
+  "$repo_root/scripts/agentic-claude.sh" >/dev/null
+assert_file_contains "$capture_dir/claude.txt" '--dangerously-skip-permissions'
+
+PATH="$fake_bin:$PATH" CAPTURE_DIR="$capture_dir" AGENTIC_YOLO=1 CODEX_BIN="$fake_bin/codex" \
+  AGENTIC_CODEX_HOME="$codex_home" "$repo_root/scripts/agentic-codex.sh" >/dev/null
+assert_file_contains "$capture_dir/codex.txt" '--dangerously-bypass-approvals-and-sandbox'
+
+if [[ -n "$real_codex" ]]; then
+  CODEX_HOME="$codex_home" "$real_codex" features list >/dev/null
+fi
+
+echo 'agentic launcher tests passed'


### PR DESCRIPTION
## Summary

Add CI coverage for the native Agentic CLI harness paths. The workflow now checks the Codex and Claude launcher contracts and runs a process-level end-to-end test against a local vLLM-compatible mock. Codex is tested across a stored `previous_response_id` continuation, while Claude Code is tested with full-history Anthropic Messages input. Claude model-tier aliases are also configured for the native harness launcher.

## Test Plan

- `cargo build --bins`
- `cargo fmt -- --check`
- `bash scripts/tests/spark-launchers-test.sh`
- `python3 scripts/tests/agentic-cli-e2e-test.py`
- Existing recorded cassette and stateful Responses tests remain covered by `cargo test`.