### PR TITLE
fix: require gateway health for local doctor

### DIFF
--- a/python/agentic_api/diagnostics.py
+++ b/python/agentic_api/diagnostics.py
@@ -54,11 +54,15 @@ def collect_doctor_report() -> DoctorReport:
         vllm_executable_path = str(find_active_environment_executable("vllm"))
     except FileNotFoundError:
         vllm_executable_path = "not found"
-    local_ok, local_message = _local_health(
+    local_runtime_ok, local_message = _local_health(
         installed_vllm_version,
         vllm_executable_path,
         platform_name=platform.system(),
     )
+    remote_ok = rust_binary_executable and not rust_binary_version.startswith("error:")
+    remote_message = _remote_health_message(rust_binary_executable, rust_binary_version)
+    if local_runtime_ok and not remote_ok:
+        local_message = remote_message
 
     return DoctorReport(
         python_version=platform.python_version(),
@@ -70,10 +74,10 @@ def collect_doctor_report() -> DoctorReport:
         supported_vllm_version=SUPPORTED_VLLM_VERSION,
         installed_vllm_version=installed_vllm_version,
         vllm_executable_path=vllm_executable_path,
-        local_ok=local_ok,
-        remote_ok=rust_binary_executable and not rust_binary_version.startswith("error:"),
+        local_ok=local_runtime_ok and remote_ok,
+        remote_ok=remote_ok,
         local_message=local_message,
-        remote_message=_remote_health_message(rust_binary_executable, rust_binary_version),
+        remote_message=remote_message,
     )
 
 

--- a/tests/python/test_diagnostics.py
+++ b/tests/python/test_diagnostics.py
@@ -89,6 +89,42 @@ def test_local_doctor_reports_missing_vllm_installation(
     assert "file:///path/to/agentic_api-PLATFORM.whl" in output
 
 
+@pytest.mark.parametrize(
+    ("rust_binary_details", "expected_message"),
+    [
+        (
+            ("not found", False, "error: agentic-server not found"),
+            "The packaged Rust gateway executable is missing or not executable.",
+        ),
+        (
+            ("/venv/bin/agentic-server", True, "error: version probe failed"),
+            "The packaged Rust gateway executable could not report its version.",
+        ),
+    ],
+)
+def test_local_doctor_requires_a_healthy_packaged_gateway(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+    rust_binary_details: tuple[str, bool, str],
+    expected_message: str,
+) -> None:
+    vllm_binary = tmp_path / "vllm"
+    vllm_binary.write_text("")
+    vllm_binary.chmod(0o755)
+
+    monkeypatch.setattr("agentic_api.diagnostics._rust_binary_details", lambda: rust_binary_details)
+    monkeypatch.setattr("agentic_api.diagnostics.metadata_version", _metadata_version_with_supported_vllm)
+    monkeypatch.setattr("agentic_api.diagnostics.find_active_environment_executable", lambda name: vllm_binary)
+
+    exit_code = diagnostics.doctor("local")
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "Local mode health: unavailable" in output
+    assert f"Local mode details: {expected_message}" in output
+
+
 def test_local_doctor_explains_linux_only_extra_on_unsupported_platform(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary

`agentic-api doctor --mode local` currently derives `local_ok` only from the platform and local vLLM installation, even though local mode depends on both the managed vLLM runtime and the packaged Rust gateway. It can therefore exit 0 and print `Local mode health: ok` while the same report marks gateway health unavailable because the gateway is missing or its bounded version probe failed. A missing gateway prevents `serve --model` from starting; a failed probe specifically means `doctor` could not validate the gateway and must not declare the complete local mode healthy, although the probe result alone does not establish whether a normal server invocation would launch.

Make local health the conjunction of the existing local-runtime check and packaged-gateway health. When the local runtime is otherwise healthy, surface the gateway failure in the local-mode detail as the actionable blocker.

Remote-mode health and the default no-mode exit policy are unchanged. The diagnostic JSON shape, launcher behavior, package metadata, networking, and process lifecycle are also unchanged.

## Test Plan

- Negative control on unmodified `main` with the final regression: 0 passed, 2 failed. Both missing-gateway and failed-version-probe cases incorrectly returned exit code 0.
- Patched focused regression: 2 passed.
- Patched diagnostics module: 12 passed.
- Adversarial matrix: all 15 combinations of healthy/missing/version-failing gateway and healthy/missing-package/wrong-version/missing-executable/unsupported-platform local runtime satisfied `local_ok == remote_ok && local_runtime_ok`.
- Exact commit `d04578af560fb29e1d1543d43c3458bcac7d1115`, tested from a clean detached worktree:
  - rebuilt and installed the 0.5.0 macOS arm64 wheel;
  - Python suite including wheel-only CLI and prefix-install checks: 114 passed;
  - `scripts/check-python-wheel.sh`: passed;
  - `cargo fmt --all -- --check`: passed;
  - `cargo check --workspace --all-targets`: passed;
  - `cargo clippy --workspace --all-targets -- -D warnings`: passed;
  - `cargo test --workspace`: passed (PostgreSQL integration tests and one doctest remain repository-declared ignored tests);
  - `pre-commit run --all-files`: passed;
  - `git diff --check`: passed.

- Post-completion audit repeated the 15-case matrix, JSON/exit-policy checks, diagnostics tests, and broad workspace gates. One unbounded workspace rerun hit macOS `EAGAIN`/`WouldBlock` while an unchanged MCP test created a thread. That exact test then passed 3/3 times at the PR head and 1/1 on unchanged main; the complete workspace suite passed with four test threads.

The wheel build was validated on macOS arm64. Linux-only local-mode branches are covered deterministically by the unit and adversarial matrix tests; no live vLLM or GPU is required for this diagnostics-only change.
