### PR TITLE
chore: prepare release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to Agentic API are documented here.
+
+## [0.4.0] - 2026-08-23
+
+### Added
+
+- Added the Agentic API harness CLI for running Codex and Claude Code against Agentic API.
+- Added home-based configuration and typed tool settings for standalone deployments.
+- Added support for Codex CLI remote compaction V2.
+- Added Kubernetes deployment guidance and architecture documentation.
+
+### Changed
+
+- Improved handling of Codex and Claude harness upstream configuration and compatible reasoning effort values.
+- Preserved unsupported parallel tool calls through serialized upstream requests.
+- Hardened MCP configuration and startup behavior.
+- Improved Kubernetes health and readiness behavior for read-only container roots.
+
+### Testing
+
+- Added native Codex and Claude harness coverage and expanded compatibility tests.
+
+## [0.3.0]
+
+Initial documented release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,14 +4,14 @@ version = 4
 
 [[package]]
 name = "agentic-praxis"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "agentic-server-core",
 ]
 
 [[package]]
 name = "agentic-server"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "agentic-server-core",
  "axum",
@@ -44,7 +44,7 @@ dependencies = [
 
 [[package]]
 name = "agentic-server-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/vllm-project/agentic-api"
@@ -16,7 +16,7 @@ all = { level = "deny", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
 
 [workspace.dependencies]
-agentic-core = { package = "agentic-server-core", path = "crates/agentic-server-core", version = "0.3.0" }
+agentic-core = { package = "agentic-server-core", path = "crates/agentic-server-core", version = "0.4.0" }
 async-stream = "0.3"
 axum = { version = "0.8", features = ["ws"] }
 either = "1"


### PR DESCRIPTION
## Summary

Prepare the v0.4.0 crates release by updating workspace and published crate dependency versions and adding release notes.

## Test Plan

- cargo check --workspace
- cargo fmt -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test

The full test suite passed with 370 core tests and 48 server tests; environment-dependent PostgreSQL tests were ignored.