### PR TITLE
feat: add attached Claude Code and Codex workflows

### DIFF
--- a/.github/workflows/claude-code-e2e.yml
+++ b/.github/workflows/claude-code-e2e.yml
@@ -1,6 +1,6 @@
-name: Claude Code E2E
+name: Harness CLI E2E
 
-run-name: Claude Code through Messages gateway
+run-name: Real coding CLIs through Agentic API
 
 on:
   pull_request:
@@ -17,7 +17,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  claude-code-e2e:
+  harness-cli-e2e:
+    name: ${{ matrix.name }} through Agentic API
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Claude Code
+            package: '@anthropic-ai/claude-code'
+            version: '2.1.245'
+            binary: claude
+            expected-version: '2.1.245 (Claude Code)'
+            smoke-script: scripts/claude-code-smoke.sh
+          - name: Codex
+            package: '@openai/codex'
+            version: '0.149.1'
+            binary: codex
+            expected-version: 'codex-cli 0.149.1'
+            smoke-script: scripts/codex-smoke.sh
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -53,14 +70,14 @@ jobs:
       - name: Install pinned test dependencies
         run: |
           python -m pip install 'PyYAML==6.0.3'
-          npm install --global '@anthropic-ai/claude-code@2.1.218'
-          test "$(claude --version)" = '2.1.218 (Claude Code)'
+          npm install --global '${{ matrix.package }}@${{ matrix.version }}'
+          test "$(${{ matrix.binary }} --version)" = '${{ matrix.expected-version }}'
 
       - name: Test replay server
         run: python -m unittest scripts/test_claude_code_replay_server.py -v
 
-      - name: Build agentic-server
-        run: cargo build -p agentic-server
+      - name: Build Agentic API CLI and server
+        run: cargo build -p agentic-server --bins
 
-      - name: Run Claude Code through agentic-server
-        run: bash scripts/claude-code-smoke.sh
+      - name: Run ${{ matrix.name }} through Agentic API
+        run: bash '${{ matrix.smoke-script }}'

--- a/crates/agentic-server-core/tests/cassettes/README.md
+++ b/crates/agentic-server-core/tests/cassettes/README.md
@@ -29,31 +29,34 @@ python tests/cassettes/record_cassette.py --mode responses --turns 1 --no-stream
 
 The recorder scripts (`record_reasoning_cassettes.sh`, `record_tool_call_cassettes.sh`, etc.) use `printf` to feed fixed prompts per test so no manual input is needed.
 
-## Claude Code cache-control parity
+## Coding-harness CLI acceptance tests
 
 The literal fixture at `../fixtures/claude-code-cache-control-request.json` mirrors the cache-bearing parts of a
 Claude Code Messages request: multi-block `system`, a structured user message, and both `WebSearch` and client-owned
 tool declarations. It includes explicit `5m` and `1h` TTLs. The Messages HTTP and loop integration tests assert that
 the fixture remains unchanged through transparent proxying and every streaming and non-streaming gateway-tool round.
 
-The fixture is hand-checked test data, not a captured cassette. A dedicated GitHub Actions job also runs the real,
-pinned Claude Code CLI through `agentic-server` against the recorded streaming vLLM Messages cassette and a
-deterministic local search backend. It uses a placeholder API key and makes no request to Anthropic or a live model.
+The fixture is hand-checked test data, not a captured cassette. A dedicated GitHub Actions matrix runs the real,
+pinned Claude Code and Codex CLIs through the `agentic harness` attach commands. Claude Code replays the streaming
+vLLM Messages web-search cassette through a deterministic local search backend. Codex replays the streaming vLLM
+Responses reasoning cassette. Neither job contacts Anthropic, OpenAI, or a live model.
 
 To run the same end-to-end check locally, install the pinned dependencies, build the server, and run the harness:
 
 ```bash
-npm install --global '@anthropic-ai/claude-code@2.1.218'
+npm install --global '@anthropic-ai/claude-code@2.1.245' '@openai/codex@0.149.1'
 python -m pip install 'PyYAML==6.0.3'
-cargo build -p agentic-server
+cargo build -p agentic-server --bins
 bash scripts/claude-code-smoke.sh
+bash scripts/codex-smoke.sh
 ```
 
-The harness starts both local services, opts `WebSearch` into gateway execution with
-`MESSAGES_GATEWAY_TOOL_ALIASES=WebSearch=web_search`, and invokes Claude Code's non-interactive interface in safe
-mode. It disables nonessential traffic and session persistence, maps every Claude model tier to the replayed `qwen3`
-model, then asserts two Messages rounds, one search request, a hidden `tool_result`, and the cache-bearing system and
-user blocks emitted by Claude Code 2.1.218.
+Each smoke script starts a replay server and Agentic API, then invokes the installed CLI through the corresponding
+`agentic harness` command. The Claude job opts `WebSearch` into gateway execution with
+`MESSAGES_GATEWAY_TOOL_ALIASES=WebSearch=web_search`; it asserts the recorded answer, two Messages rounds, one search
+request, a hidden `tool_result`, cache-bearing system and user blocks, and the exact Qwen model requested by Claude
+Code 2.1.245. The Codex job asserts the recorded `HELLO` answer, one streaming Responses request, and the exact Qwen
+model requested by Codex 0.149.1.
 
 ## Modes
 

--- a/crates/agentic-server/src/agentic_cli.rs
+++ b/crates/agentic-server/src/agentic_cli.rs
@@ -39,10 +39,54 @@ pub enum Command {
         #[command(subcommand)]
         harness: HarnessCommand,
     },
+    /// Launch a coding harness against an already-running Agentic API gateway
+    Harness {
+        #[command(subcommand)]
+        harness: AttachedHarnessCommand,
+    },
     /// Start Agentic API without launching a harness
     Serve(ServeOptions),
     /// Validate the local Agentic API session prerequisites
     Validate(ValidateOptions),
+}
+
+#[derive(Debug, Subcommand)]
+pub enum AttachedHarnessCommand {
+    /// Launch Codex with an isolated provider configuration
+    Codex(AttachedHarnessOptions),
+    /// Launch Claude Code with isolated provider and model configuration
+    Claude(AttachedHarnessOptions),
+}
+
+#[derive(Args, Clone, Debug)]
+pub struct AttachedHarnessOptions {
+    /// URL of an already-running Agentic API gateway
+    #[arg(long, value_parser = parse_upstream_url)]
+    pub gateway_url: String,
+
+    /// Model ID served by the gateway
+    #[arg(long)]
+    pub model: String,
+
+    /// API key forwarded to the gateway and harness when configured
+    #[arg(long, env = "OPENAI_API_KEY", hide_env_values = true)]
+    pub api_key: Option<String>,
+
+    /// Suppress lifecycle output
+    #[arg(long)]
+    pub quiet: bool,
+
+    /// Skip harness permission prompts and sandbox restrictions
+    #[arg(long)]
+    pub yolo: bool,
+
+    /// Disable ANSI color output
+    #[arg(long)]
+    pub no_color: bool,
+
+    /// Arguments forwarded to the selected harness after `--`
+    #[arg(last = true, allow_hyphen_values = true)]
+    pub harness_args: Vec<String>,
 }
 
 #[derive(Debug, Subcommand)]
