### PR TITLE
chore: prepare release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Agentic API are documented here.
 
+## [0.5.0] - 2026-08-25
+
+### Changed
+
+- Preserved Claude Code Messages transport fidelity across the gateway.
+- Updated You.com web search integration to use GET query parameters.
+- Aligned deployment and harness documentation with the 0.4.0 release.
+
+### Testing
+
+- Fixed web search test hangs in CI.
+
 ## [0.4.0] - 2026-08-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,14 +4,14 @@ version = 4
 
 [[package]]
 name = "agentic-praxis"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "agentic-server-core",
 ]
 
 [[package]]
 name = "agentic-server"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "agentic-server-core",
  "axum",
@@ -44,7 +44,7 @@ dependencies = [
 
 [[package]]
 name = "agentic-server-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/vllm-project/agentic-api"
@@ -16,7 +16,7 @@ all = { level = "deny", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
 
 [workspace.dependencies]
-agentic-core = { package = "agentic-server-core", path = "crates/agentic-server-core", version = "0.4.0" }
+agentic-core = { package = "agentic-server-core", path = "crates/agentic-server-core", version = "0.5.0" }
 async-stream = "0.3"
 axum = { version = "0.8", features = ["ws"] }
 either = "1"


### PR DESCRIPTION
## Summary

Prepare the v0.5.0 crates release by updating workspace and published crate dependency versions and adding release notes.

## Test Plan

- cargo check --workspace
- cargo fmt -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test

The full test suite passed with 371 core tests and 48 server tests; 3 PostgreSQL tests were ignored because they require an isolated TEST_POSTGRES_URL.