### PR TITLE
fix: touch source files after cargo-chef cook to prevent stale artifacts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ RUN cargo chef cook --locked --release --recipe-path recipe.json
 COPY Cargo.toml Cargo.lock ./
 COPY crates ./crates
 
-RUN cargo build --locked --release -p agentic-server && \
+RUN find crates -type f -name '*.rs' -exec touch {} + && \
+    cargo build --locked --release -p agentic-server && \
     install -Dm755 -s target/release/agentic-server /out/agentic-server
 
 FROM debian:${DEBIAN_VERSION}-slim@${DEBIAN_IMAGE_DIGEST} AS runtime


### PR DESCRIPTION
## Summary

- After `cargo chef cook` pre-builds dependencies with dummy source files, the real source is copied over but cargo may reuse compiled artifacts with stale metadata (e.g. wrong crate version)
- Adding `find crates -type f -name '*.rs' -exec touch {} +` before `cargo build` forces cargo to recompile the actual source with correct workspace version
- Discovered when a Kaniko in-cluster build produced `agentic-server v0.0.1` instead of `v0.5.0`

## Test plan

- [ ] Build the container image and verify `Compiling agentic-server v0.5.0` appears in the build log
- [ ] Confirm the resulting binary reports the correct version

🤖 Generated with [Claude Code](https://claude.com/claude-code)