### PR TITLE
fix: serialize unsupported parallel tool calls

### DIFF
--- a/crates/agentic-server-core/src/types/request_response.rs
+++ b/crates/agentic-server-core/src/types/request_response.rs
@@ -121,17 +121,10 @@ impl RequestPayload {
     /// member, or when a custom tool declares a format whose constrained
     /// decoding cannot be preserved upstream.
     pub fn to_upstream_request(&self, stream: bool) -> Result<UpstreamRequest<'_>, ToolError> {
-        let has_built_in_tool = self.declares_built_in_tool();
-        if has_built_in_tool && self.parallel_tool_calls == Some(true) {
-            return Err(ToolError::Config(
-                "parallel_tool_calls must be false when using built-in tools".into(),
-            ));
-        }
-        let parallel_tool_calls = if has_built_in_tool {
-            Some(false)
-        } else {
-            self.parallel_tool_calls
-        };
+        // The gateway currently executes tool calls serially. Accept the client's
+        // preference for compatibility, but do not advertise parallel execution
+        // to the upstream model.
+        let parallel_tool_calls = Some(false);
 
         let renamed_tools = self
             .tools
@@ -170,12 +163,6 @@ impl RequestPayload {
             parallel_tool_calls,
             cache_salt: self.cache_salt.as_deref(),
         })
-    }
-
-    fn declares_built_in_tool(&self) -> bool {
-        self.tools
-            .as_deref()
-            .is_some_and(|tools| tools.iter().any(ResponsesTool::is_gateway_owned))
     }
 }
 
@@ -407,7 +394,7 @@ mod tests {
     }
 
     #[test]
