### PR TITLE
fix: clean workspace crates before rebuild to prevent stale artifacts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,14 @@ WORKDIR /workspace
 COPY --from=planner /workspace/recipe.json recipe.json
 RUN cargo chef cook --locked --release --recipe-path recipe.json
 
+RUN rm -rf crates
 COPY Cargo.toml Cargo.lock ./
 COPY crates ./crates
 
-RUN find crates -type f -name '*.rs' -exec touch {} + && \
+RUN cargo clean \
+      -p agentic-server-core \
+      -p agentic-server \
+      -p agentic-praxis && \
     cargo build --locked --release -p agentic-server && \
     install -Dm755 -s target/release/agentic-server /out/agentic-server
 


### PR DESCRIPTION
## Summary

- Replace the `touch`-based workaround from #208 with a more thorough fix
- `rm -rf crates` removes dummy source files left by `cargo chef cook` before copying the real source
- `cargo clean -p` removes compiled artifacts for the three workspace crates so they rebuild with correct metadata (version, features)
- Dependency artifacts from the cook step are preserved — only workspace crates recompile

## Test plan

- [ ] Build the container image and verify `Compiling agentic-server v0.5.0` in the build log
- [ ] Confirm dependency caching still works (cook step should be a cache hit on unchanged deps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)