### PR TITLE
fix: keep the Kubernetes base healthy on a read-only root and stable /ready

### DIFF
--- a/crates/agentic-server-core/src/readiness.rs
+++ b/crates/agentic-server-core/src/readiness.rs
@@ -40,12 +40,19 @@ pub enum LlmReadiness {
 /// The client rejects redirects so an authentication page or generic UI cannot
 /// turn an unsuccessful `/health` response into a false-positive readiness result.
 ///
+/// Connections are never pooled: the probe runs every few seconds, which is close
+/// to the idle keep-alive timeout of common upstream servers (uvicorn closes idle
+/// connections after 5 s). Reusing a pooled connection the upstream has already
+/// closed fails with `hyper::Error(IncompleteMessage)` and flaps `/ready` even
+/// though the upstream is healthy.
+///
 /// # Errors
 ///
 /// Returns an error when the HTTP client cannot be constructed.
 pub fn llm_readiness_client() -> Result<reqwest::Client, Error> {
     reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
+        .pool_max_idle_per_host(0)
         .build()
         .map_err(Error::HttpClient)
 }

--- a/crates/agentic-server-core/src/readiness.rs
+++ b/crates/agentic-server-core/src/readiness.rs
@@ -221,6 +221,56 @@ mod tests {
         assert_eq!(interval.min(remaining), Duration::from_millis(100));
     }
 
+    /// Regression test for readiness flapping: the probe must not reuse a pooled
+    /// keep-alive connection between runs, because upstreams such as uvicorn close
+    /// idle connections on roughly the same cadence as the probe and a reused dead
+    /// socket fails with `IncompleteMessage` while the upstream is healthy.
+    #[tokio::test]
+    async fn readiness_client_opens_a_new_connection_per_probe() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let connections = Arc::new(AtomicUsize::new(0));
+        let upstream = tokio::spawn({
+            let connections = Arc::clone(&connections);
+            async move {
+                loop {
+                    let (mut socket, _) = listener.accept().await.unwrap();
+                    connections.fetch_add(1, Ordering::SeqCst);
+                    tokio::spawn(async move {
+                        // Serve keep-alive responses for as many requests as arrive on this socket.
+                        let mut buffer = [0_u8; 2048];
+                        while let Ok(read) = socket.read(&mut buffer).await {
+                            if read == 0 {
+                                break;
+                            }
+                            let response = "HTTP/1.1 204 No Content\r\nconnection: keep-alive\r\n\r\n";
+                            if socket.write_all(response.as_bytes()).await.is_err() {
+                                break;
+                            }
+                        }
+                    });
+                }
+            }
+        });
+
+        let client = super::llm_readiness_client().unwrap();
+        for _ in 0..3 {
+            let readiness = probe_llm_readiness(&client, &url, None, Duration::from_secs(1))
+                .await
+                .unwrap();
+            assert!(matches!(readiness, super::LlmReadiness::Ready), "{readiness:?}");
+        }
+        upstream.abort();
+
+        assert_eq!(
+            connections.load(Ordering::SeqCst),
+            3,
+            "each probe must open its own TCP connection instead of reusing a pooled one"
+        );
+    }
+
     #[tokio::test]
     async fn probe_rejects_invalid_bearer_header_before_network_io() {
         let error = probe_llm_readiness(

--- a/crates/agentic-server/src/config_file.rs
+++ b/crates/agentic-server/src/config_file.rs
@@ -65,6 +65,13 @@ pub(crate) struct FileConfig {
     pub mcp_servers: HashMap<String, McpServerEntry>,
 }
 
+fn is_unwritable_home(error: &std::io::Error) -> bool {
+    matches!(
+        error.kind(),
+        std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::ReadOnlyFilesystem
+    ) || error.raw_os_error() == Some(30) // EROFS on platforms without the stable ErrorKind mapping
+}
+
 impl FileConfig {
     pub(crate) fn load(home: &Path) -> Result<Option<Self>, Error> {
         let path = home.join(CONFIG_FILE_NAME);
@@ -98,10 +105,24 @@ impl FileConfig {
              # Secret values are read from referenced environment variables and are not written here.\n\n{body}"
         );
 
-        let mut file = tempfile::Builder::new()
-            .prefix(".agentic-config-")
-            .tempfile_in(home)
-            .map_err(|error| Error::Config(format!("failed to create temporary configuration file: {error}")))?;
+        let mut file = match tempfile::Builder::new().prefix(".agentic-config-").tempfile_in(home) {
+            Ok(file) => file,
+            Err(error) if is_unwritable_home(&error) => {
+                // A read-only root filesystem (the Kubernetes base) or an unwritable home must not
+                // prevent startup: the generated file is a convenience, not a requirement.
+                tracing::warn!(
+                    home = %home.display(),
+                    error = %error,
+                    "Agentic API home is not writable; continuing with the generated configuration in memory"
+                );
+                return Ok(self);
+            }
+            Err(error) => {
+                return Err(Error::Config(format!(
+                    "failed to create temporary configuration file: {error}"
+                )));
+            }
+        };
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
@@ -339,5 +360,30 @@ mod tests {
 
         assert_eq!(config.llm_api_base.as_deref(), Some("http://existing:8000"));
         assert!(!contents.contains("replacement"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_or_load_continues_when_home_is_not_writable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let home = tempfile::tempdir().expect("tempdir");
+        fs::set_permissions(home.path(), fs::Permissions::from_mode(0o555)).expect("make home read-only");
+        if fs::File::create(home.path().join("probe")).is_ok() {
+            // Running as root: the permission bits are not enforced, so the scenario cannot be reproduced.
+            return;
+        }
+        let defaults = FileConfig {
+            llm_api_base: Some("http://127.0.0.1:5050".to_owned()),
+            ..FileConfig::default()
+        };
+
+        let config = defaults
+            .create_or_load(home.path())
+            .expect("an unwritable home must not fail startup");
+
+        assert_eq!(config.llm_api_base.as_deref(), Some("http://127.0.0.1:5050"));
+        assert!(!home.path().join("config.toml").exists());
+        fs::set_permissions(home.path(), fs::Permissions::from_mode(0o755)).expect("restore permissions");
     }
 }

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -110,3 +110,12 @@ spec:
             capabilities:
               drop:
                 - ALL
+          volumeMounts:
+            # Writable home for the generated config.toml and any local state; the
+            # root filesystem stays read-only.
+            - name: agentic-api-home
+              mountPath: /var/lib/agentic-api
+      volumes:
+        - name: agentic-api-home
+          emptyDir:
+            sizeLimit: 64Mi

--- a/deploy/overlays/kind-linux/kustomization.yaml
+++ b/deploy/overlays/kind-linux/kustomization.yaml
@@ -1,0 +1,19 @@
+# kind overlay for native Linux Docker, where host.docker.internal does not
+# resolve inside the cluster. The IP is the gateway of the `kind` Docker network
+# (not the default bridge); confirm it with:
+#   docker network inspect kind --format '{{range .IPAM.Config}}{{.Gateway}} {{end}}'
+#
+#   kubectl apply -k deploy/overlays/kind-linux
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: agentic-api
+resources:
+  - ../kind
+patches:
+  - target: {kind: Deployment, name: agentic-api}
+    patch: |
+      - op: add
+        path: /spec/template/spec/hostAliases
+        value:
+          - ip: "172.18.0.1"
+            hostnames: [host.docker.internal]

--- a/deploy/overlays/kind/kustomization.yaml
+++ b/deploy/overlays/kind/kustomization.yaml
@@ -2,11 +2,12 @@
 # Overlays must live outside deploy/kubernetes: Kustomize rejects a base that is
 # an ancestor of the overlay directory ("cycle detected").
 #
-#   kubectl apply -k deploy/overlays/kind
+#   kubectl apply -k deploy/overlays/kind          # Docker Desktop (macOS/Windows)
+#   kubectl apply -k deploy/overlays/kind-linux    # native Linux Docker
 #
-# The hostAliases entry is only needed on native Linux Docker, where
-# host.docker.internal does not resolve inside kind. Confirm the IP with:
-#   docker network inspect kind --format '{{range .IPAM.Config}}{{.Gateway}} {{end}}'
+# vLLM (or the llm-d endpoint) listens on the host at port 5050, matching the
+# kind guide. Docker Desktop resolves host.docker.internal inside the cluster;
+# native Linux Docker needs the hostAliases entry from the kind-linux overlay.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: agentic-api
@@ -21,11 +22,4 @@ patches:
     patch: |
       - op: replace
         path: /data/LLM_API_BASE
-        value: http://host.docker.internal:8000
-  - target: {kind: Deployment, name: agentic-api}
-    patch: |
-      - op: add
-        path: /spec/template/spec/hostAliases
-        value:
-          - ip: "172.18.0.1"
-            hostnames: [host.docker.internal]
+        value: http://host.docker.internal:5050

--- a/deploy/overlays/kind/kustomization.yaml
+++ b/deploy/overlays/kind/kustomization.yaml
@@ -1,0 +1,31 @@
+# Development overlay for the kind cluster described in docs/deploying/README.md.
+# Overlays must live outside deploy/kubernetes: Kustomize rejects a base that is
+# an ancestor of the overlay directory ("cycle detected").
+#
+#   kubectl apply -k deploy/overlays/kind
+#
+# The hostAliases entry is only needed on native Linux Docker, where
+# host.docker.internal does not resolve inside kind. Confirm the IP with:
+#   docker network inspect kind --format '{{range .IPAM.Config}}{{.Gateway}} {{end}}'
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: agentic-api
+resources:
+  - ../../kubernetes
+images:
+  - name: agentic-api
+    newName: agentic-api
+    newTag: kind
+patches:
+  - target: {kind: ConfigMap, name: agentic-api}
+    patch: |
+      - op: replace
+        path: /data/LLM_API_BASE
+        value: http://host.docker.internal:8000
+  - target: {kind: Deployment, name: agentic-api}
+    patch: |
+      - op: add
+        path: /spec/template/spec/hostAliases
+        value:
+          - ip: "172.18.0.1"
+            hostnames: [host.docker.internal]

--- a/docs/deploying/kubernetes.md
+++ b/docs/deploying/kubernetes.md
@@ -10,14 +10,15 @@ or put an authenticated application boundary in front of it before allowing traf
 Build and publish the production image described in the [container guide](container.md). The base uses
 `agentic-api:dev` so it also works with images loaded directly into a local cluster. Before deploying to a shared
 cluster, replace that image with an immutable registry digest in an environment-specific Kustomize overlay such as
-`deploy/kubernetes/overlays/production/kustomization.yaml`:
+`deploy/overlays/production/kustomization.yaml`. Keep overlays outside `deploy/kubernetes`: Kustomize rejects a base
+that is an ancestor of the overlay directory with a "cycle detected" error.
 
 ```yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: agentic-api
 resources:
-  - ../..
+  - ../../kubernetes
 images:
   - name: agentic-api
     newName: registry.example.com/vllm/agentic-api
@@ -25,7 +26,9 @@ images:
 ```
 
 Change `LLM_API_BASE` and `CORS_ALLOWED_ORIGINS` in `deploy/kubernetes/configmap.yaml` or patch them in the same
-overlay. Keep `SKIP_LLM_READY_CHECK=false` when the inference service exposes `/health`. The recurring upstream check
+overlay. `deploy/overlays/kind` is a working example for the local kind cluster from the
+[kind guide](README.md): it points `LLM_API_BASE` at vLLM on the host and adds the `hostAliases` entry that native
+Linux Docker needs for `host.docker.internal`. Keep `SKIP_LLM_READY_CHECK=false` when the inference service exposes `/health`. The recurring upstream check
 uses `OPENAI_API_KEY` as a bearer credential when configured. For a provider without `/health`, set
 `SKIP_LLM_READY_CHECK=true`; `/ready` will continue checking PostgreSQL but will omit the upstream check. Add a small
 Responses API request as an external monitor in that configuration.
@@ -91,7 +94,9 @@ The base defines:
 - a 30-second pod termination grace period for endpoint propagation and the gateway's bounded eight-second drain;
 - CPU and memory requests and limits that should be tuned from observed traffic;
 - a preferred hostname anti-affinity rule for the two gateway replicas;
-- a non-root, read-only runtime with no Linux capabilities or mounted service-account token;
+- a non-root, read-only root filesystem with no Linux capabilities or mounted service-account token, plus a small
+  `emptyDir` mounted at `/var/lib/agentic-api` for the generated `config.toml` (the gateway also starts without a
+  writable home and keeps that configuration in memory);
 - a default-deny ingress NetworkPolicy; and
 - a PodDisruptionBudget that retains one replica during voluntary disruption.
 

--- a/docs/deploying/kubernetes.md
+++ b/docs/deploying/kubernetes.md
@@ -27,8 +27,9 @@ images:
 
 Change `LLM_API_BASE` and `CORS_ALLOWED_ORIGINS` in `deploy/kubernetes/configmap.yaml` or patch them in the same
 overlay. `deploy/overlays/kind` is a working example for the local kind cluster from the
-[kind guide](README.md): it points `LLM_API_BASE` at vLLM on the host and adds the `hostAliases` entry that native
-Linux Docker needs for `host.docker.internal`. Keep `SKIP_LLM_READY_CHECK=false` when the inference service exposes `/health`. The recurring upstream check
+[kind guide](README.md): it points `LLM_API_BASE` at `host.docker.internal:5050` on the host. On native Linux
+Docker, apply `deploy/overlays/kind-linux` instead; it layers the `hostAliases` entry that `host.docker.internal`
+needs there on top of the same overlay. Keep `SKIP_LLM_READY_CHECK=false` when the inference service exposes `/health`. The recurring upstream check
 uses `OPENAI_API_KEY` as a bearer credential when configured. For a provider without `/health`, set
 `SKIP_LLM_READY_CHECK=true`; `/ready` will continue checking PostgreSQL but will omit the upstream check. Add a small
 Responses API request as an external monitor in that configuration.


### PR DESCRIPTION
## Summary

Found by following `docs/deploying/kubernetes.md` end-to-end on kind (kustomize base, 2 replicas, PostgreSQL) with Codex and Claude Code.

- **Kustomize base crashes on current main** (`CrashLoopBackOff`): #189 writes a generated `config.toml` into `/var/lib/agentic-api`, but the base sets `readOnlyRootFilesystem: true` with no writable volume (`failed to create temporary configuration file: Read-only file system`). The server now continues with the generated configuration in memory and logs a warning when the home is unwritable (regression test included), and the base mounts a 64Mi `emptyDir` at `/var/lib/agentic-api`.
- **`/ready` flapped 1–3×/min per pod** with 503 readiness-probe failures while vLLM was healthy. The probe client reused pooled keep-alive connections that the upstream (uvicorn, 5 s idle timeout ≈ 5 s probe period) had already closed, failing with `hyper::Error(IncompleteMessage)`. The readiness client no longer pools connections (`pool_max_idle_per_host(0)`), guarded by a regression test that counts TCP connections across sequential probes.
- **The overlay location the guide suggested fails**: Kustomize rejects a base that is an ancestor of the overlay (`cycle detected`). Added `deploy/overlays/kind` (platform-neutral, `host.docker.internal:5050` per the kind guide) and `deploy/overlays/kind-linux` (layers the `hostAliases` entry native Linux Docker needs) as working examples, and fixed the doc.

Split out of #193; the CLI fixes are in #198.

Review round (b83d048): kind overlay port aligned with the guide, Linux `hostAliases` split into `deploy/overlays/kind-linux`, readiness regression test.

## Test Plan

- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --workspace`, `kubectl kustomize deploy/overlays/kind | kubectl apply --dry-run=server -f -`.
- New unit tests: `create_or_load_continues_when_home_is_not_writable`; `readiness_client_opens_a_new_connection_per_probe` (verified to fail, 1 connection vs 3, when `pool_max_idle_per_host(0)` is removed).
- On kind with the kustomize base and PostgreSQL: before the fix both replicas were in `CrashLoopBackOff`; after, both ready. Readiness warnings went from ~60 in 15 minutes to 0 in 10+ minutes (also 0/24 probes locally at the 5 s cadence).
- Verified on the deployment: the guide's persistence check (`store: true` → rolling restart → `previous_response_id` continuation), 6 concurrent chained conversations across both replicas, Codex `exec` with a shell tool over WebSocket, Claude Code tool-call turn, and an 86-case Responses/Messages edge battery. The `kind-linux` overlay was live-applied on kind with both replicas ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