-    fn to_upstream_request_allows_parallel_tool_calls_for_client_function_tools() {
+    fn to_upstream_request_serializes_parallel_tool_calls_for_client_function_tools() {
         let payload: RequestPayload = serde_json::from_value(serde_json::json!({
             "model": "test",
             "input": "hi",
@@ -418,15 +405,15 @@ mod tests {
 
         let upstream = payload
             .to_upstream_request(false)
-            .expect("function tools allow parallel calls");
+            .expect("function tools are serialized by the gateway");
         let value = serde_json::to_value(upstream).unwrap();
-        assert_eq!(value["parallel_tool_calls"], true);
+        assert_eq!(value["parallel_tool_calls"], false);
     }
 
     #[test]
-    fn to_upstream_request_validates_parallel_tool_calls_for_mixed_tools() {
+    fn to_upstream_request_serializes_parallel_tool_calls_for_mixed_tools() {
         for built_in_tool in builtin_tool_declarations() {
-            for (parallel_tool_calls, should_reject) in [(false, false), (true, true)] {
+            for parallel_tool_calls in [false, true] {
                 let payload: RequestPayload = serde_json::from_value(serde_json::json!({
                     "model": "test",
                     "input": "hi",
@@ -438,16 +425,13 @@ mod tests {
                 }))
                 .unwrap();
 
-                let result = payload.to_upstream_request(false);
-                if should_reject {
-                    let err = result.expect_err("built-in tools should reject parallel tool calls");
-                    assert!(err.to_string().contains("parallel_tool_calls must be false"));
-                } else {
-                    let value =
-                        serde_json::to_value(result.expect("mixed built-in and function tools allow serial calls"))
-                            .unwrap();
-                    assert_eq!(value["parallel_tool_calls"], false);
-                }
+                let value = serde_json::to_value(
+                    payload
+                        .to_upstream_request(false)
+                        .expect("mixed tools are serialized by the gateway"),
+                )
+                .unwrap();
+                assert_eq!(value["parallel_tool_calls"], false);
             }
         }
     }
@@ -471,7 +455,7 @@ mod tests {
     }
 
     #[test]
-    fn to_upstream_request_rejects_parallel_tool_calls_for_builtin_tools() {
+    fn to_upstream_request_serializes_parallel_tool_calls_for_builtin_tools() {
         for tool in builtin_tool_declarations() {
             let payload: RequestPayload = serde_json::from_value(serde_json::json!({
                 "model": "test",
@@ -481,11 +465,11 @@ mod tests {
             }))
             .unwrap();
 
-            let Err(err) = payload.to_upstream_request(false) else {
-                panic!("built-in tools should reject parallel_tool_calls=true");
-            };
-
-            assert!(err.to_string().contains("parallel_tool_calls must be false"));
+            let upstream = payload
+                .to_upstream_request(false)
+                .expect("parallel tool calls are ignored by the gateway");
+            let value = serde_json::to_value(upstream).unwrap();
+            assert_eq!(value["parallel_tool_calls"], false);
         }
     }
 

--- a/crates/agentic-server/src/auth.rs
+++ b/crates/agentic-server/src/auth.rs
@@ -361,7 +361,7 @@ pub async fn require_oidc(
         .headers()
         .get_all("x-api-key")
         .iter()
-        .any(|value| value.to_str().ok().is_some_and(|value| value.trim() == token));
+        .any(|value| value.to_str().is_ok_and(|value| value.trim() == token));
 
     match authenticator.authenticate(token).await {
         Ok(principal) => {

--- a/crates/agentic-server/src/handler/common.rs
+++ b/crates/agentic-server/src/handler/common.rs
@@ -40,10 +40,12 @@ pub fn executor_error_response(err: ExecutorError) -> Response {
         .expect("valid error response")
 }
 
+#[allow(clippy::result_large_err)]
 pub(super) async fn read_bytes(body: Body) -> Result<Bytes, Response> {
     read_bytes_with_auth(body, ProxyAuth::OpenAiBearer).await
 }
 
+#[allow(clippy::result_large_err)]
 pub(super) async fn read_bytes_with_auth(body: Body, auth: ProxyAuth) -> Result<Bytes, Response> {
     axum::body::to_bytes(body, MAX_BODY_SIZE).await.map_err(|_| {
         convert_response(error_response_for_auth(
@@ -55,6 +57,7 @@ pub(super) async fn read_bytes_with_auth(body: Body, auth: ProxyAuth) -> Result<
     })
 }
 
+#[allow(clippy::result_large_err)]
 pub(super) async fn read_and_parse(body: Body) -> Result<(Bytes, RequestPayload), Response> {
     let bytes = read_bytes(body).await?;
     let payload = serde_json::from_slice::<RequestPayload>(&bytes)
@@ -62,6 +65,7 @@ pub(super) async fn read_and_parse(body: Body) -> Result<(Bytes, RequestPayload)
     Ok((bytes, payload))
 }
 
+#[allow(clippy::result_large_err)]
 pub(super) async fn read_json<T: DeserializeOwned>(body: Body) -> Result<T, Response> {
     let bytes = read_bytes(body).await?;
     serde_json::from_slice::<T>(&bytes).map_err(|error| executor_error_response(ExecutorError::from(error)))

--- a/crates/agentic-server/src/server.rs
+++ b/crates/agentic-server/src/server.rs
@@ -61,6 +61,7 @@ async fn serve_gateway(
     let websocket_tracker = state.websocket_tracker.clone();
     let router = build_router_with_auth(state, &server_config, authenticator);
     let listener = TcpListener::bind(&addr).await?;
+    warn!("parallel tool calls are not supported; requests are serialized by the gateway");
     info!("gateway listening on {addr}");
     axum::serve(listener, router)
         .with_graceful_shutdown(async move {


### PR DESCRIPTION
## Summary

- Accept client requests with `parallel_tool_calls: true` for compatibility.
- Force the upstream Responses request to use `parallel_tool_calls: false` until gateway parallel tool execution is supported.
- Emit a startup warning documenting the serialized behavior.
- Addresses the interim behavior discussed in #190 and avoids rejecting Codex requests based on client configuration.

## Test Plan

- `cargo clippy --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo fmt --all -- --check`
- `git diff --check`

Full workspace tests passed; PostgreSQL integration tests were skipped because `TEST_POSTGRES_URL` was not configured.