### PR TITLE
ci: fix web search test hangs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,6 +50,7 @@ jobs:
 
   rust:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/crates/agentic-server-core/tests/dispatch_loop_cassette_test.rs
+++ b/crates/agentic-server-core/tests/dispatch_loop_cassette_test.rs
@@ -224,7 +224,7 @@ async fn openai_mixed_gateway_and_client_owned_hands_back_after_gateway_exec() {
     };
 
     // web_search is gateway-owned → executed against You.com mock.
-    let search = captured_you.recv().await.expect("web_search should hit You.com");
+    let search = recv_search(&mut captured_you, "web_search should hit You.com").await;
     assert!(search.body.get("query").is_some(), "web_search executed with a query");
 
     // get_job_status is still client-owned → RequiresClientAction, one model call.
@@ -275,7 +275,7 @@ async fn assert_web_search_then_namespace(cassette_rel_path: &str) {
 
     // Round 0 executed the gateway web_search against the You.com mock, then
     // round 1 emitted the namespace call — two model calls in one conversation.
-    let search = captured_you.recv().await.expect("web_search should hit You.com");
+    let search = recv_search(&mut captured_you, "web_search should hit You.com").await;
     assert!(search.body.get("query").is_some(), "web_search executed with a query");
     assert_eq!(
         llm.request_bodies().await.len(),
@@ -366,9 +366,9 @@ async fn assert_multi_round_web_search(cassette_rel_path: &str) {
 
     // Two gateway web_search executions (rounds 0 and 1), three model calls total
     // (the loop continued twice, then the model answered).
-    let first = captured_you.recv().await.expect("first web_search should hit You.com");
+    let first = recv_search(&mut captured_you, "first web_search should hit You.com").await;
     assert!(first.body.get("query").is_some(), "round-0 web_search executed");
-    let second = captured_you.recv().await.expect("second web_search should hit You.com");
+    let second = recv_search(&mut captured_you, "second web_search should hit You.com").await;
     assert!(second.body.get("query").is_some(), "round-1 web_search executed");
     assert_eq!(
         llm.request_bodies().await.len(),
@@ -448,7 +448,7 @@ async fn openai_web_search_and_namespace_same_turn_hands_back_in_one_round() {
 
     // The gateway web_search executed this turn, and the turn ended in ONE model
     // call (no loop-back) because a client-owned namespace call was also present.
-    let search = captured_you.recv().await.expect("web_search should hit You.com");
+    let search = recv_search(&mut captured_you, "web_search should hit You.com").await;
     assert!(search.body.get("query").is_some(), "web_search executed with a query");
     assert_eq!(
         llm.request_bodies().await.len(),
@@ -486,13 +486,28 @@ struct CapturedSearch {
     body: serde_json::Value,
 }
 
+async fn recv_search(captured: &mut tokio::sync::mpsc::Receiver<CapturedSearch>, expectation: &str) -> CapturedSearch {
+    tokio::time::timeout(std::time::Duration::from_secs(5), captured.recv())
+        .await
+        .unwrap_or_else(|_| panic!("{expectation}: timed out after 5 seconds"))
+        .unwrap_or_else(|| panic!("{expectation}: mock server stopped before receiving a request"))
+}
+
+fn query_params_as_json(uri: &axum::http::Uri) -> serde_json::Value {
+    let params = url::form_urlencoded::parse(uri.query().unwrap_or_default().as_bytes())
+        .map(|(key, value)| (key.into_owned(), serde_json::Value::String(value.into_owned())))
+        .collect();
+    serde_json::Value::Object(params)
+}
+
 async fn spawn_mock_you() -> (
     String,
     tokio::sync::mpsc::Receiver<CapturedSearch>,
     tokio::task::JoinHandle<()>,
 ) {
     use axum::extract::State;
-    use axum::routing::post;
+    use axum::http::Uri;
+    use axum::routing::get;
     use axum::{Json, Router};
     use tokio::net::TcpListener;
     use tokio::sync::mpsc;
@@ -501,8 +516,9 @@ async fn spawn_mock_you() -> (
     let app = Router::new()
         .route(
             "/v1/search",
-            post(
-                move |State(tx): State<mpsc::Sender<CapturedSearch>>, Json(body): Json<serde_json::Value>| async move {
+            get(
+                move |State(tx): State<mpsc::Sender<CapturedSearch>>, uri: Uri| async move {
+                    let body = query_params_as_json(&uri);
                     tx.send(CapturedSearch { body }).await.unwrap();
                     (
                         axum::http::StatusCode::OK,

--- a/crates/agentic-server-core/tests/messages_loop_test.rs
+++ b/crates/agentic-server-core/tests/messages_loop_test.rs
@@ -18,7 +18,8 @@ use agentic_core::storage::{ConversationStore, ResponseStore};
 use agentic_core::tool::{ToolRegistry, WebSearchHandler};
 use agentic_core::types::messages::{GatewayToolMap, ToolParam, registry_tools};
 use axum::extract::State;
-use axum::routing::post;
+use axum::http::Uri;
+use axum::routing::{get, post};
 use axum::{Json, Router};
 use serde_json::Value;
 use tokio::net::TcpListener;
@@ -90,6 +91,38 @@ struct CapturedSearch {
     body: Value,
 }
 
+async fn recv_search(captured: &mut mpsc::UnboundedReceiver<CapturedSearch>, expectation: &str) -> CapturedSearch {
+    tokio::time::timeout(std::time::Duration::from_secs(5), captured.recv())
+        .await
+        .unwrap_or_else(|_| panic!("{expectation}: timed out after 5 seconds"))
+        .unwrap_or_else(|| panic!("{expectation}: mock server stopped before receiving a request"))
+}
+
+fn query_params_as_json(uri: &Uri) -> Value {
+    let mut params = serde_json::Map::new();
+    for (key, value) in url::form_urlencoded::parse(uri.query().unwrap_or_default().as_bytes()) {
+        let value = if let Ok(number) = value.parse::<u64>() {
+            Value::from(number)
+        } else {
+            Value::String(value.into_owned())
+        };
+        let key = key.into_owned();
+        match params.remove(&key) {
+            None => {
+                params.insert(key, value);
+            }
+            Some(Value::Array(mut values)) => {
+                values.push(value);
+                params.insert(key, Value::Array(values));
+            }
+            Some(previous) => {
+                params.insert(key, Value::Array(vec![previous, value]));
+            }
+        }
+    }
+    Value::Object(params)
+}
+
 /// Mock You.com search backend the `web_search` executor calls. Uses an
 /// unbounded channel so a test that doesn't drain captures (e.g. the max-rounds
 /// cap, which fires ~10 searches) never blocks the handler.
@@ -102,14 +135,17 @@ async fn spawn_mock_search() -> (
     let app = Router::new()
         .route(
             "/v1/search",
-            post(|State(tx): State<mpsc::UnboundedSender<CapturedSearch>>, Json(body): Json<Value>| async move {
-                let _ = tx.send(CapturedSearch { body });
-                Json(serde_json::json!({
-                    "results": {"web": [{"url": "https://www.rust-lang.org/", "title": "Rust",
-                        "description": "d", "snippets": ["Rust 1.89.0 is the latest stable release."]}], "news": []},
-                    "metadata": {"query": "q", "search_uuid": "s1", "latency": 0.1}
-                }))
-            }),
+            get(
+                |State(tx): State<mpsc::UnboundedSender<CapturedSearch>>, uri: Uri| async move {
+                    let body = query_params_as_json(&uri);
+                    let _ = tx.send(CapturedSearch { body });
+                    Json(serde_json::json!({
+                        "results": {"web": [{"url": "https://www.rust-lang.org/", "title": "Rust",
+                            "description": "d", "snippets": ["Rust 1.89.0 is the latest stable release."]}], "news": []},
+                        "metadata": {"query": "q", "search_uuid": "s1", "latency": 0.1}
+                    }))
+                },
+            ),
         )
         .with_state(tx);
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -126,12 +162,10 @@ async fn spawn_failing_search() -> (String, mpsc::Receiver<()>, tokio::task::Joi
     let app = Router::new()
         .route(
             "/v1/search",
-            post(
-                |State(tx): State<mpsc::Sender<()>>, _body: axum::body::Bytes| async move {
-                    let _ = tx.send(()).await;
-                    (http::StatusCode::INTERNAL_SERVER_ERROR, "search backend down")
-                },
-            ),
+            get(|State(tx): State<mpsc::Sender<()>>| async move {
+                let _ = tx.send(()).await;
+                (http::StatusCode::INTERNAL_SERVER_ERROR, "search backend down")
+            }),
         )
         .with_state(tx);
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -186,7 +220,7 @@ async fn messages_loop_hides_gateway_tool_and_surfaces_final_text() {
         .expect("loop runs");
 
     // The gateway executed the web_search server-side.
-    let search = captured.recv().await.expect("search backend hit");
+    let search = recv_search(&mut captured, "search backend hit").await;
     assert!(search.body.get("query").is_some(), "web_search dispatched with a query");
 
     // Two upstream rounds, and round 2 carried the fed-back tool_result.
@@ -242,8 +276,8 @@ async fn native_web_search_applies_domain_and_location_configuration() {
         .await
         .expect("loop runs");
 
-    let search = captured.recv().await.expect("search backend hit");
-    assert_eq!(search.body["include_domains"], serde_json::json!(["rust-lang.org"]));
+    let search = recv_search(&mut captured, "search backend hit").await;
+    assert_eq!(search.body["include_domains"], "rust-lang.org");
     assert_eq!(search.body["country"], "CA");
 }
 
@@ -268,8 +302,8 @@ async fn native_web_search_applies_blocked_domains() {
         .await
         .expect("loop runs");
 
-    let search = captured.recv().await.expect("search backend hit");
-    assert_eq!(search.body["exclude_domains"], serde_json::json!(["example.com"]));
+    let search = recv_search(&mut captured, "search backend hit").await;
+    assert_eq!(search.body["exclude_domains"], "example.com");
 }
 
 #[tokio::test]
@@ -302,7 +336,7 @@ async fn native_web_search_enforces_max_uses() {
         .await
         .expect("loop runs");
 
-    captured.recv().await.expect("first search runs");
+    recv_search(&mut captured, "first search runs").await;
     assert!(captured.try_recv().is_err(), "second search must not run");
     let requests = upstream.requests.lock().await;
     let results = requests[1]["messages"]
@@ -476,8 +510,8 @@ async fn messages_loop_multi_round_sequential() {
 
     assert_eq!(upstream.calls.load(Ordering::SeqCst), 3, "three upstream rounds");
     // Two gateway searches executed (rounds 0 and 1).
-    captured.recv().await.expect("first search");
-    captured.recv().await.expect("second search");
+    recv_search(&mut captured, "first search").await;
+    recv_search(&mut captured, "second search").await;
     let content = result["content"].as_array().unwrap();
     assert!(!content.iter().any(|b| b["type"] == "tool_use"), "gateway tools hidden");
     assert_eq!(result["stop_reason"], "end_turn");
@@ -498,8 +532,8 @@ async fn messages_loop_parallel_tool_use() {
     let result = run_messages_loop(request, &registry, &exec_ctx, None).await.unwrap();
 
     // Two parallel gateway calls both executed against the backend.
-    captured.recv().await.expect("first parallel search");
-    captured.recv().await.expect("second parallel search");
+    recv_search(&mut captured, "first parallel search").await;
+    recv_search(&mut captured, "second parallel search").await;
     assert_eq!(upstream.calls.load(Ordering::SeqCst), 2, "tool round + final round");
     let content = result["content"].as_array().unwrap();
     assert!(!content.iter().any(|b| b["type"] == "tool_use"), "gateway tools hidden");
@@ -532,13 +566,18 @@ async fn messages_loop_tool_failure_becomes_error_tool_result() {
     });
     let (vllm_url, upstream, _v) = spawn_mock_vllm_messages(vec![round0, round1]).await;
     // Search backend that returns 500 → dispatch error.
-    let (search_url, _rx, _s) = spawn_failing_search().await;
+    let (search_url, mut captured, _s) = spawn_failing_search().await;
     let exec_ctx = build_exec_ctx(&vllm_url, &search_url).await;
     let request = web_search_request();
     let tools: Vec<ToolParam> = serde_json::from_value(request["tools"].clone()).unwrap();
     let registry = build_tool_registry(&tools, &exec_ctx).await;
 
     let result = run_messages_loop(request, &registry, &exec_ctx, None).await.unwrap();
+
+    tokio::time::timeout(std::time::Duration::from_secs(5), captured.recv())
+        .await
+        .expect("failing search backend should be reached within 5 seconds")
+        .expect("failing search backend should receive a request");
 
     // The request did NOT fail — it looped to a final answer.
     assert_eq!(result["stop_reason"], "end_turn");

--- a/crates/agentic-server-core/tests/messages_stream_test.rs
+++ b/crates/agentic-server-core/tests/messages_stream_test.rs
@@ -16,8 +16,9 @@ use agentic_core::storage::{ConversationStore, ResponseStore};
 use agentic_core::tool::{ToolRegistry, WebSearchHandler};
 use agentic_core::types::messages::{GatewayToolMap, ToolParam, registry_tools};
 use axum::extract::State;
+use axum::http::Uri;
 use axum::response::{IntoResponse, Response};
-use axum::routing::post;
+use axum::routing::{get, post};
 use axum::{Json, Router};
 use futures::StreamExt;
 use http::StatusCode;
@@ -102,15 +103,53 @@ async fn spawn_mock_vllm_stream(streams: Vec<String>) -> (String, UpstreamState,
     (format!("http://{addr}"), state, handle)
 }
 
-async fn spawn_mock_search() -> (String, tokio::task::JoinHandle<()>) {
+async fn recv_search(captured: &mut tokio::sync::mpsc::UnboundedReceiver<Value>) -> Value {
+    tokio::time::timeout(std::time::Duration::from_secs(5), captured.recv())
+        .await
+        .expect("search backend should be reached within 5 seconds")
+        .expect("search backend should receive a request")
+}
+
+fn query_params_as_json(uri: &Uri) -> Value {
+    let mut params = serde_json::Map::new();
+    for (key, value) in url::form_urlencoded::parse(uri.query().unwrap_or_default().as_bytes()) {
+        let key = key.into_owned();
+        let value = Value::String(value.into_owned());
+        match params.remove(&key) {
+            None => {
+                params.insert(key, value);
+            }
+            Some(Value::Array(mut values)) => {
+                values.push(value);
+                params.insert(key, Value::Array(values));
+            }
+            Some(previous) => {
+                params.insert(key, Value::Array(vec![previous, value]));
+            }
+        }
+    }
+    Value::Object(params)
+}
+
+async fn spawn_mock_search() -> (
+    String,
+    tokio::sync::mpsc::UnboundedReceiver<Value>,
+    tokio::task::JoinHandle<()>,
+) {
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
     let app = Router::new().route(
         "/v1/search",
-        post(|Json(_body): Json<Value>| async move {
-            Json(serde_json::json!({
-                "results": {"web": [{"url": "https://www.rust-lang.org/", "title": "Rust",
-                    "description": "d", "snippets": ["Rust 1.89.0 is the latest stable release."]}], "news": []},
-                "metadata": {"query": "q", "search_uuid": "s1", "latency": 0.1}
-            }))
+        get(move |uri: Uri| {
+            let tx = tx.clone();
+            async move {
+                let body = query_params_as_json(&uri);
+                let _ = tx.send(body);
+                Json(serde_json::json!({
+                    "results": {"web": [{"url": "https://www.rust-lang.org/", "title": "Rust",
+                        "description": "d", "snippets": ["Rust 1.89.0 is the latest stable release."]}], "news": []},
+                    "metadata": {"query": "q", "search_uuid": "s1", "latency": 0.1}
+                }))
+            }
         }),
     );
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -118,7 +157,7 @@ async fn spawn_mock_search() -> (String, tokio::task::JoinHandle<()>) {
     let handle = tokio::spawn(async move {
         axum::serve(listener, app).await.ok();
     });
-    (format!("http://{addr}"), handle)
+    (format!("http://{addr}"), rx, handle)
 }
 
 async fn build_exec_ctx(vllm_url: &str, search_url: &str) -> Arc<ExecutionContext> {
@@ -136,7 +175,7 @@ async fn build_exec_ctx(vllm_url: &str, search_url: &str) -> Arc<ExecutionContex
 #[tokio::test]
 async fn messages_stream_presents_one_message_and_hides_gateway_tool() {
     let (vllm_url, upstream, _v) = spawn_mock_vllm_stream(cassette_turn_streams()).await;
-    let (search_url, _s) = spawn_mock_search().await;
+    let (search_url, mut captured, _s) = spawn_mock_search().await;
     let exec_ctx = build_exec_ctx(&vllm_url, &search_url).await;
 
     let request = serde_json::json!({
@@ -157,6 +196,8 @@ async fn messages_stream_presents_one_message_and_hides_gateway_tool() {
     let stream = run_messages_stream(request, registry, Arc::clone(&exec_ctx), None);
     let chunks: Vec<String> = stream.collect().await;
     let sse = chunks.join("");
+    let search = recv_search(&mut captured).await;
+    assert!(search.get("query").is_some(), "web_search dispatched with a query");
 
     // Two upstream rounds ran (tool round + final).
     assert_eq!(
@@ -211,7 +252,7 @@ async fn messages_stream_presents_one_message_and_hides_gateway_tool() {
 async fn messages_stream_normalizes_claude_native_web_search_for_vllm() {
     let final_stream = cassette_turn_streams().into_iter().nth(1).expect("final cassette turn");
     let (vllm_url, upstream, _v) = spawn_mock_vllm_stream(vec![final_stream]).await;
-    let (search_url, _s) = spawn_mock_search().await;
+    let (search_url, _captured, _s) = spawn_mock_search().await;
     let exec_ctx = build_exec_ctx(&vllm_url, &search_url).await;
 
     let request = serde_json::json!({
@@ -246,7 +287,7 @@ async fn messages_stream_normalizes_claude_native_web_search_for_vllm() {
 async fn messages_stream_enforces_native_web_search_max_uses() {
     let streams = streams_at(MULTIROUND);
     let (vllm_url, upstream, _v) = spawn_mock_vllm_stream(streams).await;
-    let (search_url, _s) = spawn_mock_search().await;
+    let (search_url, _captured, _s) = spawn_mock_search().await;
     let exec_ctx = build_exec_ctx(&vllm_url, &search_url).await;
 
     let request = serde_json::json!({
@@ -288,7 +329,7 @@ async fn messages_stream_enforces_native_web_search_max_uses() {
 #[tokio::test]
 async fn messages_stream_multiround_single_lifecycle() {
     let (vllm_url, upstream, _v) = spawn_mock_vllm_stream(streams_at(MULTIROUND)).await;
-    let (search_url, _s) = spawn_mock_search().await;
+    let (search_url, _captured, _s) = spawn_mock_search().await;
     let exec_ctx = build_exec_ctx(&vllm_url, &search_url).await;
 
     let request = serde_json::json!({
@@ -352,7 +393,7 @@ async fn messages_stream_multiround_single_lifecycle() {
 #[tokio::test]
 async fn messages_stream_preserves_multi_block_system_across_rounds() {
     let (vllm_url, upstream, _v) = spawn_mock_vllm_stream(cassette_turn_streams()).await;
-    let (search_url, _s) = spawn_mock_search().await;
+    let (search_url, _captured, _s) = spawn_mock_search().await;
     let exec_ctx = build_exec_ctx(&vllm_url, &search_url).await;
 
     let system = serde_json::json!([


### PR DESCRIPTION
## Summary

- align the remaining You.com test mocks with the GET query-parameter contract introduced in #203
- bound mock request captures so future contract mismatches fail within five seconds instead of hanging CI
- verify the intentional 500 search mock is actually reached and cap the Rust job at 30 minutes

## Test Plan

- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- cargo build
- cargo test
- cargo test -p agentic-server-core --test dispatch_loop_cassette_test
- cargo test -p agentic-server-core --test messages_loop_test
- cargo test -p agentic-server-core --test messages_stream_test