### PR TITLE
Allow configuring streaming chunk timeout

### DIFF
--- a/crates/agentic-server-core/src/executor/messages_stream.rs
+++ b/crates/agentic-server-core/src/executor/messages_stream.rs
@@ -37,7 +37,7 @@ use crate::executor::messages_loop::{
 };
 /// vLLM streaming chunk timeout (per line). Generous — the loop's own budget is
 /// the round cap, not this.
-const CHUNK_TIMEOUT: Duration = Duration::from_secs(120);
+const CHUNK_TIMEOUT: Duration = Duration::from_secs(600);
 
 /// Drive the streaming Messages-native loop, yielding Anthropic SSE lines for
 /// the client. Owns the multi-round → single-message accumulation.

--- a/crates/agentic-server-core/src/executor/request.rs
+++ b/crates/agentic-server-core/src/executor/request.rs
@@ -99,7 +99,7 @@ impl ExecutionContext {
             gateway_executors,
             messages_gateway_tools: messages_gateway_tools_from_env(),
             llm_base_url,
-            streaming_timeout: Duration::from_secs(30),
+            streaming_timeout: streaming_timeout_from_env(),
             storage_pool: None,
         }
     }
@@ -170,10 +170,17 @@ impl ExecutionContext {
                 .map(GatewayToolMap::from_env_str)
                 .unwrap_or_default(),
             llm_base_url: cfg.llm_api_base.clone(),
-            streaming_timeout: Duration::from_secs(30),
+            streaming_timeout: streaming_timeout_from_env(),
             storage_pool: Some(pool),
         })
     }
+}
+
+fn streaming_timeout_from_env() -> Duration {
+    std::env::var("STREAMING_CHUNK_TIMEOUT_S")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map_or(Duration::from_secs(600), Duration::from_secs)
 }
 
 fn database_open_error(database_backend: DatabaseBackend, error: &sqlx::Error) -> Error {


### PR DESCRIPTION
## Summary

Added support for STREAMING_CHUNK_TIMEOUT_S env variable that configures the timeout for chunks during streaming.

Increased the fallback default from 30 seconds to 600 seconds (10 minutes)

Fixes: #220 

## Test Plan

So far I tested e2e using forked aiperf.