@@ -226,7 +270,7 @@ impl HarnessCommand {
 mod tests {
     use clap::Parser;
 
-    use super::{Cli, Command, DEFAULT_DATABASE_URL, HarnessCommand};
+    use super::{AttachedHarnessCommand, Cli, Command, DEFAULT_DATABASE_URL, HarnessCommand};
 
     #[test]
     fn run_codex_uses_sqlite_by_default_and_preserves_arguments() {
@@ -335,5 +379,74 @@ mod tests {
             panic!("expected run command");
         };
         assert!(harness.options().common.yolo);
+    }
+
+    #[test]
+    fn harness_claude_accepts_gateway_and_namespaced_model() {
+        let cli = Cli::try_parse_from([
+            "agentic",
+            "harness",
+            "claude",
+            "--gateway-url",
+            "http://127.0.0.1:9000/",
+            "--model",
+            "Qwen/Qwen3-8B",
+            "--",
+            "--resume",
+        ])
+        .expect("valid attached Claude CLI");
+
+        let Command::Harness { harness } = cli.command else {
+            panic!("expected harness command");
+        };
+        let AttachedHarnessCommand::Claude(options) = harness else {
+            panic!("expected Claude harness");
+        };
+        assert_eq!(options.gateway_url, "http://127.0.0.1:9000");
+        assert_eq!(options.model, "Qwen/Qwen3-8B");
+        assert_eq!(options.harness_args, ["--resume"]);
+    }
+
+    #[test]
+    fn harness_claude_rejects_malformed_gateway_urls() {
+        let error = Cli::try_parse_from([
+            "agentic",
+            "harness",
+            "claude",
+            "--gateway-url",
+            "127.0.0.1:9000",
+            "--model",
+            "Qwen/Qwen3-8B",
+        ])
+        .expect_err("malformed gateway URL should be rejected");
+
+        assert!(error.to_string().contains("invalid upstream URL"));
+    }
+
+    #[test]
+    fn harness_codex_accepts_gateway_model_and_passthrough() {
+        let cli = Cli::try_parse_from([
+            "agentic",
+            "harness",
+            "codex",
+            "--gateway-url",
+            "http://127.0.0.1:9000/",
+            "--model",
+            "Qwen/Qwen3-8B",
+            "--",
+            "exec",
+            "say hello",
+        ])
+        .expect("valid attached Codex CLI");
+
+        let Command::Harness { harness } = cli.command else {
+            panic!("expected harness command");
+        };
+        let AttachedHarnessCommand::Codex(options) = harness else {
+            panic!("expected Codex harness");
+        };
+        assert_eq!(options.gateway_url, "http://127.0.0.1:9000");
+        assert_eq!(options.model, "Qwen/Qwen3-8B");
+        assert_eq!(options.harness_args, ["exec", "say hello"]);
     }
 }

--- a/crates/agentic-server/src/agentic_cli.rs
+++ b/crates/agentic-server/src/agentic_cli.rs
@@ -3,6 +3,8 @@ use clap::{
     builder::{Styles, styling::AnsiColor},
 };
 
+use crate::agentic_output::redact_url;
+
 const fn brand_styles() -> Styles {
     Styles::styled()
         .header(AnsiColor::BrightCyan.on_default().bold())
@@ -69,7 +71,7 @@ pub struct AttachedHarnessOptions {
     pub model: String,
 
     /// API key forwarded to the gateway and harness when configured
-    #[arg(long, env = "OPENAI_API_KEY", hide_env_values = true)]
+    #[arg(long, env = "AGENTIC_GATEWAY_API_KEY", hide_env_values = true)]
     pub api_key: Option<String>,
 
     /// Suppress lifecycle output
@@ -193,18 +195,19 @@ pub struct CommonOptions {
 }
 
 fn parse_upstream_url(value: &str) -> Result<String, String> {
-    let parsed = url::Url::parse(value).map_err(|error| format!("invalid upstream URL `{value}`: {error}"))?;
+    let display_value = redact_url(value);
+    let parsed = url::Url::parse(value).map_err(|error| format!("invalid upstream URL `{display_value}`: {error}"))?;
     if !matches!(parsed.scheme(), "http" | "https") {
         return Err(format!(
-            "invalid upstream URL `{value}`: expected an http:// or https:// base URL"
+            "invalid upstream URL `{display_value}`: expected an http:// or https:// base URL"
         ));
     }
     if parsed.host_str().is_none_or(str::is_empty) {
-        return Err(format!("invalid upstream URL `{value}`: missing host"));
+        return Err(format!("invalid upstream URL `{display_value}`: missing host"));
     }
     if parsed.query().is_some() || parsed.fragment().is_some() {
         return Err(format!(
-            "invalid upstream URL `{value}`: query strings and fragments are not supported; pass a base URL such as http://host:port"
+            "invalid upstream URL `{display_value}`: query strings and fragments are not supported; pass a base URL such as http://host:port"
         ));
     }
     Ok(value.trim_end_matches('/').to_owned())
@@ -268,7 +271,9 @@ impl HarnessCommand {
 
 #[cfg(test)]
 mod tests {
-    use clap::Parser;
+    use std::ffi::OsStr;
+
+    use clap::{CommandFactory, Parser};
 
     use super::{AttachedHarnessCommand, Cli, Command, DEFAULT_DATABASE_URL, HarnessCommand};
 
@@ -448,5 +453,24 @@ mod tests {
         assert_eq!(options.gateway_url, "http://127.0.0.1:9000");
         assert_eq!(options.model, "Qwen/Qwen3-8B");
         assert_eq!(options.harness_args, ["exec", "say hello"]);
+    }
+
+    #[test]
+    fn attached_api_key_uses_gateway_specific_environment_variable() {
+        let command = Cli::command();
+        let harness = command
+            .get_subcommands()
+            .find(|command| command.get_name() == "harness")
+            .expect("harness subcommand");
+        let claude = harness
+            .get_subcommands()
+            .find(|command| command.get_name() == "claude")
+            .expect("Claude subcommand");
+        let api_key = claude
+            .get_arguments()
+            .find(|argument| argument.get_id() == "api_key")
+            .expect("attached API key argument");
+
+        assert_eq!(api_key.get_env(), Some(OsStr::new("AGENTIC_GATEWAY_API_KEY")));
     }
 }

--- a/crates/agentic-server/src/agentic_harness.rs
+++ b/crates/agentic-server/src/agentic_harness.rs
@@ -7,9 +7,12 @@ use std::{
 #[derive(Debug)]
 pub struct HarnessEnv {
     pub environment: BTreeMap<String, String>,
+    pub environment_remove: Vec<String>,
     pub files: Vec<PathBuf>,
     pub summary: String,
 }
+
+pub const CLAUDE_CANONICAL_MODEL: &str = "claude-sonnet-4-5-20250929";
 
 /// Write an isolated Codex home for an Agentic API session.
 ///
@@ -96,59 +99,85 @@ wire_api = \"responses\"\nrequires_openai_auth = {requires_auth}\nsupports_webso
 
     Ok(HarnessEnv {
         environment,
+        environment_remove: Vec::new(),
         files: vec![config_path, catalog_path],
         summary: format!("Codex home: {} (model: {model})", root.display()),
     })
 }
 
-#[must_use]
-pub fn prepare_claude_env(gateway_url: &str, model: &str, api_key: Option<&str>) -> HarnessEnv {
-    let auth_token = std::env::var("ANTHROPIC_AUTH_TOKEN")
-        .ok()
-        .or_else(|| api_key.map(str::to_owned))
-        .unwrap_or_else(|| "agentic-api-local".to_owned());
+/// Write an isolated Claude Code configuration for an Agentic API session.
+///
+/// # Errors
+///
+/// Returns an I/O error when the temporary configuration directory or settings file cannot be written.
+pub fn prepare_claude_home(
+    root: &Path,
+    gateway_url: &str,
+    model: &str,
+    api_key: Option<&str>,
+) -> Result<HarnessEnv, io::Error> {
+    fs::create_dir_all(root)?;
+    let settings_path = root.join("settings.json");
+    let settings = serde_json::json!({
+        "modelOverrides": {
+            CLAUDE_CANONICAL_MODEL: model,
+        }
+    });
+    let settings_bytes = serde_json::to_vec_pretty(&settings).map_err(io::Error::other)?;
+    fs::write(&settings_path, settings_bytes).map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!(
+                "failed to write Claude Code settings {}: {error}",
+                settings_path.display()
+            ),
+        )
+    })?;
+
+    let auth_token = api_key.unwrap_or("agentic-api-local");
     let mut environment = BTreeMap::from([
         (
             "ANTHROPIC_BASE_URL".to_owned(),
             gateway_url.trim_end_matches('/').to_owned(),
         ),
-        ("ANTHROPIC_MODEL".to_owned(), model.to_owned()),
-        ("ANTHROPIC_SMALL_FAST_MODEL".to_owned(), model.to_owned()),
-        ("ANTHROPIC_DEFAULT_OPUS_MODEL".to_owned(), model.to_owned()),
-        ("ANTHROPIC_DEFAULT_SONNET_MODEL".to_owned(), model.to_owned()),
-        ("ANTHROPIC_DEFAULT_HAIKU_MODEL".to_owned(), model.to_owned()),
-        (
-            "ANTHROPIC_API_KEY".to_owned(),
-            api_key.unwrap_or("agentic-api-local").to_owned(),
-        ),
-        ("ANTHROPIC_AUTH_TOKEN".to_owned(), auth_token),
+        ("ANTHROPIC_API_KEY".to_owned(), auth_token.to_owned()),
+        ("ANTHROPIC_AUTH_TOKEN".to_owned(), auth_token.to_owned()),
+        ("CLAUDE_CONFIG_DIR".to_owned(), root.display().to_string()),
+        ("CLAUDE_CODE_MAX_CONTEXT_TOKENS".to_owned(), "32768".to_owned()),
+        ("CLAUDE_CODE_MAX_OUTPUT_TOKENS".to_owned(), "2048".to_owned()),
+        ("MAX_THINKING_TOKENS".to_owned(), "0".to_owned()),
     ]);
     if let Some(api_key) = api_key {
         environment.insert("OPENAI_API_KEY".to_owned(), api_key.to_owned());
     }
-    HarnessEnv {
+    Ok(HarnessEnv {
         environment,
-        files: Vec::new(),
+        environment_remove: [
+            "CLAUDE_CODE_USE_VERTEX",
+            "CLAUDE_CODE_USE_BEDROCK",
+            "CLAUDE_CODE_USE_FOUNDRY",
+            "CLAUDE_CODE_USE_ANTHROPIC_AWS",
+            "CLAUDE_CODE_USE_MANTLE",
+            "CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST",
+            "ANTHROPIC_VERTEX_PROJECT_ID",
+            "CLOUD_ML_REGION",
+            "GOOGLE_APPLICATION_CREDENTIALS",
+            "ANTHROPIC_MODEL",
+            "ANTHROPIC_SMALL_FAST_MODEL",
+            "ANTHROPIC_DEFAULT_OPUS_MODEL",
+            "ANTHROPIC_DEFAULT_SONNET_MODEL",
+            "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+        ]
+        .into_iter()
+        .map(str::to_owned)
+        .collect(),
+        files: vec![settings_path],
         summary: format!(
-            "Claude Code gateway: {} (model: {model})",
+            "Claude Code config: {} (gateway: {}, model: {model})",
+            root.display(),
             gateway_url.trim_end_matches('/')
         ),
-    }
-}
-
-/// Validates that a Claude Code model name is a slash-free served alias.
-///
-/// # Errors
-///
-/// Returns an error when the model name contains `/`, which Claude Code does not
-/// accept for custom model names.
-pub fn validate_claude_model(model: &str) -> Result<(), String> {
-    if model.contains('/') {
-        return Err(format!(
-            "Claude Code requires a slash-free served model alias; start vLLM with --served-model-name and set --model to that alias (received {model})"
-        ));
-    }
-    Ok(())
+    })
 }
 
 fn toml_escape(value: &str) -> String {
@@ -159,7 +188,7 @@ fn toml_escape(value: &str) -> String {
 mod tests {
     use std::fs;
 
-    use super::{prepare_claude_env, prepare_codex_home};
+    use super::{prepare_claude_home, prepare_codex_home};
 
     #[test]
     fn codex_config_is_isolated_and_contains_gateway_provider() {
@@ -178,38 +207,73 @@ mod tests {
     }
 
     #[test]
-    fn claude_environment_uses_gateway_and_does_not_expose_key() {
-        let env = prepare_claude_env("http://127.0.0.1:3000", "Qwen/test", Some("secret-key"));
+    fn claude_home_is_isolated_and_maps_the_canonical_model() {
+        let root = unique_temp_dir("claude");
+        let env = prepare_claude_home(&root, "http://127.0.0.1:3000", "Qwen/test", Some("secret-key"))
+            .expect("Claude config");
+        let settings = fs::read_to_string(root.join("settings.json")).expect("settings file");
+        let settings: serde_json::Value = serde_json::from_str(&settings).expect("valid settings JSON");
 
         assert_eq!(
             env.environment.get("ANTHROPIC_BASE_URL"),
             Some(&"http://127.0.0.1:3000".to_owned())
         );
-        assert_eq!(env.environment.get("ANTHROPIC_MODEL"), Some(&"Qwen/test".to_owned()));
         assert_eq!(
-            env.environment.get("ANTHROPIC_DEFAULT_OPUS_MODEL"),
-            Some(&"Qwen/test".to_owned())
+            env.environment.get("CLAUDE_CONFIG_DIR"),
+            Some(&root.display().to_string())
         );
         assert_eq!(
-            env.environment.get("ANTHROPIC_DEFAULT_SONNET_MODEL"),
-            Some(&"Qwen/test".to_owned())
+            env.environment.get("CLAUDE_CODE_MAX_CONTEXT_TOKENS"),
+            Some(&"32768".to_owned())
         );
         assert_eq!(
-            env.environment.get("ANTHROPIC_DEFAULT_HAIKU_MODEL"),
-            Some(&"Qwen/test".to_owned())
+            env.environment.get("CLAUDE_CODE_MAX_OUTPUT_TOKENS"),
+            Some(&"2048".to_owned())
         );
+        assert_eq!(env.environment.get("MAX_THINKING_TOKENS"), Some(&"0".to_owned()));
         assert_eq!(env.environment.get("ANTHROPIC_API_KEY"), Some(&"secret-key".to_owned()));
         assert_eq!(
             env.environment.get("ANTHROPIC_AUTH_TOKEN"),
             Some(&"secret-key".to_owned())
         );
+        assert_eq!(settings["modelOverrides"]["claude-sonnet-4-5-20250929"], "Qwen/test");
+        assert!(env.environment_remove.contains(&"CLAUDE_CODE_USE_VERTEX".to_owned()));
+        assert!(
+            env.environment_remove
+                .contains(&"CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST".to_owned())
+        );
+        assert!(
+            env.environment_remove
+                .contains(&"CLAUDE_CODE_USE_ANTHROPIC_AWS".to_owned())
+        );
+        assert!(env.environment_remove.contains(&"CLAUDE_CODE_USE_MANTLE".to_owned()));
+        assert!(
+            env.environment_remove
+                .contains(&"ANTHROPIC_VERTEX_PROJECT_ID".to_owned())
+        );
+        assert!(env.environment_remove.contains(&"CLOUD_ML_REGION".to_owned()));
+        assert!(env.environment_remove.contains(&"ANTHROPIC_MODEL".to_owned()));
         assert!(!env.summary.contains("secret-key"));
+
+        fs::remove_dir_all(root).expect("cleanup");
     }
 
     #[test]
-    fn claude_model_requires_a_served_alias() {
-        assert!(super::validate_claude_model("Qwen/test").is_err());
-        assert!(super::validate_claude_model("Qwen-test").is_ok());
+    fn claude_home_uses_a_local_placeholder_without_inherited_auth() {
+        let root = unique_temp_dir("claude-no-key");
+        let env = prepare_claude_home(&root, "http://127.0.0.1:3000", "Qwen/test", None).expect("Claude config");
+
+        assert_eq!(
+            env.environment.get("ANTHROPIC_API_KEY"),
+            Some(&"agentic-api-local".to_owned())
+        );
+        assert_eq!(
+            env.environment.get("ANTHROPIC_AUTH_TOKEN"),
+            Some(&"agentic-api-local".to_owned())
+        );
+        assert!(!env.environment.contains_key("OPENAI_API_KEY"));
+
+        fs::remove_dir_all(root).expect("cleanup");
     }
 
     fn unique_temp_dir(name: &str) -> std::path::PathBuf {

--- a/crates/agentic-server/src/agentic_harness.rs
+++ b/crates/agentic-server/src/agentic_harness.rs
@@ -4,10 +4,13 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use crate::agentic_output::redact_url;
+
 #[derive(Debug)]
 pub struct HarnessEnv {
     pub environment: BTreeMap<String, String>,
     pub environment_remove: Vec<String>,
+    pub arguments: Vec<String>,
     pub files: Vec<PathBuf>,
     pub summary: String,
 }
@@ -99,7 +102,8 @@ wire_api = \"responses\"\nrequires_openai_auth = {requires_auth}\nsupports_webso
 
     Ok(HarnessEnv {
         environment,
-        environment_remove: Vec::new(),
+        environment_remove: vec!["OPENAI_API_KEY".to_owned()],
+        arguments: Vec::new(),
         files: vec![config_path, catalog_path],
         summary: format!("Codex home: {} (model: {model})", root.display()),
     })
@@ -116,7 +120,19 @@ pub fn prepare_claude_home(
     model: &str,
     api_key: Option<&str>,
 ) -> Result<HarnessEnv, io::Error> {
+    prepare_claude_home_with_state(root, root, gateway_url, model, None, api_key)
+}
+
+pub(crate) fn prepare_claude_home_with_state(
+    root: &Path,
+    state_root: &Path,
+    gateway_url: &str,
+    model: &str,
+    auth_token: Option<&str>,
+    api_key: Option<&str>,
+) -> Result<HarnessEnv, io::Error> {
     fs::create_dir_all(root)?;
+    ensure_private_directory(state_root)?;
     let settings_path = root.join("settings.json");
     let settings = serde_json::json!({
         "modelOverrides": {
@@ -134,15 +150,21 @@ pub fn prepare_claude_home(
         )
     })?;
 
-    let auth_token = api_key.unwrap_or("agentic-api-local");
+    let api_key_value = api_key.unwrap_or("agentic-api-local");
+    let auth_token = auth_token.unwrap_or(api_key_value);
     let mut environment = BTreeMap::from([
         (
             "ANTHROPIC_BASE_URL".to_owned(),
             gateway_url.trim_end_matches('/').to_owned(),
         ),
-        ("ANTHROPIC_API_KEY".to_owned(), auth_token.to_owned()),
+        ("ANTHROPIC_MODEL".to_owned(), model.to_owned()),
+        ("ANTHROPIC_SMALL_FAST_MODEL".to_owned(), model.to_owned()),
+        ("ANTHROPIC_DEFAULT_OPUS_MODEL".to_owned(), model.to_owned()),
+        ("ANTHROPIC_DEFAULT_SONNET_MODEL".to_owned(), model.to_owned()),
+        ("ANTHROPIC_DEFAULT_HAIKU_MODEL".to_owned(), model.to_owned()),
+        ("ANTHROPIC_API_KEY".to_owned(), api_key_value.to_owned()),
         ("ANTHROPIC_AUTH_TOKEN".to_owned(), auth_token.to_owned()),
-        ("CLAUDE_CONFIG_DIR".to_owned(), root.display().to_string()),
+        ("CLAUDE_CONFIG_DIR".to_owned(), state_root.display().to_string()),
         ("CLAUDE_CODE_MAX_CONTEXT_TOKENS".to_owned(), "32768".to_owned()),
         ("CLAUDE_CODE_MAX_OUTPUT_TOKENS".to_owned(), "2048".to_owned()),
         ("MAX_THINKING_TOKENS".to_owned(), "0".to_owned()),
@@ -153,29 +175,27 @@ pub fn prepare_claude_home(
     Ok(HarnessEnv {
         environment,
         environment_remove: [
+            "OPENAI_API_KEY",
             "CLAUDE_CODE_USE_VERTEX",
             "CLAUDE_CODE_USE_BEDROCK",
             "CLAUDE_CODE_USE_FOUNDRY",
             "CLAUDE_CODE_USE_ANTHROPIC_AWS",
             "CLAUDE_CODE_USE_MANTLE",
             "CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST",
+            "ANTHROPIC_CUSTOM_HEADERS",
             "ANTHROPIC_VERTEX_PROJECT_ID",
             "CLOUD_ML_REGION",
             "GOOGLE_APPLICATION_CREDENTIALS",
-            "ANTHROPIC_MODEL",
-            "ANTHROPIC_SMALL_FAST_MODEL",
-            "ANTHROPIC_DEFAULT_OPUS_MODEL",
-            "ANTHROPIC_DEFAULT_SONNET_MODEL",
-            "ANTHROPIC_DEFAULT_HAIKU_MODEL",
         ]
         .into_iter()
         .map(str::to_owned)
         .collect(),
+        arguments: vec!["--settings".to_owned(), settings_path.display().to_string()],
         files: vec![settings_path],
         summary: format!(
             "Claude Code config: {} (gateway: {}, model: {model})",
             root.display(),
-            gateway_url.trim_end_matches('/')
+            redact_url(gateway_url.trim_end_matches('/'))
         ),
     })
 }
@@ -184,11 +204,25 @@ fn toml_escape(value: &str) -> String {
     value.replace('\\', "\\\\").replace('\"', "\\\"")
 }
 
+fn ensure_private_directory(path: &Path) -> Result<(), io::Error> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+
+        let mut builder = fs::DirBuilder::new();
+        builder.recursive(true).mode(0o700).create(path)?;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
+    }
+    #[cfg(not(unix))]
+    fs::create_dir_all(path)?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs;
 
-    use super::{prepare_claude_home, prepare_codex_home};
+    use super::{prepare_claude_home, prepare_claude_home_with_state, prepare_codex_home};
 
     #[test]
     fn codex_config_is_isolated_and_contains_gateway_provider() {
@@ -207,10 +241,36 @@ mod tests {
     }
 
     #[test]
+    fn codex_home_removes_inherited_openai_key_unless_explicitly_configured() {
+        let root = unique_temp_dir("codex-credential-isolation");
+        let without_key = prepare_codex_home(&root, "http://127.0.0.1:3000", "Qwen/test", None)
+            .expect("Codex config without gateway key");
+
+        assert!(without_key.environment_remove.contains(&"OPENAI_API_KEY".to_owned()));
+        assert!(!without_key.environment.contains_key("OPENAI_API_KEY"));
+
+        let with_key = prepare_codex_home(&root, "http://127.0.0.1:3000", "Qwen/test", Some("gateway-key"))
+            .expect("Codex config with gateway key");
+        assert_eq!(
+            with_key.environment.get("OPENAI_API_KEY"),
+            Some(&"gateway-key".to_owned())
+        );
+
+        fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    #[test]
     fn claude_home_is_isolated_and_maps_the_canonical_model() {
         let root = unique_temp_dir("claude");
-        let env = prepare_claude_home(&root, "http://127.0.0.1:3000", "Qwen/test", Some("secret-key"))
-            .expect("Claude config");
+        let env = prepare_claude_home_with_state(
+            &root,
+            &root,
+            "http://127.0.0.1:3000",
+            "Qwen/test",
+            None,
+            Some("secret-key"),
+        )
+        .expect("Claude config");
         let settings = fs::read_to_string(root.join("settings.json")).expect("settings file");
         let settings: serde_json::Value = serde_json::from_str(&settings).expect("valid settings JSON");
 
@@ -247,13 +307,36 @@ mod tests {
                 .contains(&"CLAUDE_CODE_USE_ANTHROPIC_AWS".to_owned())
         );
         assert!(env.environment_remove.contains(&"CLAUDE_CODE_USE_MANTLE".to_owned()));
+        assert!(env.environment_remove.contains(&"ANTHROPIC_CUSTOM_HEADERS".to_owned()));
         assert!(
             env.environment_remove
                 .contains(&"ANTHROPIC_VERTEX_PROJECT_ID".to_owned())
         );
         assert!(env.environment_remove.contains(&"CLOUD_ML_REGION".to_owned()));
-        assert!(env.environment_remove.contains(&"ANTHROPIC_MODEL".to_owned()));
         assert!(!env.summary.contains("secret-key"));
+
+        fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    #[test]
+    fn claude_home_maps_every_model_tier_to_the_served_model() {
+        let root = unique_temp_dir("claude-model-tiers");
+        let env = prepare_claude_home(&root, "http://127.0.0.1:3000", "Qwen/test", None).expect("Claude config");
+
+        for variable in [
+            "ANTHROPIC_MODEL",
+            "ANTHROPIC_SMALL_FAST_MODEL",
+            "ANTHROPIC_DEFAULT_OPUS_MODEL",
+            "ANTHROPIC_DEFAULT_SONNET_MODEL",
+            "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+        ] {
+            assert_eq!(
+                env.environment.get(variable),
+                Some(&"Qwen/test".to_owned()),
+                "missing model mapping for {variable}"
+            );
+            assert!(!env.environment_remove.contains(&variable.to_owned()));
+        }
 
         fs::remove_dir_all(root).expect("cleanup");
     }
@@ -261,7 +344,8 @@ mod tests {
     #[test]
     fn claude_home_uses_a_local_placeholder_without_inherited_auth() {
         let root = unique_temp_dir("claude-no-key");
-        let env = prepare_claude_home(&root, "http://127.0.0.1:3000", "Qwen/test", None).expect("Claude config");
+        let env = prepare_claude_home_with_state(&root, &root, "http://127.0.0.1:3000", "Qwen/test", None, None)
+            .expect("Claude config");
 
         assert_eq!(
             env.environment.get("ANTHROPIC_API_KEY"),
@@ -272,8 +356,94 @@ mod tests {
             Some(&"agentic-api-local".to_owned())
         );
         assert!(!env.environment.contains_key("OPENAI_API_KEY"));
+        assert!(env.environment_remove.contains(&"OPENAI_API_KEY".to_owned()));
 
         fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    #[test]
+    fn claude_home_accepts_an_explicit_auth_token() {
+        let root = unique_temp_dir("claude-explicit-auth");
+        let env = prepare_claude_home_with_state(
+            &root,
+            &root,
+            "http://127.0.0.1:3000",
+            "Qwen/test",
+            Some("oidc-token"),
+            None,
+        )
+        .expect("Claude config");
+
+        assert_eq!(
+            env.environment.get("ANTHROPIC_AUTH_TOKEN"),
+            Some(&"oidc-token".to_owned())
+        );
+        assert_eq!(
+            env.environment.get("ANTHROPIC_API_KEY"),
+            Some(&"agentic-api-local".to_owned())
+        );
+        fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    #[test]
+    fn claude_summary_redacts_gateway_password() {
+        let root = unique_temp_dir("claude-redacted-url");
+        let env = prepare_claude_home(&root, "https://agentic:gateway-secret@example.com", "Qwen/test", None)
+            .expect("Claude config");
+
+        assert!(!env.summary.contains("gateway-secret"));
+        assert!(env.summary.contains("https://[REDACTED]@example.com"));
+
+        fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    #[test]
+    fn claude_uses_persistent_state_with_per_run_settings() {
+        let settings_root = tempfile::tempdir().expect("settings root");
+        let state_root = tempfile::tempdir().expect("state root");
+        let env = prepare_claude_home_with_state(
+            settings_root.path(),
+            state_root.path(),
+            "http://127.0.0.1:3000",
+            "Qwen/test",
+            None,
+            None,
+        )
+        .expect("Claude config");
+
+        assert_eq!(
+            env.environment.get("CLAUDE_CONFIG_DIR"),
+            Some(&state_root.path().display().to_string())
+        );
+        assert_eq!(
+            env.arguments,
+            [
+                "--settings".to_owned(),
+                settings_root.path().join("settings.json").display().to_string(),
+            ]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn claude_persistent_state_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let settings_root = tempfile::tempdir().expect("settings root");
+        let state_parent = tempfile::tempdir().expect("state parent");
+        let state_root = state_parent.path().join("claude");
+        prepare_claude_home_with_state(
+            settings_root.path(),
+            &state_root,
+            "http://127.0.0.1:3000",
+            "Qwen/test",
+            None,
+            None,
+        )
+        .expect("Claude config");
+
+        let mode = fs::metadata(state_root).expect("state metadata").permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700);
     }
 
     fn unique_temp_dir(name: &str) -> std::path::PathBuf {

--- a/crates/agentic-server/src/agentic_output.rs
+++ b/crates/agentic-server/src/agentic_output.rs
@@ -131,13 +131,32 @@ pub fn redact_url(url: &str) -> String {
     };
     let suffix_start = rest.find(['/', '?', '#']).unwrap_or(rest.len());
     let (authority, suffix) = rest.split_at(suffix_start);
-    let Some((userinfo, host)) = authority.split_once('@') else {
+    let Some((_userinfo, host)) = authority.rsplit_once('@') else {
         return url.to_owned();
     };
-    let Some((username, _password)) = userinfo.split_once(':') else {
-        return url.to_owned();
-    };
-    format!("{scheme}://{username}:[REDACTED]@{host}{suffix}")
+    format!("{scheme}://[REDACTED]@{host}{suffix}")
+}
+
+#[must_use]
+pub fn redact_urls(text: &str) -> String {
+    let mut output = String::with_capacity(text.len());
+    let mut remaining = text;
+    while let Some(separator) = remaining.find("://") {
+        let scheme_start = remaining[..separator]
+            .rfind(|character: char| !(character.is_ascii_alphanumeric() || matches!(character, '+' | '-' | '.')))
+            .map_or(0, |index| index + 1);
+        let authority_start = separator + 3;
+        let url_end = remaining[authority_start..]
+            .find(|character: char| character.is_whitespace() || matches!(character, '`' | '"' | '\'' | '<' | '>'))
+            .map_or(remaining.len(), |index| authority_start + index);
+        let candidate = &remaining[scheme_start..url_end];
+
+        output.push_str(&remaining[..scheme_start]);
+        output.push_str(&redact_url(candidate));
+        remaining = &remaining[url_end..];
+    }
+    output.push_str(remaining);
+    output
 }
 
 fn display_width(value: &str) -> usize {
@@ -149,7 +168,7 @@ fn display_width(value: &str) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use super::{colorize_help, redact_url, render_banner, render_examples, render_help};
+    use super::{colorize_help, redact_url, redact_urls, render_banner, render_examples, render_help};
 
     #[test]
     fn banner_rows_have_equal_display_width() {
@@ -206,15 +225,27 @@ mod tests {
     fn redact_url_hides_password() {
         assert_eq!(
             redact_url("postgresql://alice:secret@db.example/agentic"),
-            "postgresql://alice:[REDACTED]@db.example/agentic"
+            "postgresql://[REDACTED]@db.example/agentic"
         );
         assert_eq!(
             redact_url("postgresql://alice:secret@db.example"),
-            "postgresql://alice:[REDACTED]@db.example"
+            "postgresql://[REDACTED]@db.example"
         );
         assert_eq!(
             redact_url("postgresql://alice:secret@db.example?sslmode=require"),
-            "postgresql://alice:[REDACTED]@db.example?sslmode=require"
+            "postgresql://[REDACTED]@db.example?sslmode=require"
+        );
+        assert_eq!(
+            redact_url("https://secret-token@example.com/path"),
+            "https://[REDACTED]@example.com/path"
+        );
+    }
+
+    #[test]
+    fn redact_urls_hides_userinfo_inside_diagnostics() {
+        assert_eq!(
+            redact_urls("error: invalid value `https://secret-token@example.com?bad=1` for '--upstream'"),
+            "error: invalid value `https://[REDACTED]@example.com?bad=1` for '--upstream'"
         );
     }
 

--- a/crates/agentic-server/src/agentic_process.rs
+++ b/crates/agentic-server/src/agentic_process.rs
@@ -14,6 +14,7 @@ use crate::agentic_cli::{CommonOptions, SourceOptions};
 pub const DEFAULT_CLAUDE_EFFORT: &str = "medium";
 const CLAUDE_EFFORT_ENV: &str = "AGENTIC_CLAUDE_EFFORT";
 const PLACEHOLDER_MODEL: &str = "agentic-api";
+const CLAUDE_TOOLS: &str = "Bash,Edit,Read,WebSearch";
 
 #[must_use]
 pub fn server_args(source: &SourceOptions, common: &CommonOptions) -> Vec<OsString> {
@@ -76,11 +77,33 @@ fn harness_launch_args(
             if yolo {
                 args.push("--dangerously-skip-permissions".to_owned());
             }
+            args.extend([
+                "--model".to_owned(),
+                crate::agentic_harness::CLAUDE_CANONICAL_MODEL.to_owned(),
+                "--tools".to_owned(),
+                CLAUDE_TOOLS.to_owned(),
+                "--setting-sources".to_owned(),
+                "user".to_owned(),
+            ]);
             args.extend(["--effort".to_owned(), claude_effort.to_owned()]);
         }
     }
     args.extend_from_slice(passthrough);
     args
+}
+
+fn validate_claude_passthrough(passthrough: &[String]) -> Result<(), Error> {
+    const MANAGED_FLAGS: [&str; 4] = ["--model", "--settings", "--setting-sources", "--bare"];
+    if let Some(argument) = passthrough.iter().find(|argument| {
+        MANAGED_FLAGS
+            .iter()
+            .any(|flag| argument.as_str() == *flag || argument.starts_with(&format!("{flag}=")))
+    }) {
+        return Err(Error::Config(format!(
+            "Claude Code argument {argument} cannot be forwarded because Agentic API manages model and setting isolation"
+        )));
+    }
+    Ok(())
 }
 
 #[derive(Debug, Deserialize)]
@@ -186,6 +209,9 @@ pub async fn run_session(
     harness: crate::agentic_cli::Harness,
     options: crate::agentic_cli::HarnessOptions,
 ) -> Result<std::process::ExitStatus, Error> {
+    if matches!(harness, crate::agentic_cli::Harness::Claude) {
+        validate_claude_passthrough(&options.harness_args)?;
+    }
     let gateway_url = format!("http://{}:{}", options.common.gateway_host, options.common.gateway_port);
     let session_root = std::env::temp_dir().join(format!(
         "agentic-api-session-{}-{}",
@@ -240,7 +266,7 @@ pub async fn run_session(
         println!("{}", harness_env.summary);
     }
 
-    let mut harness_child = match spawn_harness(harness, &options, &harness_env) {
+    let mut harness_child = match spawn_harness(harness, options.common.yolo, &options.harness_args, &harness_env) {
         Ok(child) => child,
         Err(error) => {
             cleanup(&mut server, &session_root).await;
@@ -285,9 +311,6 @@ fn harness_environment(
     options: &crate::agentic_cli::HarnessOptions,
     session_root: &Path,
 ) -> Result<crate::agentic_harness::HarnessEnv, Error> {
-    if matches!(harness, crate::agentic_cli::Harness::Claude) {
-        crate::agentic_harness::validate_claude_model(model).map_err(Error::Config)?;
-    }
     let mut environment = match harness {
         crate::agentic_cli::Harness::Codex => crate::agentic_harness::prepare_codex_home(
             session_root,
@@ -296,11 +319,13 @@ fn harness_environment(
             options.common.api_key.as_deref(),
         )
         .map_err(Error::from),
-        crate::agentic_cli::Harness::Claude => Ok(crate::agentic_harness::prepare_claude_env(
+        crate::agentic_cli::Harness::Claude => crate::agentic_harness::prepare_claude_home(
+            session_root,
             gateway_url,
             model,
             options.common.api_key.as_deref(),
-        )),
+        )
+        .map_err(Error::from),
     }?;
     if matches!(harness, crate::agentic_cli::Harness::Claude) {
         // Claude Code gives CLAUDE_CODE_EFFORT_LEVEL precedence over --effort, so set both
@@ -314,7 +339,8 @@ fn harness_environment(
 
 fn spawn_harness(
     harness: crate::agentic_cli::Harness,
-    options: &crate::agentic_cli::HarnessOptions,
+    yolo: bool,
+    passthrough: &[String],
     harness_env: &crate::agentic_harness::HarnessEnv,
 ) -> Result<tokio::process::Child, Error> {
     let binary_name = match harness {
@@ -327,12 +353,10 @@ fn spawn_harness(
     };
     let binary = std::env::var_os(override_name).unwrap_or_else(|| binary_name.into());
     let mut harness_command = tokio::process::Command::new(binary);
-    harness_command.args(harness_launch_args(
-        harness,
-        options.common.yolo,
-        &claude_effort(),
-        &options.harness_args,
-    ));
+    harness_command.args(harness_launch_args(harness, yolo, &claude_effort(), passthrough));
+    for name in &harness_env.environment_remove {
+        harness_command.env_remove(name);
+    }
     harness_command.envs(&harness_env.environment);
     harness_command.stdin(std::process::Stdio::inherit());
     harness_command.stdout(std::process::Stdio::inherit());
@@ -340,6 +364,88 @@ fn spawn_harness(
     harness_command
         .spawn()
         .map_err(|error| Error::Config(format!("failed to launch {binary_name} ({override_name}): {error}")))
+}
+
+fn prepare_attached_harness_environment(
+    harness: crate::agentic_cli::Harness,
+    session_root: &Path,
+    gateway_url: &str,
+    model: &str,
+    api_key: Option<&str>,
+) -> Result<crate::agentic_harness::HarnessEnv, Error> {
+    match harness {
+        crate::agentic_cli::Harness::Codex => {
+            crate::agentic_harness::prepare_codex_home(session_root, gateway_url, model, api_key).map_err(Error::from)
+        }
+        crate::agentic_cli::Harness::Claude => {
+            crate::agentic_harness::prepare_claude_home(session_root, gateway_url, model, api_key).map_err(Error::from)
+        }
+    }
+}
+
+/// Launch a coding harness against an already-running Agentic API gateway.
+///
+/// # Errors
+///
+/// Returns an error when the gateway is not ready, configuration cannot be written, or the harness cannot start.
+pub async fn run_attached_harness(
+    harness: crate::agentic_cli::Harness,
+    options: crate::agentic_cli::AttachedHarnessOptions,
+) -> Result<std::process::ExitStatus, Error> {
+    if matches!(harness, crate::agentic_cli::Harness::Claude) {
+        validate_claude_passthrough(&options.harness_args)?;
+    }
+    let session_root = std::env::temp_dir().join(format!(
+        "agentic-api-harness-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |duration| duration.as_nanos())
+    ));
+    tokio::fs::create_dir_all(&session_root).await?;
+
+    let result = async {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(2))
+            .build()
+            .map_err(Error::HttpClient)?;
+        wait_for_gateway(
+            &client,
+            &options.gateway_url,
+            Duration::from_secs(30),
+            Duration::from_millis(250),
+            false,
+        )
+        .await?;
+        let mut harness_env = prepare_attached_harness_environment(
+            harness,
+            &session_root,
+            &options.gateway_url,
+            &options.model,
+            options.api_key.as_deref(),
+        )?;
+        if matches!(harness, crate::agentic_cli::Harness::Claude) {
+            harness_env
+                .environment
+                .insert("CLAUDE_CODE_EFFORT_LEVEL".to_owned(), claude_effort());
+        }
+        if !options.quiet {
+            println!("{}", harness_env.summary);
+        }
+        let mut child = spawn_harness(harness, options.yolo, &options.harness_args, &harness_env)?;
+        let status = tokio::select! {
+            status = child.wait() => status?,
+            signal = tokio::signal::ctrl_c() => {
+                signal?;
+                let _ = child.kill().await;
+                child.wait().await?
+            }
+        };
+        Ok(status)
+    }
+    .await;
+    let _ = tokio::fs::remove_dir_all(&session_root).await;
+    result
 }
 
 async fn cleanup(server: &mut tokio::process::Child, session_root: &Path) {
@@ -419,7 +525,17 @@ mod tests {
     fn yolo_mode_uses_native_claude_bypass_and_compatible_effort() {
         assert_eq!(
             harness_launch_args(Harness::Claude, true, DEFAULT_CLAUDE_EFFORT, &[]),
-            ["--dangerously-skip-permissions", "--effort", "medium"]
+            [
+                "--dangerously-skip-permissions",
+                "--model",
+                "claude-sonnet-4-5-20250929",
+                "--tools",
+                "Bash,Edit,Read,WebSearch",
+                "--setting-sources",
+                "user",
+                "--effort",
+                "medium"
+            ]
         );
     }
 
@@ -427,7 +543,18 @@ mod tests {
     fn claude_always_receives_a_compatible_effort() {
         assert_eq!(
             harness_launch_args(Harness::Claude, false, "low", &["-p".to_owned(), "hi".to_owned()]),
-            ["--effort", "low", "-p", "hi"]
+            [
+                "--model",
+                "claude-sonnet-4-5-20250929",
+                "--tools",
+                "Bash,Edit,Read,WebSearch",
+                "--setting-sources",
+                "user",
+                "--effort",
+                "low",
+                "-p",
+                "hi"
+            ]
         );
         assert_eq!(
             harness_launch_args(Harness::Codex, false, DEFAULT_CLAUDE_EFFORT, &[]),
@@ -460,10 +587,52 @@ mod tests {
             environment.environment.get("CLAUDE_CODE_EFFORT_LEVEL"),
             Some(&DEFAULT_CLAUDE_EFFORT.to_owned())
         );
+        assert!(root.join("settings.json").is_file());
+        std::fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    #[test]
+    fn claude_rejects_passthrough_that_can_replace_isolated_configuration() {
+        for argument in [
+            "--model",
+            "--model=opus",
+            "--settings",
+            "--settings={}",
+            "--setting-sources",
+            "--setting-sources=project",
+            "--bare",
+        ] {
+            let error = super::validate_claude_passthrough(&[argument.to_owned()])
+                .expect_err("configuration-owning argument should be rejected");
+            assert!(error.to_string().contains(argument));
+        }
+        super::validate_claude_passthrough(&["-p".to_owned(), "hello".to_owned()])
+            .expect("normal passthrough arguments");
+    }
+
+    #[test]
+    fn attached_codex_uses_an_isolated_responses_provider() {
+        let root = std::env::temp_dir().join(format!("agentic-api-attached-codex-test-{}", std::process::id()));
+        let environment = super::prepare_attached_harness_environment(
+            Harness::Codex,
+            &root,
+            "http://127.0.0.1:9000",
+            "Qwen/Qwen3-8B",
+            None,
+        )
+        .expect("Codex environment");
+        let config = std::fs::read_to_string(root.join("config.toml")).expect("Codex config");
+
         assert_eq!(
-            environment.environment.get("ANTHROPIC_MODEL"),
-            Some(&"served-discovered".to_owned())
+            environment.environment.get("CODEX_HOME"),
+            Some(&root.display().to_string())
         );
+        assert!(!environment.environment.contains_key("CLAUDE_CONFIG_DIR"));
+        assert!(config.contains("model = \"Qwen/Qwen3-8B\""));
+        assert!(config.contains("base_url = \"http://127.0.0.1:9000/v1\""));
+        assert!(config.contains("wire_api = \"responses\""));
+
+        std::fs::remove_dir_all(root).expect("cleanup");
     }
 
     #[tokio::test]
@@ -566,5 +735,6 @@ mod tests {
             environment.environment.get("CLAUDE_CODE_EFFORT_LEVEL"),
             Some(&"medium".to_owned())
         );
+        std::fs::remove_dir_all(root).expect("cleanup");
     }
 }

--- a/crates/agentic-server/src/agentic_process.rs
+++ b/crates/agentic-server/src/agentic_process.rs
@@ -5,7 +5,10 @@ use reqwest::Client;
 use serde::Deserialize;
 use tokio::time::{Instant, sleep};
 
-use crate::agentic_cli::{CommonOptions, SourceOptions};
+use crate::{
+    agentic_cli::{CommonOptions, SourceOptions},
+    agentic_output::redact_url,
+};
 
 /// Reasoning effort passed to Claude Code unless `AGENTIC_CLAUDE_EFFORT` overrides it.
 ///
@@ -64,9 +67,10 @@ fn harness_launch_args(
     harness: crate::agentic_cli::Harness,
     yolo: bool,
     claude_effort: &str,
+    managed: &[String],
     passthrough: &[String],
 ) -> Vec<String> {
-    let mut args = Vec::with_capacity(passthrough.len() + 3);
+    let mut args = Vec::with_capacity(managed.len() + passthrough.len() + 3);
     match harness {
         crate::agentic_cli::Harness::Codex => {
             if yolo {
@@ -88,6 +92,7 @@ fn harness_launch_args(
             args.extend(["--effort".to_owned(), claude_effort.to_owned()]);
         }
     }
+    args.extend_from_slice(managed);
     args.extend_from_slice(passthrough);
     args
 }
@@ -130,6 +135,8 @@ pub async fn resolve_model(client: &Client, source: &SourceOptions, api_key: Opt
         return Ok(PLACEHOLDER_MODEL.to_owned());
     };
     let models_url = format!("{}/v1/models", agentic_core::config::normalize_base_url(upstream));
+    let display_models_url = redact_url(&models_url);
+    let display_upstream = redact_url(upstream);
     let mut request = client.get(&models_url);
     if let Some(api_key) = api_key {
         request = request.bearer_auth(api_key);
@@ -137,19 +144,31 @@ pub async fn resolve_model(client: &Client, source: &SourceOptions, api_key: Opt
     let response = request
         .send()
         .await
-        .map_err(|error| Error::Config(format!("failed to list upstream models at {models_url}: {error}")))?
+        .map_err(|error| {
+            Error::Config(format!(
+                "failed to list upstream models at {display_models_url}: {}",
+                error.without_url()
+            ))
+        })?
         .error_for_status()
-        .map_err(|error| Error::Config(format!("upstream model listing at {models_url} failed: {error}")))?;
-    let body = response
-        .text()
-        .await
-        .map_err(|error| Error::Config(format!("failed to read model listing from {models_url}: {error}")))?;
+        .map_err(|error| {
+            Error::Config(format!(
+                "upstream model listing at {display_models_url} failed: {}",
+                error.without_url()
+            ))
+        })?;
+    let body = response.text().await.map_err(|error| {
+        Error::Config(format!(
+            "failed to read model listing from {display_models_url}: {}",
+            error.without_url()
+        ))
+    })?;
     let list: ModelList = agentic_core::utils::common::deserialize_from_str(&body)
-        .map_err(|error| Error::Config(format!("invalid model listing from {models_url}: {error}")))?;
+        .map_err(|error| Error::Config(format!("invalid model listing from {display_models_url}: {error}")))?;
     let mut ids = list.data.into_iter().map(|entry| entry.id);
     let Some(model) = ids.next() else {
         return Err(Error::Config(format!(
-            "upstream {upstream} serves no models; pass --model explicitly"
+            "upstream {display_upstream} serves no models; pass --model explicitly"
         )));
     };
     let remaining = ids.count();
@@ -179,7 +198,10 @@ pub async fn wait_for_gateway(
     let ready_url = format!("{}/ready", gateway_url.trim_end_matches('/'));
     loop {
         if Instant::now() >= deadline {
-            return Err(Error::Config(format!("gateway did not become ready at {gateway_url}")));
+            return Err(Error::Config(format!(
+                "gateway did not become ready at {}",
+                redact_url(gateway_url)
+            )));
         }
         let health_ok = client
             .get(&health_url)
@@ -213,25 +235,15 @@ pub async fn run_session(
         validate_claude_passthrough(&options.harness_args)?;
     }
     let gateway_url = format!("http://{}:{}", options.common.gateway_host, options.common.gateway_port);
-    let session_root = std::env::temp_dir().join(format!(
-        "agentic-api-session-{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map_or(0, |duration| duration.as_nanos())
-    ));
-    tokio::fs::create_dir_all(&session_root).await?;
+    let session_root = create_session_root("agentic-api-session")?;
+    let claude_state_root = harness_state_root(harness, session_root.path())?;
 
     let mut server = start_server(current_exe, &options)?;
 
-    let client = match Client::builder()
-        .timeout(Duration::from_secs(2))
-        .build()
-        .map_err(Error::HttpClient)
-    {
+    let client = match gateway_client() {
         Ok(client) => client,
         Err(error) => {
-            cleanup(&mut server, &session_root).await;
+            cleanup(&mut server, session_root.path()).await;
             return Err(error);
         }
     };
@@ -244,21 +256,28 @@ pub async fn run_session(
     )
     .await
     {
-        cleanup(&mut server, &session_root).await;
+        cleanup(&mut server, session_root.path()).await;
         return Err(error);
     }
 
     let model = match resolve_model(&client, &options.source, options.common.api_key.as_deref()).await {
         Ok(model) => model,
         Err(error) => {
-            cleanup(&mut server, &session_root).await;
+            cleanup(&mut server, session_root.path()).await;
             return Err(error);
         }
     };
-    let harness_env = match harness_environment(harness, &gateway_url, &model, &options, &session_root) {
+    let harness_env = match harness_environment(
+        harness,
+        &gateway_url,
+        &model,
+        &options,
+        session_root.path(),
+        &claude_state_root,
+    ) {
         Ok(environment) => environment,
         Err(error) => {
-            cleanup(&mut server, &session_root).await;
+            cleanup(&mut server, session_root.path()).await;
             return Err(error);
         }
     };
@@ -269,7 +288,7 @@ pub async fn run_session(
     let mut harness_child = match spawn_harness(harness, options.common.yolo, &options.harness_args, &harness_env) {
         Ok(child) => child,
         Err(error) => {
-            cleanup(&mut server, &session_root).await;
+            cleanup(&mut server, session_root.path()).await;
             return Err(error);
         }
     };
@@ -282,7 +301,7 @@ pub async fn run_session(
             harness_child.wait().await?
         }
     };
-    cleanup(&mut server, &session_root).await;
+    cleanup(&mut server, session_root.path()).await;
     Ok(harness_status)
 }
 
@@ -298,6 +317,7 @@ fn start_server(
         )));
     }
     let mut server = tokio::process::Command::new(server_path);
+    server.kill_on_drop(true);
     server.args(server_args(&options.source, &options.common));
     server.stdout(std::process::Stdio::inherit());
     server.stderr(std::process::Stdio::inherit());
@@ -310,7 +330,11 @@ fn harness_environment(
     model: &str,
     options: &crate::agentic_cli::HarnessOptions,
     session_root: &Path,
+    claude_state_root: &Path,
 ) -> Result<crate::agentic_harness::HarnessEnv, Error> {
+    let inherited_auth_token = std::env::var("ANTHROPIC_AUTH_TOKEN")
+        .ok()
+        .filter(|value| !value.trim().is_empty());
     let mut environment = match harness {
         crate::agentic_cli::Harness::Codex => crate::agentic_harness::prepare_codex_home(
             session_root,
@@ -319,10 +343,12 @@ fn harness_environment(
             options.common.api_key.as_deref(),
         )
         .map_err(Error::from),
-        crate::agentic_cli::Harness::Claude => crate::agentic_harness::prepare_claude_home(
+        crate::agentic_cli::Harness::Claude => crate::agentic_harness::prepare_claude_home_with_state(
             session_root,
+            claude_state_root,
             gateway_url,
             model,
+            inherited_auth_token.as_deref(),
             options.common.api_key.as_deref(),
         )
         .map_err(Error::from),
@@ -352,8 +378,28 @@ fn spawn_harness(
         crate::agentic_cli::Harness::Claude => "AGENTIC_CLAUDE_BIN",
     };
     let binary = std::env::var_os(override_name).unwrap_or_else(|| binary_name.into());
+    let mut harness_command = build_harness_command(&binary, harness, yolo, passthrough, harness_env);
+    harness_command
+        .spawn()
+        .map_err(|error| Error::Config(format!("failed to launch {binary_name} ({override_name}): {error}")))
+}
+
+fn build_harness_command(
+    binary: &std::ffi::OsStr,
+    harness: crate::agentic_cli::Harness,
+    yolo: bool,
+    passthrough: &[String],
+    harness_env: &crate::agentic_harness::HarnessEnv,
+) -> tokio::process::Command {
     let mut harness_command = tokio::process::Command::new(binary);
-    harness_command.args(harness_launch_args(harness, yolo, &claude_effort(), passthrough));
+    harness_command.kill_on_drop(true);
+    harness_command.args(harness_launch_args(
+        harness,
+        yolo,
+        &claude_effort(),
+        &harness_env.arguments,
+        passthrough,
+    ));
     for name in &harness_env.environment_remove {
         harness_command.env_remove(name);
     }
@@ -362,13 +408,12 @@ fn spawn_harness(
     harness_command.stdout(std::process::Stdio::inherit());
     harness_command.stderr(std::process::Stdio::inherit());
     harness_command
-        .spawn()
-        .map_err(|error| Error::Config(format!("failed to launch {binary_name} ({override_name}): {error}")))
 }
 
 fn prepare_attached_harness_environment(
     harness: crate::agentic_cli::Harness,
     session_root: &Path,
+    claude_state_root: &Path,
     gateway_url: &str,
     model: &str,
     api_key: Option<&str>,
@@ -377,9 +422,15 @@ fn prepare_attached_harness_environment(
         crate::agentic_cli::Harness::Codex => {
             crate::agentic_harness::prepare_codex_home(session_root, gateway_url, model, api_key).map_err(Error::from)
         }
-        crate::agentic_cli::Harness::Claude => {
-            crate::agentic_harness::prepare_claude_home(session_root, gateway_url, model, api_key).map_err(Error::from)
-        }
+        crate::agentic_cli::Harness::Claude => crate::agentic_harness::prepare_claude_home_with_state(
+            session_root,
+            claude_state_root,
+            gateway_url,
+            model,
+            None,
+            api_key,
+        )
+        .map_err(Error::from),
     }
 }
 
@@ -395,20 +446,11 @@ pub async fn run_attached_harness(
     if matches!(harness, crate::agentic_cli::Harness::Claude) {
         validate_claude_passthrough(&options.harness_args)?;
     }
-    let session_root = std::env::temp_dir().join(format!(
-        "agentic-api-harness-{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map_or(0, |duration| duration.as_nanos())
-    ));
-    tokio::fs::create_dir_all(&session_root).await?;
+    let session_root = create_session_root("agentic-api-harness")?;
+    let claude_state_root = harness_state_root(harness, session_root.path())?;
 
     let result = async {
-        let client = Client::builder()
-            .timeout(Duration::from_secs(2))
-            .build()
-            .map_err(Error::HttpClient)?;
+        let client = gateway_client()?;
         wait_for_gateway(
             &client,
             &options.gateway_url,
@@ -419,7 +461,8 @@ pub async fn run_attached_harness(
         .await?;
         let mut harness_env = prepare_attached_harness_environment(
             harness,
-            &session_root,
+            session_root.path(),
+            &claude_state_root,
             &options.gateway_url,
             &options.model,
             options.api_key.as_deref(),
@@ -444,7 +487,7 @@ pub async fn run_attached_harness(
         Ok(status)
     }
     .await;
-    let _ = tokio::fs::remove_dir_all(&session_root).await;
+    let _ = tokio::fs::remove_dir_all(session_root.path()).await;
     result
 }
 
@@ -452,6 +495,50 @@ async fn cleanup(server: &mut tokio::process::Child, session_root: &Path) {
     let _ = server.kill().await;
     let _ = server.wait().await;
     let _ = tokio::fs::remove_dir_all(session_root).await;
+}
+
+struct SessionRoot {
+    directory: tempfile::TempDir,
+}
+
+impl SessionRoot {
+    fn path(&self) -> &Path {
+        self.directory.path()
+    }
+}
+
+fn create_session_root(prefix: &str) -> Result<SessionRoot, Error> {
+    let prefix = format!("{prefix}-");
+    let mut builder = tempfile::Builder::new();
+    builder.prefix(&prefix);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        builder.permissions(std::fs::Permissions::from_mode(0o700));
+    }
+    Ok(SessionRoot {
+        directory: builder.tempdir()?,
+    })
+}
+
+fn harness_state_root(
+    harness: crate::agentic_cli::Harness,
+    temporary_root: &Path,
+) -> Result<std::path::PathBuf, Error> {
+    match harness {
+        crate::agentic_cli::Harness::Claude => Ok(agentic_core::config::agentic_api_home()?
+            .join("harnesses")
+            .join("claude")),
+        crate::agentic_cli::Harness::Codex => Ok(temporary_root.to_owned()),
+    }
+}
+
+fn gateway_client() -> Result<Client, Error> {
+    Client::builder()
+        .timeout(Duration::from_secs(2))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(Error::HttpClient)
 }
 
 #[cfg(test)]
@@ -516,7 +603,7 @@ mod tests {
     #[test]
     fn yolo_mode_uses_native_codex_bypass_flag() {
         assert_eq!(
-            harness_launch_args(Harness::Codex, true, DEFAULT_CLAUDE_EFFORT, &["exec".to_owned()]),
+            harness_launch_args(Harness::Codex, true, DEFAULT_CLAUDE_EFFORT, &[], &["exec".to_owned()]),
             ["--dangerously-bypass-approvals-and-sandbox", "exec"]
         );
     }
@@ -524,7 +611,7 @@ mod tests {
     #[test]
     fn yolo_mode_uses_native_claude_bypass_and_compatible_effort() {
         assert_eq!(
-            harness_launch_args(Harness::Claude, true, DEFAULT_CLAUDE_EFFORT, &[]),
+            harness_launch_args(Harness::Claude, true, DEFAULT_CLAUDE_EFFORT, &[], &[]),
             [
                 "--dangerously-skip-permissions",
                 "--model",
@@ -542,7 +629,7 @@ mod tests {
     #[test]
     fn claude_always_receives_a_compatible_effort() {
         assert_eq!(
-            harness_launch_args(Harness::Claude, false, "low", &["-p".to_owned(), "hi".to_owned()]),
+            harness_launch_args(Harness::Claude, false, "low", &[], &["-p".to_owned(), "hi".to_owned()]),
             [
                 "--model",
                 "claude-sonnet-4-5-20250929",
@@ -557,7 +644,7 @@ mod tests {
             ]
         );
         assert_eq!(
-            harness_launch_args(Harness::Codex, false, DEFAULT_CLAUDE_EFFORT, &[]),
+            harness_launch_args(Harness::Codex, false, DEFAULT_CLAUDE_EFFORT, &[], &[]),
             Vec::<String>::new()
         );
     }
@@ -574,12 +661,14 @@ mod tests {
             harness_args: Vec::new(),
         };
         let root = std::env::temp_dir().join(format!("agentic-api-effort-test-{}", std::process::id()));
+        let state_root = std::env::temp_dir().join(format!("agentic-api-state-test-{}", std::process::id()));
         let environment = super::harness_environment(
             Harness::Claude,
             "http://127.0.0.1:3000",
             "served-discovered",
             &options,
             &root,
+            &state_root,
         )
         .expect("Claude environment");
 
@@ -587,8 +676,58 @@ mod tests {
             environment.environment.get("CLAUDE_CODE_EFFORT_LEVEL"),
             Some(&DEFAULT_CLAUDE_EFFORT.to_owned())
         );
+        assert_eq!(
+            environment.environment.get("CLAUDE_CONFIG_DIR"),
+            Some(&state_root.display().to_string())
+        );
         assert!(root.join("settings.json").is_file());
         std::fs::remove_dir_all(root).expect("cleanup");
+        std::fs::remove_dir_all(state_root).expect("state cleanup");
+    }
+
+    #[test]
+    fn integrated_claude_preserves_inherited_auth_token() {
+        const CHILD_MARKER: &str = "AGENTIC_TEST_INTEGRATED_CLAUDE_AUTH";
+        if std::env::var_os(CHILD_MARKER).is_some() {
+            let settings_root = tempfile::tempdir().expect("settings root");
+            let state_root = tempfile::tempdir().expect("state root");
+            let options = crate::agentic_cli::HarnessOptions {
+                source: SourceOptions {
+                    upstream: Some("http://127.0.0.1:8000".to_owned()),
+                    model: None,
+                    llm_port: 8000,
+                },
+                common: CommonOptions::default(),
+                harness_args: Vec::new(),
+            };
+            let environment = super::harness_environment(
+                Harness::Claude,
+                "http://127.0.0.1:3000",
+                "served-discovered",
+                &options,
+                settings_root.path(),
+                state_root.path(),
+            )
+            .expect("Claude environment");
+
+            assert_eq!(
+                environment.environment.get("ANTHROPIC_AUTH_TOKEN"),
+                Some(&"oidc-token".to_owned())
+            );
+            return;
+        }
+
+        let status = std::process::Command::new(std::env::current_exe().expect("test binary"))
+            .args([
+                "--exact",
+                "agentic_process::tests::integrated_claude_preserves_inherited_auth_token",
+            ])
+            .env(CHILD_MARKER, "1")
+            .env("ANTHROPIC_AUTH_TOKEN", "oidc-token")
+            .status()
+            .expect("run isolated integrated auth test");
+
+        assert!(status.success(), "isolated integrated auth test failed with {status}");
     }
 
     #[test]
@@ -616,6 +755,7 @@ mod tests {
         let environment = super::prepare_attached_harness_environment(
             Harness::Codex,
             &root,
+            &root,
             "http://127.0.0.1:9000",
             "Qwen/Qwen3-8B",
             None,
@@ -633,6 +773,126 @@ mod tests {
         assert!(config.contains("wire_api = \"responses\""));
 
         std::fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    #[test]
+    fn attached_claude_uses_persistent_state_root() {
+        let session_root = tempfile::tempdir().expect("session root");
+        let state_root = tempfile::tempdir().expect("state root");
+        let environment = super::prepare_attached_harness_environment(
+            Harness::Claude,
+            session_root.path(),
+            state_root.path(),
+            "http://127.0.0.1:9000",
+            "Qwen/Qwen3-8B",
+            None,
+        )
+        .expect("Claude environment");
+
+        assert_eq!(
+            environment.environment.get("CLAUDE_CONFIG_DIR"),
+            Some(&state_root.path().display().to_string())
+        );
+    }
+
+    #[test]
+    fn attached_claude_ignores_inherited_anthropic_auth_token() {
+        const CHILD_MARKER: &str = "AGENTIC_TEST_ATTACHED_CLAUDE_AUTH";
+        if std::env::var_os(CHILD_MARKER).is_some() {
+            let session_root = tempfile::tempdir().expect("session root");
+            let state_root = tempfile::tempdir().expect("state root");
+            let environment = super::prepare_attached_harness_environment(
+                Harness::Claude,
+                session_root.path(),
+                state_root.path(),
+                "http://127.0.0.1:9000",
+                "Qwen/Qwen3-8B",
+                None,
+            )
+            .expect("Claude environment");
+
+            assert_eq!(
+                environment.environment.get("ANTHROPIC_AUTH_TOKEN"),
+                Some(&"agentic-api-local".to_owned())
+            );
+            return;
+        }
+
+        let status = std::process::Command::new(std::env::current_exe().expect("test binary"))
+            .args([
+                "--exact",
+                "agentic_process::tests::attached_claude_ignores_inherited_anthropic_auth_token",
+            ])
+            .env(CHILD_MARKER, "1")
+            .env("ANTHROPIC_AUTH_TOKEN", "must-not-be-forwarded")
+            .status()
+            .expect("run isolated attached auth test");
+
+        assert!(status.success(), "isolated attached auth test failed with {status}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn session_root_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = super::create_session_root("agentic-api-private-test").expect("private session root");
+        let mode = std::fs::metadata(root.path())
+            .expect("session root metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+
+        assert_eq!(mode, 0o700);
+
+        std::fs::remove_dir_all(root.path()).expect("cleanup");
+    }
+
+    #[test]
+    fn session_root_is_removed_when_its_guard_drops() {
+        let path = {
+            let root = super::create_session_root("agentic-api-drop-test").expect("session root");
+            root.path().to_owned()
+        };
+
+        let removed = !path.exists();
+        if !removed {
+            std::fs::remove_dir_all(&path).expect("cleanup failed session root");
+        }
+        assert!(removed, "session root survived its guard");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn dropping_harness_child_prevents_later_side_effects() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let marker = temporary.path().join("child-survived");
+        let environment = crate::agentic_harness::HarnessEnv {
+            environment: std::collections::BTreeMap::new(),
+            environment_remove: Vec::new(),
+            arguments: Vec::new(),
+            files: Vec::new(),
+            summary: String::new(),
+        };
+        let passthrough = vec![
+            "-c".to_owned(),
+            "sleep 0.15; printf survived > \"$1\"".to_owned(),
+            "agentic-test".to_owned(),
+            marker.display().to_string(),
+        ];
+        let mut command = super::build_harness_command(
+            std::ffi::OsStr::new("/bin/sh"),
+            Harness::Codex,
+            false,
+            &passthrough,
+            &environment,
+        );
+        let child = command.spawn().expect("test child");
+
+        drop(child);
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+        assert!(!marker.exists(), "dropped harness child continued running");
     }
 
     #[tokio::test]
@@ -685,6 +945,95 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn readiness_timeout_redacts_gateway_password() {
+        let error = super::wait_for_gateway(
+            &reqwest::Client::new(),
+            "https://agentic:gateway-secret@example.com",
+            std::time::Duration::ZERO,
+            std::time::Duration::from_millis(1),
+            false,
+        )
+        .await
+        .expect_err("readiness should time out");
+        let message = error.to_string();
+
+        assert!(!message.contains("gateway-secret"));
+        assert!(message.contains("https://[REDACTED]@example.com"));
+    }
+
+    #[tokio::test]
+    async fn empty_model_listing_error_redacts_upstream_userinfo() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("listener");
+        let address = listener.local_addr().expect("listener address");
+        tokio::spawn(async move {
+            use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+            let (mut socket, _) = listener.accept().await.expect("connection");
+            let mut buffer = [0_u8; 1024];
+            let _ = socket.read(&mut buffer).await;
+            let body = r#"{"data":[]}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            socket.write_all(response.as_bytes()).await.expect("response");
+        });
+        let source = SourceOptions {
+            upstream: Some(format!("http://secret-token@{address}")),
+            model: None,
+            llm_port: 8000,
+        };
+
+        let error = super::resolve_model(&reqwest::Client::new(), &source, None)
+            .await
+            .expect_err("empty model listing should fail");
+        let message = error.to_string();
+
+        assert!(!message.contains("secret-token"));
+        assert!(message.contains("http://[REDACTED]@"));
+    }
+
+    #[tokio::test]
+    async fn readiness_rejects_redirected_login_pages() {
+        use axum::{Router, response::Redirect, routing::get};
+        use std::sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        };
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("listener");
+        let address = listener.local_addr().expect("listener address");
+        let login_visits = Arc::new(AtomicUsize::new(0));
+        let login_visits_for_route = Arc::clone(&login_visits);
+        let application = Router::new()
+            .route("/health", get(|| async { Redirect::temporary("/login") }))
+            .route("/ready", get(|| async { Redirect::temporary("/login") }))
+            .route(
+                "/login",
+                get(move || {
+                    login_visits_for_route.fetch_add(1, Ordering::SeqCst);
+                    async { "sign in" }
+                }),
+            );
+        let server = tokio::spawn(async move {
+            axum::serve(listener, application).await.expect("test server");
+        });
+
+        let result = super::wait_for_gateway(
+            &super::gateway_client().expect("gateway client"),
+            &format!("http://{address}"),
+            std::time::Duration::from_millis(100),
+            std::time::Duration::from_millis(1),
+            false,
+        )
+        .await;
+        server.abort();
+
+        assert!(result.is_err(), "redirected login page passed readiness");
+        assert_eq!(login_visits.load(Ordering::SeqCst), 0, "readiness followed a redirect");
+    }
+
+    #[tokio::test]
     async fn resolve_model_discovers_first_upstream_model() {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
@@ -727,9 +1076,15 @@ mod tests {
             harness_args: Vec::new(),
         };
         let root = std::env::temp_dir().join(format!("agentic-api-yolo-test-{}", std::process::id()));
-        let environment =
-            super::harness_environment(Harness::Claude, "http://127.0.0.1:3000", "served-test", &options, &root)
-                .expect("Claude environment");
+        let environment = super::harness_environment(
+            Harness::Claude,
+            "http://127.0.0.1:3000",
+            "served-test",
+            &options,
+            &root,
+            &root,
+        )
+        .expect("Claude environment");
 
         assert_eq!(
             environment.environment.get("CLAUDE_CODE_EFFORT_LEVEL"),

--- a/crates/agentic-server/src/bin/agentic.rs
+++ b/crates/agentic-server/src/bin/agentic.rs
@@ -2,9 +2,9 @@ use std::{ffi::OsStr, io::IsTerminal, path::Path, process::ExitCode};
 
 use agentic_core::error::Error;
 use agentic_server::{
-    agentic_cli::{Cli, Command, HarnessCommand},
+    agentic_cli::{AttachedHarnessCommand, Cli, Command, HarnessCommand},
     agentic_output::{colorize_help, redact_url, render_banner, render_help},
-    agentic_process::{run_session, server_args, server_binary_path},
+    agentic_process::{run_attached_harness, run_session, server_args, server_binary_path},
 };
 use clap::{Parser, error::ErrorKind};
 
@@ -22,9 +22,27 @@ async fn main() -> Result<ExitCode, Error> {
     };
     match cli.command {
         Command::Run { harness } => run_harness(harness).await,
+        Command::Harness { harness } => attach_harness(harness).await,
         Command::Serve(options) => serve(options.source, options.common).await,
         Command::Validate(options) => validate(options).await,
     }
+}
+
+async fn attach_harness(harness: AttachedHarnessCommand) -> Result<ExitCode, Error> {
+    let (selected, options) = match harness {
+        AttachedHarnessCommand::Codex(options) => (agentic_server::agentic_cli::Harness::Codex, options),
+        AttachedHarnessCommand::Claude(options) => (agentic_server::agentic_cli::Harness::Claude, options),
+    };
+    if !options.quiet {
+        println!("{}", render_banner(!options.no_color));
+        if options.no_color {
+            println!("Starting {selected:?} via {}", redact_url(&options.gateway_url));
+        } else {
+            println!("\u{1b}[35mStarting {selected:?}\u{1b}[0m");
+        }
+    }
+    let status = run_attached_harness(selected, options).await?;
+    Ok(ExitCode::from(status.code().unwrap_or(1).try_into().unwrap_or(1)))
 }
 
 async fn run_harness(harness: HarnessCommand) -> Result<ExitCode, Error> {

--- a/crates/agentic-server/src/bin/agentic.rs
+++ b/crates/agentic-server/src/bin/agentic.rs
@@ -3,7 +3,7 @@ use std::{ffi::OsStr, io::IsTerminal, path::Path, process::ExitCode};
 use agentic_core::error::Error;
 use agentic_server::{
     agentic_cli::{AttachedHarnessCommand, Cli, Command, HarnessCommand},
-    agentic_output::{colorize_help, redact_url, render_banner, render_help},
+    agentic_output::{colorize_help, redact_url, redact_urls, render_banner, render_help},
     agentic_process::{run_attached_harness, run_session, server_args, server_binary_path},
 };
 use clap::{Parser, error::ErrorKind};
@@ -18,7 +18,14 @@ async fn main() -> Result<ExitCode, Error> {
             println!("{}", render_help(&help, color));
             return Ok(ExitCode::SUCCESS);
         }
-        Err(error) => error.exit(),
+        Err(error) if error.kind() == ErrorKind::DisplayVersion => {
+            print!("{}", error.render());
+            return Ok(ExitCode::SUCCESS);
+        }
+        Err(error) => {
+            eprint!("{}", redact_urls(&error.render().to_string()));
+            return Ok(ExitCode::from(2));
+        }
     };
     match cli.command {
         Command::Run { harness } => run_harness(harness).await,

--- a/crates/agentic-server/tests/cli_test.rs
+++ b/crates/agentic-server/tests/cli_test.rs
@@ -34,3 +34,33 @@ fn help_does_not_expose_database_url_credentials() {
     assert!(!stdout.contains(database_url));
     assert!(!stdout.contains("super-secret"));
 }
+
+#[test]
+fn agentic_cli_errors_redact_url_userinfo() {
+    let output = Command::new(env!("CARGO_BIN_EXE_agentic"))
+        .args([
+            "run",
+            "claude",
+            "--upstream",
+            "https://secret-token@example.com?unsupported=true",
+        ])
+        .output()
+        .expect("agentic CLI must run");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).expect("stderr must be UTF-8");
+    assert!(!stderr.contains("secret-token"), "credential leaked in: {stderr}");
+    assert!(stderr.contains("https://[REDACTED]@example.com?unsupported=true"));
+}
+
+#[test]
+fn agentic_version_exits_successfully() {
+    let output = Command::new(env!("CARGO_BIN_EXE_agentic"))
+        .arg("--version")
+        .output()
+        .expect("agentic CLI must run");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("stdout must be UTF-8");
+    assert!(stdout.starts_with("agentic "));
+}

--- a/docs/deploying/README.md
+++ b/docs/deploying/README.md
@@ -283,7 +283,10 @@ to the Deployment’s container environment:
                   name: agentic-api-secrets
                   key: you-api-key
             - name: YOU_API_BASE_URL
-              value: https://api.ydc-index.io
+              value: https://ydc-index.io
+            # Opt Claude Code's WebSearch function into gateway execution.
+            - name: MESSAGES_GATEWAY_TOOL_ALIASES
+              value: WebSearch=web_search
 ```
 
 Create the secret before applying the Deployment:

--- a/docs/deploying/kubernetes.md
+++ b/docs/deploying/kubernetes.md
@@ -417,7 +417,7 @@ for a saturated database or inference service.
 ## Enable and verify web search
 
 The `web_search_preview` built-in tool is executed by Agentic API when `YOU_API_KEY` and `YOU_API_BASE_URL` are
-configured. Keep the key in a Secret and use the current You.com Search API base URL, `https://api.ydc-index.io`.
+configured. Keep the key in a Secret and use the current You.com Search API base URL, `https://ydc-index.io`.
 
 Create the Secret from a protected environment file so the key does not enter shell history or process arguments:
 
@@ -441,7 +441,10 @@ patches:
     patch: |-
       - op: add
         path: /data/YOU_API_BASE_URL
-        value: https://api.ydc-index.io
+        value: https://ydc-index.io
+      - op: add
+        path: /data/MESSAGES_GATEWAY_TOOL_ALIASES
+        value: WebSearch=web_search
   - target:
       kind: Deployment
       name: agentic-api
@@ -452,6 +455,10 @@ patches:
           secretRef:
             name: agentic-api-web-search
 ```
+
+`MESSAGES_GATEWAY_TOOL_ALIASES` is required only when Claude Code's client-owned `WebSearch` function should be
+executed by the gateway. Responses API clients declare web search structurally and do not need this alias. Leaving
+the setting empty preserves the default client-owned behavior.
 
 Apply the overlay, restart the Deployment after every Secret update, and wait for readiness:
 

--- a/docs/guides/harness-cli-testing.md
+++ b/docs/guides/harness-cli-testing.md
@@ -40,12 +40,12 @@ Responses answer. Run the same checks locally with `bash scripts/claude-code-smo
 |---|---|
 | `--upstream` must be a full URL | `http://` or `https://` with a host. A typo such as `http//127.0.0.1:8000` is rejected at parse time with `invalid upstream URL`. |
 | `--model` is optional with `--upstream` | When omitted, the CLI calls `GET {upstream}/v1/models` and uses the first model listed. Pass `--model` to pick another when the upstream serves several. |
-| Claude uses an isolated model override | The CLI maps Claude Code's canonical `claude-sonnet-4-5-20250929` identifier to the exact served model ID, so names such as `Qwen/Qwen3-8B` work without a vLLM alias. It also isolates `CLAUDE_CONFIG_DIR` and removes inherited Vertex, Bedrock, and Foundry routing switches. |
+| Claude uses isolated settings and state | Per-run settings map Claude Code's canonical `claude-sonnet-4-5-20250929` identifier to the exact served model ID, while every default and small/fast model tier is pinned to that served model. Session history is isolated from the user's normal Claude home under `$AGENTIC_API_HOME/harnesses/claude` (default `~/.agentic-api/harnesses/claude`) so `--resume` and `--continue` work across invocations. Inherited Vertex, Bedrock, and Foundry routing switches are removed. |
 | Claude effort is pinned to `medium` | Claude Code defaults to `high`, which Qwen's vLLM chat template rejects (`ValueError`). The CLI always passes `--effort medium` and sets `CLAUDE_CODE_EFFORT_LEVEL=medium` (the env var wins inside Claude Code). Override both with `AGENTIC_CLAUDE_EFFORT=low|medium|xhigh`. |
 | Claude resource limits are pinned | The generated environment sets a 32,768-token context, 2,048 output tokens, and disables extended thinking. These conservative defaults fit the tested Qwen deployment. |
 | `--yolo` | Adds `--dangerously-skip-permissions` (Claude) or `--dangerously-bypass-approvals-and-sandbox` (Codex). Use only in an externally isolated environment. |
 | `--skip-llm-ready-check` | Skips the upstream `/health` probe. Avoid it while testing: the probe is what surfaces an unreachable upstream before the harness starts. |
-| Arguments after `--` | Forwarded to the harness (`-p`, `--resume`, `exec`, ...). Claude's `--model`, `--settings`, `--setting-sources`, and `--bare` are rejected because they would bypass the generated model and provider isolation. |
+| Arguments after `--` | Forwarded to the harness (`-p`, `--resume`, `exec`, ...). Claude's `--model`, `--settings`, `--setting-sources`, and `--bare` are rejected because they would bypass the generated model and provider isolation. Generated settings are temporary, but Claude session history persists in the isolated Agentic API home. |
 
 ## 1. Validate the configuration
 
@@ -180,23 +180,26 @@ agentic harness claude \
   -- -p "Reply with exactly one word: pong"
 ```
 
-The Claude command waits for `/health` and `/ready`, creates a temporary isolated Claude configuration, removes
-inherited cloud-provider routing variables, launches Claude Code, and deletes the temporary configuration when Claude exits.
+The Claude command waits for `/health` and `/ready` without following redirects, creates owner-only temporary settings,
+removes inherited cloud-provider routing variables, and deletes the temporary settings when Claude exits. Claude's session
+history persists under `$AGENTIC_API_HOME/harnesses/claude`, separate from the user's normal Claude Code configuration.
 It advertises the compact `Bash,Edit,Read,WebSearch` tool set. There is intentionally no `--web-search` switch:
 whether Claude Code's `WebSearch` function is gateway-owned is a deployment policy controlled by
 `MESSAGES_GATEWAY_TOOL_ALIASES=WebSearch=web_search`.
 
-For a raw-command diagnosis, the critical pieces are an isolated `CLAUDE_CONFIG_DIR`, a `settings.json` whose
+For a raw-command diagnosis, the critical pieces are a persistent isolated `CLAUDE_CONFIG_DIR`, a temporary `settings.json` whose
 `modelOverrides` maps the full canonical ID `claude-sonnet-4-5-20250929` to the served model, removal of inherited
 `CLAUDE_CODE_USE_VERTEX`/`CLAUDE_CODE_USE_BEDROCK`/`CLAUDE_CODE_USE_FOUNDRY`, and passing the canonical ID to
 `claude --model`. Short aliases such as `claude-sonnet-4-5` are not sufficient for this override.
 
 ```console
-CLAUDE_SMOKE_HOME=$(mktemp -d)
-trap 'rm -rf -- "$CLAUDE_SMOKE_HOME"' EXIT
+CLAUDE_SETTINGS_HOME=$(mktemp -d)
+CLAUDE_STATE_HOME="${AGENTIC_API_HOME:-$HOME/.agentic-api}/harnesses/claude"
+mkdir -p -m 700 "$CLAUDE_STATE_HOME"
+trap 'rm -rf -- "$CLAUDE_SETTINGS_HOME"' EXIT
 jq --null-input --arg model 'Qwen/Qwen3.8-27B-FP8' \
   '{modelOverrides: {"claude-sonnet-4-5-20250929": $model}}' \
-  >"$CLAUDE_SMOKE_HOME/settings.json"
+  >"$CLAUDE_SETTINGS_HOME/settings.json"
 
 env -u CLAUDE_CODE_USE_VERTEX \
   -u CLAUDE_CODE_USE_BEDROCK \
@@ -206,8 +209,13 @@ env -u CLAUDE_CODE_USE_VERTEX \
   -u CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST \
   -u ANTHROPIC_VERTEX_PROJECT_ID \
   -u CLOUD_ML_REGION \
-  CLAUDE_CONFIG_DIR="$CLAUDE_SMOKE_HOME" \
+  CLAUDE_CONFIG_DIR="$CLAUDE_STATE_HOME" \
   ANTHROPIC_BASE_URL=http://127.0.0.1:9000 \
+  ANTHROPIC_MODEL=Qwen/Qwen3.8-27B-FP8 \
+  ANTHROPIC_SMALL_FAST_MODEL=Qwen/Qwen3.8-27B-FP8 \
+  ANTHROPIC_DEFAULT_OPUS_MODEL=Qwen/Qwen3.8-27B-FP8 \
+  ANTHROPIC_DEFAULT_SONNET_MODEL=Qwen/Qwen3.8-27B-FP8 \
+  ANTHROPIC_DEFAULT_HAIKU_MODEL=Qwen/Qwen3.8-27B-FP8 \
   ANTHROPIC_API_KEY=agentic-api-local \
   ANTHROPIC_AUTH_TOKEN=agentic-api-local \
   CLAUDE_CODE_MAX_CONTEXT_TOKENS=32768 \
@@ -215,7 +223,8 @@ env -u CLAUDE_CODE_USE_VERTEX \
   MAX_THINKING_TOKENS=0 \
   CLAUDE_CODE_EFFORT_LEVEL=medium \
   claude --model claude-sonnet-4-5-20250929 \
-    --tools Bash,Edit,Read,WebSearch --setting-sources user --effort medium
+    --tools Bash,Edit,Read,WebSearch --setting-sources user --effort medium \
+    --settings "$CLAUDE_SETTINGS_HOME/settings.json"
 ```
 
 Codex uses the same attach-only workflow. The CLI generates an isolated `CODEX_HOME`, Responses provider
@@ -240,7 +249,9 @@ start, shell tool calls fail inside Codex itself; that is unrelated to the gatew
 (or the CLI's `--yolo`) confirms the gateway side. Codex declares web search structurally through the Responses API,
 so it does not require `MESSAGES_GATEWAY_TOOL_ALIASES`.
 
-Replace `agentic-api-local` with a real key when the deployment enforces inbound authentication. Finish by
+Replace `agentic-api-local` with a real key when the deployment enforces inbound authentication. For `agentic harness`,
+pass it explicitly with `--api-key` or set `AGENTIC_GATEWAY_API_KEY`; ambient `OPENAI_API_KEY` and
+`ANTHROPIC_CUSTOM_HEADERS` are deliberately ignored because they commonly carry unrelated provider credentials. Finish by
 confirming the gateway logged no errors during the run:
 
 ```console

--- a/docs/guides/harness-cli-testing.md
+++ b/docs/guides/harness-cli-testing.md
@@ -7,13 +7,11 @@ while verifying [issue #190](https://github.com/vllm-project/agentic-api/issues/
 
 ## Prerequisites
 
-- A running OpenAI-compatible upstream. The examples use vLLM serving Qwen on `http://127.0.0.1:8000`. For
-  Claude Code, vLLM must also serve the model under a slash-free alias (`--served-model-name` accepts several
-  names), because since 0.4.0 `agentic run claude` rejects model names containing `/`:
+- A running OpenAI-compatible upstream. The examples use vLLM serving Qwen on `http://127.0.0.1:8000`:
 
   ```console
   vllm serve Qwen/Qwen3.8-27B-FP8 \
-    --served-model-name Qwen/Qwen3.8-27B-FP8 qwen3-8-27b-fp8 ...
+    --served-model-name Qwen/Qwen3.8-27B-FP8 ...
   ```
 
   Check what is served with:
@@ -24,11 +22,17 @@ while verifying [issue #190](https://github.com/vllm-project/agentic-api/issues/
 
 - The harness binary on `PATH`: `claude --version` or `codex --version`. Override discovery with `AGENTIC_CLAUDE_BIN`
   or `AGENTIC_CODEX_BIN`.
+
 - Both Agentic API binaries built from this repository:
 
   ```console
   cargo build -p agentic-server --bins
   ```
+
+CI pins Claude Code 2.1.245 and Codex 0.149.1 and runs both real CLIs through the attach commands against recorded
+Qwen/vLLM streams. The Claude job verifies a gateway-owned web-search round trip; the Codex job verifies a completed
+Responses answer. Run the same checks locally with `bash scripts/claude-code-smoke.sh` and
+`bash scripts/codex-smoke.sh` after building both binaries with `cargo build -p agentic-server --bins`.
 
 ## CLI behavior worth knowing
 
@@ -36,11 +40,12 @@ while verifying [issue #190](https://github.com/vllm-project/agentic-api/issues/
 |---|---|
 | `--upstream` must be a full URL | `http://` or `https://` with a host. A typo such as `http//127.0.0.1:8000` is rejected at parse time with `invalid upstream URL`. |
 | `--model` is optional with `--upstream` | When omitted, the CLI calls `GET {upstream}/v1/models` and uses the first model listed. Pass `--model` to pick another when the upstream serves several. |
-| Claude requires a slash-free model | `agentic run claude` fails with `Claude Code requires a slash-free served model alias` when the model name contains `/`. Serve an alias with `--served-model-name` and pass it via `--model` (Codex accepts either form). |
+| Claude uses an isolated model override | The CLI maps Claude Code's canonical `claude-sonnet-4-5-20250929` identifier to the exact served model ID, so names such as `Qwen/Qwen3-8B` work without a vLLM alias. It also isolates `CLAUDE_CONFIG_DIR` and removes inherited Vertex, Bedrock, and Foundry routing switches. |
 | Claude effort is pinned to `medium` | Claude Code defaults to `high`, which Qwen's vLLM chat template rejects (`ValueError`). The CLI always passes `--effort medium` and sets `CLAUDE_CODE_EFFORT_LEVEL=medium` (the env var wins inside Claude Code). Override both with `AGENTIC_CLAUDE_EFFORT=low|medium|xhigh`. |
+| Claude resource limits are pinned | The generated environment sets a 32,768-token context, 2,048 output tokens, and disables extended thinking. These conservative defaults fit the tested Qwen deployment. |
 | `--yolo` | Adds `--dangerously-skip-permissions` (Claude) or `--dangerously-bypass-approvals-and-sandbox` (Codex). Use only in an externally isolated environment. |
 | `--skip-llm-ready-check` | Skips the upstream `/health` probe. Avoid it while testing: the probe is what surfaces an unreachable upstream before the harness starts. |
-| Arguments after `--` | Forwarded verbatim to the harness (`-p`, `--resume`, `exec`, ...). |
+| Arguments after `--` | Forwarded to the harness (`-p`, `--resume`, `exec`, ...). Claude's `--model`, `--settings`, `--setting-sources`, and `--bare` are rejected because they would bypass the generated model and provider isolation. |
 
 ## 1. Validate the configuration
 
@@ -56,7 +61,7 @@ the harness binary resolves, and the upstream URL is well formed.
 Claude Code:
 
 ```console
-./target/debug/agentic run claude --upstream http://127.0.0.1:8000 --model qwen3-8-27b-fp8 -- -p "Reply with exactly one word: pong"
+./target/debug/agentic run claude --upstream http://127.0.0.1:8000 --model Qwen/Qwen3.8-27B-FP8 -- -p "Reply with exactly one word: pong"
 ```
 
 Codex:
@@ -71,12 +76,13 @@ Expected lifecycle output, then the harness answer and a clean exit:
 Starting Claude via http://127.0.0.1:3000
 ... agentic_server::server: LLM ready: http://127.0.0.1:8000
 ... agentic_server::server: gateway listening on 127.0.0.1:3000
-Claude Code gateway: http://127.0.0.1:3000 (model: qwen3-8-27b-fp8)
+Claude Code config: /tmp/agentic-api-session-... (gateway: http://127.0.0.1:3000, model: Qwen/Qwen3.8-27B-FP8)
 pong
 ```
 
-Claude Code prints a warning that the model name is not one it recognizes and assumes a 200k context window. That
-is expected for any non-Anthropic model name and does not affect the request.
+Claude Code's header may still display the canonical Sonnet label. Requests are routed to the Qwen model by the
+generated `modelOverrides` entry; the display label is not evidence that Anthropic billing or an enterprise provider
+is in use.
 
 ## 3. Tool-call round trip
 
@@ -84,7 +90,7 @@ Tool calls are where the parallel-tool-call handling from #190 is exercised, so 
 session and approve the permission prompt when the harness asks to run the command:
 
 ```console
-./target/debug/agentic run claude --upstream http://127.0.0.1:8000 --model qwen3-8-27b-fp8
+./target/debug/agentic run claude --upstream http://127.0.0.1:8000 --model Qwen/Qwen3.8-27B-FP8
 > Run 'ls crates' with the Bash tool and list the directory names.
 ```
 
@@ -95,14 +101,14 @@ Permission prompts are the default. Only for an unattended run in an externally 
 throwaway container) add `--yolo`, which forwards the harness's native bypass flag:
 
 ```console
-./target/debug/agentic run claude --upstream http://127.0.0.1:8000 --model qwen3-8-27b-fp8 --yolo \
+./target/debug/agentic run claude --upstream http://127.0.0.1:8000 --model Qwen/Qwen3.8-27B-FP8 --yolo \
   -- -p "Run 'ls crates' with the Bash tool and list the directory names."
 ```
 
 ## 4. Interactive session
 
 ```console
-./target/debug/agentic run claude --upstream http://127.0.0.1:8000 --model qwen3-8-27b-fp8
+./target/debug/agentic run claude --upstream http://127.0.0.1:8000 --model Qwen/Qwen3.8-27B-FP8
 ```
 
 Inside the session, useful checks are a plain question (no tools), a file read, a multi-step edit, and `/model`
@@ -135,8 +141,8 @@ true`; it must return `HTTP 200` as well. Unit coverage lives in
 
 ## 6. Against a Kubernetes deployment
 
-The CLI always starts its own local gateway, so to test a cluster-hosted gateway point the harness at it directly
-with the same environment the CLI would set. The kind-based development cluster below is the one from
+Use the attach-only `agentic harness` command to test a cluster-hosted gateway without starting another local
+gateway. The kind-based development cluster below is the one from
 [Deploy agentic-api on Kubernetes](../deploying/kubernetes.md).
 
 ### Roll out a new image
@@ -162,43 +168,77 @@ curl -s -w '\nHTTP %{http_code}\n' -H 'content-type: application/json' http://12
   "parallel_tool_calls": true, "tools": [{"type": "web_search_preview"}]
 }'
 
-# Claude Code through the cluster gateway
-ANTHROPIC_BASE_URL=http://127.0.0.1:9000 \
-ANTHROPIC_API_KEY=agentic-api-local \
-ANTHROPIC_MODEL=Qwen/Qwen3.8-27B-FP8 \
-ANTHROPIC_SMALL_FAST_MODEL=Qwen/Qwen3.8-27B-FP8 \
-CLAUDE_CODE_EFFORT_LEVEL=medium \
-claude --effort medium -p "Reply with exactly one word: pong"
+# Claude Code through the cluster gateway (interactive)
+agentic harness claude \
+  --gateway-url http://127.0.0.1:9000 \
+  --model Qwen/Qwen3.8-27B-FP8
+
+# The same path as a one-shot smoke test
+agentic harness claude \
+  --gateway-url http://127.0.0.1:9000 \
+  --model Qwen/Qwen3.8-27B-FP8 \
+  -- -p "Reply with exactly one word: pong"
 ```
 
-Codex needs a `CODEX_HOME` with the same provider configuration the CLI generates. Keep it outside `/tmp` (Codex
-refuses to create its helper binaries there) and close stdin for `exec`, otherwise Codex waits for additional prompt
-input when it is not attached to a terminal:
+The Claude command waits for `/health` and `/ready`, creates a temporary isolated Claude configuration, removes
+inherited cloud-provider routing variables, launches Claude Code, and deletes the temporary configuration when Claude exits.
+It advertises the compact `Bash,Edit,Read,WebSearch` tool set. There is intentionally no `--web-search` switch:
+whether Claude Code's `WebSearch` function is gateway-owned is a deployment policy controlled by
+`MESSAGES_GATEWAY_TOOL_ALIASES=WebSearch=web_search`.
+
+For a raw-command diagnosis, the critical pieces are an isolated `CLAUDE_CONFIG_DIR`, a `settings.json` whose
+`modelOverrides` maps the full canonical ID `claude-sonnet-4-5-20250929` to the served model, removal of inherited
+`CLAUDE_CODE_USE_VERTEX`/`CLAUDE_CODE_USE_BEDROCK`/`CLAUDE_CODE_USE_FOUNDRY`, and passing the canonical ID to
+`claude --model`. Short aliases such as `claude-sonnet-4-5` are not sufficient for this override.
 
 ```console
-export CODEX_HOME=$HOME/.cache/agentic-codex-k8s
-mkdir -p "$CODEX_HOME"
-cat > "$CODEX_HOME/config.toml" <<EOF
-model = "Qwen/Qwen3.8-27B-FP8"
-model_provider = "agentic-api"
-model_catalog_json = "$CODEX_HOME/model_catalog.json"
+CLAUDE_SMOKE_HOME=$(mktemp -d)
+trap 'rm -rf -- "$CLAUDE_SMOKE_HOME"' EXIT
+jq --null-input --arg model 'Qwen/Qwen3.8-27B-FP8' \
+  '{modelOverrides: {"claude-sonnet-4-5-20250929": $model}}' \
+  >"$CLAUDE_SMOKE_HOME/settings.json"
 
-[model_providers.agentic-api]
-name = "Agentic API"
-base_url = "http://127.0.0.1:9000/v1"   # must match the port-forward above when reusing an older CODEX_HOME
-wire_api = "responses"
-requires_openai_auth = false
-supports_websockets = true
-EOF
-# Copy model_catalog.json from a CLI session (printed path) or from prepare_codex_home in
-# crates/agentic-server/src/agentic_harness.rs, replacing the slug with your model id.
-codex exec --skip-git-repo-check "Reply with exactly one word: pong" </dev/null
+env -u CLAUDE_CODE_USE_VERTEX \
+  -u CLAUDE_CODE_USE_BEDROCK \
+  -u CLAUDE_CODE_USE_FOUNDRY \
+  -u CLAUDE_CODE_USE_ANTHROPIC_AWS \
+  -u CLAUDE_CODE_USE_MANTLE \
+  -u CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST \
+  -u ANTHROPIC_VERTEX_PROJECT_ID \
+  -u CLOUD_ML_REGION \
+  CLAUDE_CONFIG_DIR="$CLAUDE_SMOKE_HOME" \
+  ANTHROPIC_BASE_URL=http://127.0.0.1:9000 \
+  ANTHROPIC_API_KEY=agentic-api-local \
+  ANTHROPIC_AUTH_TOKEN=agentic-api-local \
+  CLAUDE_CODE_MAX_CONTEXT_TOKENS=32768 \
+  CLAUDE_CODE_MAX_OUTPUT_TOKENS=2048 \
+  MAX_THINKING_TOKENS=0 \
+  CLAUDE_CODE_EFFORT_LEVEL=medium \
+  claude --model claude-sonnet-4-5-20250929 \
+    --tools Bash,Edit,Read,WebSearch --setting-sources user --effort medium
+```
+
+Codex uses the same attach-only workflow. The CLI generates an isolated `CODEX_HOME`, Responses provider
+configuration, and model catalog, then removes them when Codex exits:
+
+```console
+# Interactive Codex session through the cluster gateway
+agentic harness codex \
+  --gateway-url http://127.0.0.1:9000 \
+  --model Qwen/Qwen3.8-27B-FP8
+
+# One-shot smoke test
+agentic harness codex \
+  --gateway-url http://127.0.0.1:9000 \
+  --model Qwen/Qwen3.8-27B-FP8 \
+  -- exec --skip-git-repo-check "Reply with exactly one word: pong"
 ```
 
 Codex uses the gateway's WebSocket transport (`supports_websockets = true`), so this also verifies `/v1/responses`
 over WebSocket through the port-forward. On Linux hosts where Codex's sandbox (`codex-linux-sandbox`/bwrap) cannot
 start, shell tool calls fail inside Codex itself; that is unrelated to the gateway and `--dangerously-bypass-approvals-and-sandbox`
-(or the CLI's `--yolo`) confirms the gateway side.
+(or the CLI's `--yolo`) confirms the gateway side. Codex declares web search structurally through the Responses API,
+so it does not require `MESSAGES_GATEWAY_TOOL_ALIASES`.
 
 Replace `agentic-api-local` with a real key when the deployment enforces inbound authentication. Finish by
 confirming the gateway logged no errors during the run:
@@ -219,13 +259,15 @@ expected; anything at `ERROR` level is not.
 | `invalid upstream URL` at startup | Malformed `--upstream` (missing `://`, no scheme, no host) | Pass a full `http://host:port` URL. |
 | `HTTP 502` on every request | Gateway cannot reach the upstream, typically a wrong URL combined with `--skip-llm-ready-check` | Drop `--skip-llm-ready-check` so the readiness probe fails fast, then fix the URL. |
 | `There's an issue with the selected model` | Model name does not match what the upstream serves | Omit `--model` to auto-discover, or copy the id from `/v1/models` exactly. |
-| `Claude Code requires a slash-free served model alias` | The discovered or passed model name contains `/`, which `agentic run claude` rejects (0.4.0+) | Add a slash-free alias to vLLM's `--served-model-name` list and pass it with `--model`. |
+| Claude opens with `Google Vertex AI`, Bedrock, or Foundry | Provider-selection variables leaked in from the user's normal Claude configuration | Use `agentic harness claude`; it creates an isolated config and removes the provider switches from the child environment. |
+| Claude reports `There's an issue with the selected model (claude-sonnet-4-5)` | A short alias was overridden, but Claude Code requested the full canonical model ID | Map `claude-sonnet-4-5-20250929` to the served model; the CLI does this automatically. |
+| Claude answers that it cannot browse even though `WebSearch` is listed | The deployment did not opt the PascalCase client function into gateway execution, or the model did not emit a tool call | Set `MESSAGES_GATEWAY_TOOL_ALIASES=WebSearch=web_search`, restart the Deployment, and verify the gateway logs contain an actual tool call. A model's prose claim is not a tool-call verification. |
 | Template `ValueError` mentioning effort | Claude Code sent `high` | Do not override `AGENTIC_CLAUDE_EFFORT` with `high`; valid values for Qwen are `low`, `medium`, `xhigh`. |
 | `HTTP 503` from a cluster gateway | `/ready` failing because the gateway cannot reach its upstream or database | `kubectl logs deploy/agentic-api` and look for `gateway dependencies not ready`. |
 | `readiness.ready=false` warnings every minute or two while the upstream is healthy | Gateway build predates the readiness-client pooling fix ([#199](https://github.com/vllm-project/agentic-api/pull/199)): a pooled keep-alive connection that the upstream closed fails with `hyper::Error(IncompleteMessage)` | Rebuild from a tree that includes #199 and redeploy; add `agentic_server::handler::http::models=debug` to `RUST_LOG` to see the probe error. |
 | Pods in `CrashLoopBackOff` with `failed to create temporary configuration file: Read-only file system` | Gateway build predates the read-only-home fix ([#199](https://github.com/vllm-project/agentic-api/pull/199)), and the base mounts a read-only root filesystem | Rebuild from a tree that includes #199 and redeploy; that base also mounts an `emptyDir` at `/var/lib/agentic-api`. Until then, mount a writable volume at `/var/lib/agentic-api` in your overlay. |
 | `kubectl apply -k` fails with `cycle detected` | Overlay directory placed inside `deploy/kubernetes` | Move the overlay to a sibling directory such as `deploy/overlays/<env>` and reference `../../kubernetes` (a working kind example ships with #199). |
 | Codex `exec` prints `Reading additional input from stdin...` and hangs | stdin is not a terminal | Append `</dev/null`. |
-| Codex warns it could not create PATH aliases | `CODEX_HOME` under `/tmp` | Use a home under `$HOME`. |
+| Codex warns it could not create PATH aliases | Attach mode uses a temporary `CODEX_HOME` | The warning is non-fatal for an attach session. Codex still loads the generated provider and model catalog; use a persistent home under `$HOME` only for a manual configuration. |
 | A long stream stops without a terminal event during a rollout | Bounded drain: 5 s `preStop` plus up to 8 s of in-flight draining, then the pod exits | Expected for responses longer than the drain window; clients should reconnect and continue with `previous_response_id`. |
 | `parallel_tool_calls must be false when using built-in tools` | Gateway predates PR #197 | Rebuild and redeploy the image. |

--- a/scripts/claude-code-smoke.sh
+++ b/scripts/claude-code-smoke.sh
@@ -107,6 +107,7 @@ wait_until_ready "agentic-server" "http://127.0.0.1:${GATEWAY_PORT}/ready"
 
 env \
   AGENTIC_CLAUDE_BIN="$CLAUDE_BIN" \
+  ANTHROPIC_CUSTOM_HEADERS='Authorization: Bearer must-not-be-forwarded' \
   CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 \
   DISABLE_AUTOUPDATER=1 \
   "$AGENTIC_BIN" harness claude \

--- a/scripts/claude_code_replay_server.py
+++ b/scripts/claude_code_replay_server.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Replay recorded vLLM Messages turns for the Claude Code CI acceptance test."""
+"""Replay recorded vLLM turns for coding-harness CI acceptance tests."""
 
 from __future__ import annotations
 
@@ -72,13 +72,18 @@ def _cache_breakpoint_ttls(request: dict[str, Any]) -> list[str]:
     return ttls
 
 
-def validate_capture(records: list[dict[str, Any]]) -> None:
+def validate_capture(records: list[dict[str, Any]], expected_model: str | None = None) -> None:
     messages = [record["body"] for record in records if record["kind"] == "messages"]
     transports = [record["body"] for record in records if record["kind"] == "messages_transport"]
     searches = [record["body"] for record in records if record["kind"] == "search"]
     assert len(messages) == 2, f"expected two Messages rounds, got {len(messages)}"
     assert len(transports) == 2, f"expected transport capture for both Messages rounds, got {len(transports)}"
     assert len(searches) == 1, f"expected one search request, got {len(searches)}"
+
+    if expected_model is not None:
+        assert all(message.get("model") == expected_model for message in messages), (
+            f"expected Claude Code to request model {expected_model!r}"
+        )
 
     session_ids = set()
     for transport in transports:
@@ -120,6 +125,19 @@ def validate_capture(records: list[dict[str, Any]]) -> None:
         block.get("type") == "tool_result" for block in _content_blocks(messages[1])
     ), "expected a tool_result in the second Messages round"
     assert searches[0].get("query"), "expected a non-empty search query"
+
+
+def validate_responses_capture(records: list[dict[str, Any]], expected_model: str) -> None:
+    responses = [record["body"] for record in records if record["kind"] == "responses"]
+    transports = [record["body"] for record in records if record["kind"] == "responses_transport"]
+    assert len(responses) == 1, f"expected one Responses request, got {len(responses)}"
+    assert len(transports) == 1, f"expected one Responses transport capture, got {len(transports)}"
+    assert transports[0]["path"] == "/v1/responses", transports[0]
+
+    request = responses[0]
+    assert request.get("model") == expected_model, f"expected requested model {expected_model!r}, got {request.get('model')!r}"
+    assert request.get("stream") is True, "expected Codex to request a streaming response"
+    assert request.get("input"), "expected a non-empty Responses input"
 
 
 @dataclass
@@ -192,6 +210,19 @@ def make_handler(state: ReplayState) -> type[BaseHTTPRequestHandler]:
             if path == "/v1/search":
                 self._send_search_response(request)
                 return
+            if path == "/v1/responses":
+                append_capture(
+                    state.capture_path,
+                    "responses_transport",
+                    {"path": self.path},
+                )
+                append_capture(state.capture_path, "responses", request)
+                turn = state.take_turn()
+                if turn is None:
+                    self._send_json(409, {"error": {"type": "api_error", "message": "cassette exhausted"}})
+                    return
+                self._send_bytes(turn.status_code, turn.content_type, turn.body)
+                return
             if path != "/v1/messages":
                 self.send_error(404)
                 return
@@ -251,6 +282,8 @@ def parse_args() -> argparse.Namespace:
 
     assert_capture = subparsers.add_parser("assert-capture")
     assert_capture.add_argument("--capture", required=True, type=Path)
+    assert_capture.add_argument("--api", choices=("messages", "responses"), default="messages")
+    assert_capture.add_argument("--model", required=True)
     return parser.parse_args()
 
 
@@ -258,11 +291,17 @@ def main() -> None:
     args = parse_args()
     if args.command == "assert-capture":
         records = load_capture(args.capture)
-        validate_capture(records)
-        messages = sum(record["kind"] == "messages" for record in records)
-        transports = sum(record["kind"] == "messages_transport" for record in records)
-        searches = sum(record["kind"] == "search" for record in records)
-        print(f"capture valid: messages={messages} transports={transports} searches={searches}")
+        if args.api == "responses":
+            validate_responses_capture(records, args.model)
+            responses = sum(record["kind"] == "responses" for record in records)
+            transports = sum(record["kind"] == "responses_transport" for record in records)
+            print(f"capture valid: responses={responses} transports={transports}")
+        else:
+            validate_capture(records, args.model)
+            messages = sum(record["kind"] == "messages" for record in records)
+            transports = sum(record["kind"] == "messages_transport" for record in records)
+            searches = sum(record["kind"] == "search" for record in records)
+            print(f"capture valid: messages={messages} transports={transports} searches={searches}")
         return
 
     args.capture.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/codex-smoke.sh
+++ b/scripts/codex-smoke.sh
@@ -103,7 +103,7 @@ gateway_pid=$!
 wait_until_ready "agentic-server" "http://127.0.0.1:${GATEWAY_PORT}/ready"
 
 env \
-  -u OPENAI_API_KEY \
+  OPENAI_API_KEY=must-not-be-forwarded \
   AGENTIC_CODEX_BIN="$CODEX_BIN" \
   RUST_LOG=warn \
   "$AGENTIC_BIN" harness codex \

--- a/scripts/codex-smoke.sh
+++ b/scripts/codex-smoke.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CLAUDE_BIN="${CLAUDE_BIN:-claude}"
+CODEX_BIN="${CODEX_BIN:-codex}"
 AGENTIC_BIN="${AGENTIC_BIN:-target/debug/agentic}"
 AGENTIC_SERVER_BIN="${AGENTIC_SERVER_BIN:-target/debug/agentic-server}"
 PYTHON_BIN="${PYTHON_BIN:-python3}"
-CASSETTE="${CASSETTE:-crates/agentic-server-core/tests/cassettes/messages/messages-web-search-Qwen-Qwen3-30B-A3B-FP8-streaming.yaml}"
+CASSETTE="${CASSETTE:-crates/agentic-server-core/tests/cassettes/reasoning/responses/reasoning-single-Qwen-Qwen3-30B-A3B-FP8-streaming.yaml}"
 MODEL="${MODEL:-Qwen/Qwen3-30B-A3B-FP8}"
 
 choose_port() {
@@ -15,8 +15,8 @@ choose_port() {
 REPLAY_PORT="${REPLAY_PORT:-$(choose_port)}"
 GATEWAY_PORT="${GATEWAY_PORT:-$(choose_port)}"
 
-if ! command -v "$CLAUDE_BIN" >/dev/null 2>&1; then
-  echo "error: Claude Code is not installed: ${CLAUDE_BIN}" >&2
+if ! command -v "$CODEX_BIN" >/dev/null 2>&1; then
+  echo "error: Codex is not installed: ${CODEX_BIN}" >&2
   exit 2
 fi
 if [[ ! -x "$AGENTIC_SERVER_BIN" ]]; then
@@ -28,7 +28,7 @@ if [[ ! -x "$AGENTIC_BIN" ]]; then
   exit 2
 fi
 if [[ ! -f "$CASSETTE" ]]; then
-  echo "error: Messages cassette not found: ${CASSETTE}" >&2
+  echo "error: Responses cassette not found: ${CASSETTE}" >&2
   exit 2
 fi
 
@@ -36,8 +36,8 @@ temp_dir="$(mktemp -d)"
 capture_path="${temp_dir}/capture.jsonl"
 replay_log="${temp_dir}/replay.log"
 gateway_log="${temp_dir}/gateway.log"
-claude_output="${temp_dir}/claude.json"
-claude_debug="${temp_dir}/claude-debug.log"
+codex_output="${temp_dir}/codex.out"
+codex_debug="${temp_dir}/codex-debug.log"
 replay_pid=""
 gateway_pid=""
 
@@ -57,10 +57,10 @@ cleanup() {
     sed -n '1,240p' "$replay_log" >&2 || true
     echo "--- agentic-server log ---" >&2
     sed -n '1,240p' "$gateway_log" >&2 || true
-    echo "--- Claude Code output ---" >&2
-    sed -n '1,240p' "$claude_output" >&2 || true
-    echo "--- Claude Code debug log ---" >&2
-    sed -n '1,240p' "$claude_debug" >&2 || true
+    echo "--- Codex output ---" >&2
+    sed -n '1,240p' "$codex_output" >&2 || true
+    echo "--- Codex debug log ---" >&2
+    sed -n '1,240p' "$codex_debug" >&2 || true
     echo "--- replay capture ---" >&2
     sed -n '1,240p' "$capture_path" >&2 || true
   fi
@@ -97,45 +97,34 @@ env \
   GATEWAY_PORT="$GATEWAY_PORT" \
   SKIP_LLM_READY_CHECK=true \
   DATABASE_URL="sqlite://${temp_dir}/agentic.db" \
-  MESSAGES_GATEWAY_TOOL_ALIASES=WebSearch=web_search \
-  YOU_API_KEY=ci-placeholder \
-  YOU_API_BASE_URL="http://127.0.0.1:${REPLAY_PORT}" \
   "$AGENTIC_SERVER_BIN" \
   >"$gateway_log" 2>&1 &
 gateway_pid=$!
 wait_until_ready "agentic-server" "http://127.0.0.1:${GATEWAY_PORT}/ready"
 
 env \
-  AGENTIC_CLAUDE_BIN="$CLAUDE_BIN" \
-  CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 \
-  DISABLE_AUTOUPDATER=1 \
-  "$AGENTIC_BIN" harness claude \
+  -u OPENAI_API_KEY \
+  AGENTIC_CODEX_BIN="$CODEX_BIN" \
+  RUST_LOG=warn \
+  "$AGENTIC_BIN" harness codex \
   --gateway-url "http://127.0.0.1:${GATEWAY_PORT}" \
   --model "$MODEL" \
-  --api-key ci-placeholder \
   --quiet \
   -- \
-  --safe-mode \
-  --print \
-  "Use WebSearch to find the latest stable Rust release, then answer with its version only." \
-  --output-format json \
-  --debug-file "$claude_debug" \
-  --no-session-persistence \
-  --permission-mode dontAsk \
-  --allowedTools WebSearch \
-  >"$claude_output"
+  exec \
+  --skip-git-repo-check \
+  "Reply with exactly one word: HELLO" \
+  >"$codex_output" 2>"$codex_debug" </dev/null
 
-"$PYTHON_BIN" - "$claude_output" <<'PY'
-import json
+"$PYTHON_BIN" - "$codex_output" <<'PY'
 import sys
 
-result = json.load(open(sys.argv[1]))
-assert result.get("is_error") is False, result
-assert "1.89.0" in result.get("result", ""), result
-print(f"Claude Code result: {result['result']}")
+result = open(sys.argv[1]).read().strip()
+assert result == "HELLO", f"expected Codex to print exactly HELLO, got {result!r}"
+print(result)
 PY
 
 "$PYTHON_BIN" scripts/claude_code_replay_server.py assert-capture \
-  --api messages \
+  --api responses \
   --model "$MODEL" \
   --capture "$capture_path"

--- a/scripts/test_claude_code_replay_server.py
+++ b/scripts/test_claude_code_replay_server.py
@@ -1,5 +1,10 @@
+import json
 import sys
+import tempfile
+import threading
 import unittest
+import urllib.request
+from http.server import ThreadingHTTPServer
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
@@ -13,6 +18,12 @@ CASSETTE = (
     / "crates/agentic-server-core/tests/cassettes/messages/"
     "messages-web-search-Qwen-Qwen3-30B-A3B-FP8-streaming.yaml"
 )
+RESPONSES_CASSETTE = (
+    REPOSITORY_ROOT
+    / "crates/agentic-server-core/tests/cassettes/reasoning/responses/"
+    "reasoning-single-Qwen-Qwen3-30B-A3B-FP8-streaming.yaml"
+)
+QWEN_MODEL = "Qwen/Qwen3-30B-A3B-FP8"
 
 
 def cache_control(ttl: str = "5m") -> dict[str, str]:
@@ -95,6 +106,74 @@ class ReplayServerTests(unittest.TestCase):
 
         self.assertIn('"name":"WebSearch"', adapted)
         self.assertNotIn('"name":"web_search"', adapted)
+
+    def test_load_turns_reads_recorded_responses_stream(self) -> None:
+        turns = replay.load_turns(RESPONSES_CASSETTE)
+
+        self.assertEqual(len(turns), 1)
+        self.assertEqual(turns[0].status_code, 200)
+        self.assertIn(b"event: response.created", turns[0].body)
+        self.assertIn(b"HELLO", turns[0].body)
+
+    def test_validate_responses_capture_accepts_codex_wire_shape(self) -> None:
+        records = [
+            {
+                "kind": "responses_transport",
+                "body": {"path": "/v1/responses", "headers": {}},
+            },
+            {
+                "kind": "responses",
+                "body": {
+                    "model": QWEN_MODEL,
+                    "stream": True,
+                    "input": "Reply with exactly one word: HELLO",
+                },
+            },
+        ]
+
+        replay.validate_responses_capture(records, QWEN_MODEL)
+
+    def test_validate_responses_capture_rejects_wrong_model(self) -> None:
+        records = [
+            {
+                "kind": "responses_transport",
+                "body": {"path": "/v1/responses", "headers": {}},
+            },
+            {
+                "kind": "responses",
+                "body": {"model": "claude-sonnet-4-5", "stream": True, "input": "HELLO"},
+            },
+        ]
+
+        with self.assertRaisesRegex(AssertionError, "requested model"):
+            replay.validate_responses_capture(records, QWEN_MODEL)
+
+    def test_responses_route_replays_recorded_stream_and_captures_request(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            capture_path = Path(temp_dir) / "capture.jsonl"
+            capture_path.write_text("")
+            state = replay.ReplayState(replay.load_turns(RESPONSES_CASSETTE), capture_path)
+            server = ThreadingHTTPServer(("127.0.0.1", 0), replay.make_handler(state))
+            thread = threading.Thread(target=server.serve_forever)
+            thread.start()
+            try:
+                request = urllib.request.Request(
+                    f"http://127.0.0.1:{server.server_port}/v1/responses",
+                    data=json.dumps(
+                        {"model": QWEN_MODEL, "stream": True, "input": "HELLO"}
+                    ).encode(),
+                    headers={"Content-Type": "application/json"},
+                )
+                with urllib.request.urlopen(request, timeout=5) as response:
+                    body = response.read()
+                records = replay.load_capture(capture_path)
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join()
+
+        self.assertIn(b"event: response.created", body)
+        replay.validate_responses_capture(records, QWEN_MODEL)
 
     def test_validate_capture_accepts_claude_code_wire_shape_and_tool_round(self) -> None:
         records = capture_records(messages_request(), messages_request(with_tool_result=True))


### PR DESCRIPTION
## Summary

- add attached Claude Code and Codex harness commands with isolated model and provider configuration
- document Kubernetes, llm-d, Claude Code, Codex, and web-search deployment lessons
- run pinned real Claude Code and Codex CLIs in CI against recorded Qwen/vLLM Messages and Responses streams
- prevent smoke-test credentials from leaking into Responses captures

## Test Plan
- `cargo test`
- `cargo clippy --all-targets -- -D warnings\n- cargo fmt -- --check`
- Python replay-server unit tests
- Claude Code cassette smoke test
- Codex cassette smoke test
- strict MkDocs build
- all pre-commit hooks