### PR TITLE
fix: forward Responses reasoning configuration

### DIFF
--- a/crates/agentic-server-core/benches/executor_throughput.rs
+++ b/crates/agentic-server-core/benches/executor_throughput.rs
@@ -140,6 +140,7 @@ fn make_request(input: &str, stream: bool, prev_id: Option<String>) -> RequestPa
         stream,
         store: true,
         include: None,
+        reasoning: None,
         temperature: None,
         top_p: None,
         max_output_tokens: None,

--- a/crates/agentic-server-core/src/executor/compaction.rs
+++ b/crates/agentic-server-core/src/executor/compaction.rs
@@ -146,6 +146,7 @@ fn request_payload(model: String, input: ResponsesInput, instructions: Option<St
         stream: false,
         store: false,
         include: None,
+        reasoning: None,
         temperature: None,
         top_p: None,
         max_output_tokens: None,

--- a/crates/agentic-server-core/src/executor/modes/conversation.rs
+++ b/crates/agentic-server-core/src/executor/modes/conversation.rs
@@ -160,6 +160,7 @@ mod tests {
             stream: false,
             store: true,
             include: None,
+            reasoning: None,
             temperature: None,
             top_p: None,
             max_output_tokens: None,

--- a/crates/agentic-server-core/src/executor/modes/response.rs
+++ b/crates/agentic-server-core/src/executor/modes/response.rs
@@ -116,6 +116,7 @@ mod tests {
             stream: false,
             store: true,
             include: None,
+            reasoning: None,
             temperature: None,
             top_p: None,
             max_output_tokens: None,

--- a/crates/agentic-server-core/src/executor/rehydrate.rs
+++ b/crates/agentic-server-core/src/executor/rehydrate.rs
@@ -336,6 +336,7 @@ mod tests {
             stream: false,
             store: true,
             include: None,
+            reasoning: None,
             temperature: None,
             top_p: None,
             max_output_tokens: None,

--- a/crates/agentic-server-core/src/executor/upstream.rs
+++ b/crates/agentic-server-core/src/executor/upstream.rs
@@ -314,6 +314,7 @@ mod tests {
             stream: true,
             store: false,
             include: None,
+            reasoning: None,
             temperature: None,
             top_p: None,
             max_output_tokens: None,

--- a/crates/agentic-server-core/src/lib.rs
+++ b/crates/agentic-server-core/src/lib.rs
@@ -25,10 +25,10 @@ pub use types::{
     FunctionToolResultMessage, GatewayCallStatus, IncompleteDetails, InputContent, InputFileContent,
     InputFunctionToolCall, InputImageContent, InputItem, InputMessage, InputMessageContent, InputTextContent,
     InputTokenDetails, McpCall, McpCallStatus, McpToolParam, NonEmptyToolName, OutputItem, OutputMessage,
-    OutputTextContent, OutputTokenDetails, ReasoningOutput, ReasoningTextContent, RequestPayload, ResponsePayload,
-    ResponseUsage, ResponsesInput, ResponsesTool, ToolCallOutput, ToolChoice, ToolOutputContent, UpstreamRequest,
-    UpstreamTool, WebSearchAction, WebSearchActionFindInPage, WebSearchActionOpenPage, WebSearchActionSearch,
-    WebSearchCall, WebSearchCallStatus, WebSearchContextSize, WebSearchFilters, WebSearchSource, WebSearchToolParam,
-    WebSearchUserLocation,
+    OutputTextContent, OutputTokenDetails, ReasoningConfig, ReasoningOutput, ReasoningTextContent, RequestPayload,
+    ResponsePayload, ResponseUsage, ResponsesInput, ResponsesTool, ToolCallOutput, ToolChoice, ToolOutputContent,
+    UpstreamRequest, UpstreamTool, WebSearchAction, WebSearchActionFindInPage, WebSearchActionOpenPage,
+    WebSearchActionSearch, WebSearchCall, WebSearchCallStatus, WebSearchContextSize, WebSearchFilters, WebSearchSource,
+    WebSearchToolParam, WebSearchUserLocation,
 };
 pub use utils::{utcnow_str, uuid7_str};

--- a/crates/agentic-server-core/src/types/mod.rs
+++ b/crates/agentic-server-core/src/types/mod.rs
@@ -15,8 +15,8 @@ pub use io::{
     WebSearchSource,
 };
 pub use request_response::{
-    CompactRequest, CompactedResponse, ContextManagement, IncompleteDetails, RequestPayload, ResponsePayload,
-    UpstreamRequest, UpstreamTool,
+    CompactRequest, CompactedResponse, ContextManagement, IncompleteDetails, ReasoningConfig, RequestPayload,
+    ResponsePayload, UpstreamRequest, UpstreamTool,
 };
 pub use tools::{
     CodeInterpreterToolParam, CodexNamespaceMember, CodexNamespaceToolParam, CustomToolParam, EmptyToolNameError,

--- a/crates/agentic-server-core/src/types/request_response.rs
+++ b/crates/agentic-server-core/src/types/request_response.rs
@@ -92,6 +92,7 @@ pub struct UpstreamRequest<'a> {
     pub metadata: Option<&'a Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parallel_tool_calls: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_salt: Option<&'a str>,
 }
 
@@ -349,7 +350,18 @@ mod tests {
     }
 
     #[test]
-    fn request_payload_forwards_cache_salt_upstream() {
+    fn request_payload_omits_absent_and_forwards_present_cache_salt_upstream() {
+        let payload: RequestPayload = serde_json::from_value(serde_json::json!({
+            "model": "test-model",
+            "input": "hello"
+        }))
+        .expect("request should deserialize");
+
+        let upstream = serde_json::to_value(payload.to_upstream_request(false).expect("request should normalize"))
+            .expect("upstream request should serialize");
+
+        assert!(upstream.get("cache_salt").is_none());
+
         let payload: RequestPayload = serde_json::from_value(serde_json::json!({
             "model": "test-model",
             "input": "hello",

--- a/crates/agentic-server-core/src/types/request_response.rs
+++ b/crates/agentic-server-core/src/types/request_response.rs
@@ -11,6 +11,21 @@ use super::tools::ResponsesTool;
 use crate::tool::{CodexNamespaceHandler, CustomHandler, ToolError};
 use crate::utils::common::serialize_to_string;
 
+/// Standard Responses API reasoning generation settings.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReasoningConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub generate_summary: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RequestPayload {
     pub model: String,
@@ -26,6 +41,8 @@ pub struct RequestPayload {
     #[serde(default = "default_true")]
     pub store: bool,
     pub include: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning: Option<Box<ReasoningConfig>>,
     pub temperature: Option<f64>,
     pub top_p: Option<f64>,
     pub max_output_tokens: Option<u32>,
@@ -61,6 +78,8 @@ pub struct UpstreamRequest<'a> {
     pub tool_choice: Option<ToolChoice>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub include: Option<&'a Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning: Option<&'a ReasoningConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -155,6 +174,7 @@ impl RequestPayload {
             tools,
             tool_choice: Some(tool_choice),
             include: self.include.as_ref(),
+            reasoning: self.reasoning.as_deref(),
             temperature: self.temperature,
             top_p: self.top_p,
             max_output_tokens: self.max_output_tokens,
@@ -341,6 +361,72 @@ mod tests {
             .expect("upstream request should serialize");
 
         assert_eq!(upstream["cache_salt"], "tenant-a");
+    }
+
+    #[test]
+    fn request_payload_forwards_reasoning_configuration_upstream() {
+        let reasoning = serde_json::json!({
+            "context": "all_turns",
+            "effort": "high",
+            "generate_summary": "concise",
+            "mode": "pro",
+            "summary": "detailed"
+        });
+        let payload: RequestPayload = serde_json::from_value(serde_json::json!({
+            "model": "test-model",
+            "input": "hello",
+            "reasoning": reasoning
+        }))
+        .expect("request should deserialize");
+
+        for stream in [false, true] {
+            let upstream = serde_json::to_value(payload.to_upstream_request(stream).expect("request should normalize"))
+                .expect("upstream request should serialize");
+
+            assert_eq!(upstream["reasoning"], reasoning);
+            assert_eq!(upstream["stream"], stream);
+        }
+    }
+
+    #[test]
+    fn request_payload_handles_reasoning_boundaries() {
+        for reasoning in [serde_json::json!({}), serde_json::json!({"effort": "minimal"})] {
+            let payload: RequestPayload = serde_json::from_value(serde_json::json!({
+                "model": "test-model",
+                "input": "hello",
+                "reasoning": reasoning
+            }))
+            .expect("valid reasoning object should deserialize");
+            let upstream = serde_json::to_value(payload.to_upstream_request(false).expect("request should normalize"))
+                .expect("upstream request should serialize");
+
+            assert_eq!(upstream["reasoning"], reasoning);
+        }
+
+        for reasoning in [
+            serde_json::Value::Null,
+            serde_json::json!("high"),
+            serde_json::json!({"effort": 3}),
+        ] {
+            let parsed = serde_json::from_value::<RequestPayload>(serde_json::json!({
+                "model": "test-model",
+                "input": "hello",
+                "reasoning": reasoning
+            }));
+
+            if reasoning.is_null() {
+                let upstream = serde_json::to_value(
+                    parsed
+                        .expect("null should be treated as absent")
+                        .to_upstream_request(false)
+                        .expect("request should normalize"),
+                )
+                .expect("upstream request should serialize");
+                assert!(upstream.get("reasoning").is_none());
+            } else {
+                assert!(parsed.is_err(), "non-object reasoning configuration should be rejected");
+            }
+        }
     }
 
     #[test]

--- a/crates/agentic-server-core/tests/cassettes/README.md
+++ b/crates/agentic-server-core/tests/cassettes/README.md
@@ -217,18 +217,24 @@ handling from model differences. Use `REASONING_RECORD_SET=gateway`,
 `REASONING_RECORD_SET=openai`, or `REASONING_RECORD_SET=vllm` to record one
 provider. The gateway recording requires a running gateway and reasoning-capable
 upstream; the optional direct-vLLM set retains the legacy accumulator workflow.
+Every selected recording is staged and validated before any final fixture is
+replaced, so a failed provider or response cannot leave a partially refreshed
+comparison set.
 
 ```bash
-OPENAI_API_KEY=sk-... \
-bash crates/agentic-server-core/tests/cassettes/record_reasoning_cassettes.sh
-
 # Start the gateway against the same OpenAI ground-truth model in one terminal.
 OPENAI_API_KEY=sk-... \
 cargo run -p agentic-server -- \
   --llm-api-base https://api.openai.com \
   --skip-llm-ready-check
 
-# Record the gateway-facing pair from another terminal.
+# Record the OpenAI-reference and gateway pairs from another terminal.
+OPENAI_API_KEY=sk-... \
+GATEWAY_URL=http://localhost:9000 \
+MODEL=gpt-5.6 \
+bash crates/agentic-server-core/tests/cassettes/record_reasoning_cassettes.sh
+
+# To refresh only the gateway-facing pair instead:
 REASONING_RECORD_SET=gateway \
 GATEWAY_URL=http://localhost:9000 \
 MODEL=gpt-5.6 \

--- a/crates/agentic-server-core/tests/cassettes/README.md
+++ b/crates/agentic-server-core/tests/cassettes/README.md
@@ -83,6 +83,7 @@ model requested by Codex 0.149.1.
 --openai URL           OpenAI upstream (default https://api.openai.com)
 --tools FILE           JSON file containing a tools array (responses mode only)
 --tool-choice VALUE    "auto", "none", "required", or JSON e.g. '{"type":"function","name":"foo"}'
+--reasoning JSON       JSON object containing Responses reasoning settings
 --input-file FILE       JSON string or item array for one HTTP Responses turn
 --max-output-tokens N  max_output_tokens for Responses requests (default 1024; use 0 to omit)
 --proxy-port PORT      Local proxy port (default 7070)
@@ -192,7 +193,7 @@ turns:
 | Script | Cassettes | Backend |
 |--------|-----------|---------|
 | `record_text_only_cassettes.sh` | 10 text-only cassettes (responses + conv modes, streaming + non-streaming) | OpenAI (`OPENAI_API_KEY`) |
-| `record_reasoning_cassettes.sh` | 2 reasoning cassettes (single turn, streaming + non-streaming) | vLLM |
+| `record_reasoning_cassettes.sh` | Matching explicit-reasoning cassettes (streaming + non-streaming) | gateway and OpenAI reference; optional direct vLLM |
 | `record_tool_call_cassettes.sh` | 8 tool-call cassettes (4 tool_choice modes x streaming + non-streaming) | vLLM |
 | `record_codex_cli_tool_call_cassettes.sh` | Codex function/namespace/custom-tool matrix | gateway, vLLM, and OpenAI |
 | `record_custom_tool_cassettes.sh` | Matching two-turn custom-tool flows (streaming + non-streaming) | gateway and OpenAI reference |
@@ -207,12 +208,38 @@ OPENAI_API_KEY=sk-... bash tests/cassettes/record_text_only_cassettes.sh
 MODEL=gpt-4o-mini OPENAI_API_KEY=sk-... bash tests/cassettes/record_text_only_cassettes.sh
 ```
 
-### Reasoning (vLLM)
+### Reasoning (gateway and OpenAI)
+
+The default records the same explicit `reasoning` object against OpenAI and the
+gateway for both response modes. The gateway fixture uses the same OpenAI model
+as its reference so the comparison isolates gateway request and response
+handling from model differences. Use `REASONING_RECORD_SET=gateway`,
+`REASONING_RECORD_SET=openai`, or `REASONING_RECORD_SET=vllm` to record one
+provider. The gateway recording requires a running gateway and reasoning-capable
+upstream; the optional direct-vLLM set retains the legacy accumulator workflow.
 
 ```bash
-vllm serve Qwen/Qwen3-30B-A3B-FP8 --reasoning-parser deepseek_r1 --port 5050 > server.log 2>&1
+OPENAI_API_KEY=sk-... \
+bash crates/agentic-server-core/tests/cassettes/record_reasoning_cassettes.sh
 
-VLLM_URL=http://0.0.0.0:5050 MODEL=Qwen/Qwen3-30B-A3B-FP8 bash tests/cassettes/record_reasoning_cassettes.sh
+# Start the gateway against the same OpenAI ground-truth model in one terminal.
+OPENAI_API_KEY=sk-... \
+cargo run -p agentic-server -- \
+  --llm-api-base https://api.openai.com \
+  --skip-llm-ready-check
+
+# Record the gateway-facing pair from another terminal.
+REASONING_RECORD_SET=gateway \
+GATEWAY_URL=http://localhost:9000 \
+MODEL=gpt-5.6 \
+bash crates/agentic-server-core/tests/cassettes/record_reasoning_cassettes.sh
+
+vllm serve Qwen/Qwen3-30B-A3B-FP8 --reasoning-parser qwen3 --port 5050 > server.log 2>&1
+
+REASONING_RECORD_SET=vllm \
+VLLM_URL=http://0.0.0.0:5050 \
+MODEL=Qwen/Qwen3-30B-A3B-FP8 \
+bash crates/agentic-server-core/tests/cassettes/record_reasoning_cassettes.sh
 ```
 
 ### Tool calls (vLLM)

--- a/crates/agentic-server-core/tests/cassettes/reasoning/responses/reasoning-gateway-gpt-5.6-nonstreaming.yaml
+++ b/crates/agentic-server-core/tests/cassettes/reasoning/responses/reasoning-gateway-gpt-5.6-nonstreaming.yaml
@@ -1,0 +1,69 @@
+turns:
+- filename: t1
+  request:
+    body:
+      input: 'Determine whether 47 is the unique two-digit positive integer whose
+        digits sum to 11 and whose reversal is 27 larger. Analyze the constraints,
+        then reply with exactly one word: VALID or INVALID.'
+      max_output_tokens: 2048
+      model: gpt-5.6
+      reasoning:
+        effort: high
+        summary: detailed
+      store: true
+      stream: false
+    headers:
+      accept: '*/*'
+      content-type: application/json
+      user-agent: python-httpx/0.28.1
+    method: POST
+    path: /v1/responses
+    query_params: {}
+  response:
+    body:
+      conversation_id: null
+      created_at: 1788233732
+      error: null
+      id: resp_01a05b09-454e-7110-afc5-8d6d90c90c2d
+      incomplete_details: null
+      instructions: null
+      model: gpt-5.6
+      object: response
+      output:
+      - content: []
+        encrypted_content: gAAAAABqlkgE9_uH9lHgSl9RO8LgROqmAnX3KoBV4xyxBl6RQwwPI272Xqua6nOcCIY7BsJ7wbQLAGu3sPFiXUF0Jautjx_OxVZuueVDRqdDnbp8NaSSiumb7uUWVDa3PLVPGBqC6FthXUPaGn7A9sPFNqgpvG8TBZAX7NBM9wjC47j70L_YizvFLCX_gmCcJu0hDaieDI4gEVKS6LcPY4OY6c1MArI3nfegpwQaWnuV5BzFYcTYpejIzjwVTePYnXRHu-Cxby1LvGejKuKGQWz3NMeVa70E8AqjUOXaMI11EiRfcVm0Qjxt3xIgoVQV9-O-VCQsKaX0LXzZC5oGNrN-yvb7sSW_Ha7iay2SCo3U06juTAySLdlgQZgLgWw8SwaCS1GjQ8s0QBlb-jBhuZviAP1tK_OjFP5AcpfFpK8YyWyQq6K1vpM9OG045gQjVngHNvimvOtTLOulG5DPgE6Pi_f0eQst2MZTUCUopozTLDI-_7MkwZd4-UY-wNgcbaYY3e0a6mxDejZQyOMKxGY3CfnqZcM4bb5MhP4bYGVtJIOPgx0FqLcSepnCyaKIsgnDo9qRiH0ANwJVygP-o6CuJ_Z4ApgknPyt881_eoGymfD3_U2mtTFUNFe5yJzZ8H9WBXSnPKm6GmmHPVxltxPJGs9yOjqMIS_yisO16qahmQfTYofxI1Z9rBlTm-AG_nK_SsjqDiFq71dvhhM4aIbTsLbwYfGIIR_PGpiKBehlzInzvtYKSDQoV98H7bThrqr7kE-k3MOZtnjdO7hO1aEwRZY2uGL0Nc6h2vPKMVWnFDfbHI9kmB8F8z2xhlvqPlyMbnRw1hKpDPrmDjsSwADebnAKR6xc5LtT7JKtCiBDyRsqplnnoKae89gN8IUR71_k8TVcXzu4Lc_8aoDj185J-X6ablejv00enoXUkXamcivKHK1na-Z3v-_4MCPWRjKr7129OX5eGH3KBcYNjOSuCp-VLGCCZN4f6ijpTVC2Rn9PrBtTgNb6ePViP4zMAqyyXvdjjBzckhRBape3KEhbhi2_daqQ3NB7iqUTsOteArpjHWt4avfFzWUcCT-MrcsKRSVIpznlCoRfPCzbXd7BSjktRakp2Kk0aahshPep9AtEDdLQUNoEdwCUvyPObFMfizB0kjjhm_6K6aLms--UmWiZUu-Rxo39MpMjUcYEgrS1fepZSscGKwReJjsk6NPA_2HqbS7V6YVpm3Qndny5T5FgAi3T-0pmQ_PJfw1bgp1r1MDkeuB0KrFcc6NVGZtoDqFDn26Xin6Ulue9bFmN862wC26N8GbA8IgexqeI9YE74cbhrPD5kD-VtQQT9yXqHSwXU31JE33WKFxUSoeYxS-tBhja4Nhu3Cjpgm07YNbUQCxLStY=
+        id: rs_07c629dd4fdf1933006a964802ba4c87d2b46819f32237a6ee
+        status: null
+        summary:
+        - text: '**Solving a math problem**
+
+
+            I need to work through this math problem involving two digits. Let’s define
+            the number as 10a + b, where a + b = 11. If I reverse the digits, it becomes
+            10b + a, which is 27 more than the original. So, I set up the equation:
+            10b + a = 10a + b + 27. From there, I simplify and find that b - a = 3.
+            Adding the two original digits gives me 2b = 14, so b equals 7 and a equals
+            4. It''s unique, and I’ll respond with exactly “VALID.”'
+          type: summary_text
+        type: reasoning
+      - content:
+        - annotations: []
+          text: VALID
+          type: output_text
+        id: msg_07c629dd4fdf1933006a964804b69087d2b21afe11a7cbe4a4
+        role: assistant
+        status: completed
+        type: message
+      previous_response_id: null
+      status: completed
+      usage:
+        input_tokens: 46
+        input_tokens_details:
+          cached_tokens: 0
+        output_tokens: 78
+        output_tokens_details:
+          reasoning_tokens: 71
+        total_tokens: 124
+    headers:
+      content-type: application/json
+    status_code: 200

--- a/crates/agentic-server-core/tests/cassettes/reasoning/responses/reasoning-gateway-gpt-5.6-streaming.yaml
+++ b/crates/agentic-server-core/tests/cassettes/reasoning/responses/reasoning-gateway-gpt-5.6-streaming.yaml
@@ -1,0 +1,1439 @@
+turns:
+- filename: t1
+  request:
+    body:
+      input: 'Determine whether 47 is the unique two-digit positive integer whose
+        digits sum to 11 and whose reversal is 27 larger. Analyze the constraints,
+        then reply with exactly one word: VALID or INVALID.'
+      max_output_tokens: 2048
+      model: gpt-5.6
+      reasoning:
+        effort: high
+        summary: detailed
+      store: true
+      stream: true
+    headers:
+      accept: '*/*'
+      content-type: application/json
+      user-agent: python-httpx/0.28.1
+    method: POST
+    path: /v1/responses
+    query_params: {}
+  response:
+    headers:
+      content-type: text/event-stream; charset=utf-8
+    sse:
+    - 'event: response.created
+
+      '
+    - 'data: {"type":"response.created","sequence_number":0,"response":{"background":false,"completed_at":null,"created_at":1788233724,"error":null,"frequency_penalty":0.0,"id":"resp_01a05b09-3062-7b32-8706-8e8a8b47def2","incomplete_details":null,"instructions":null,"max_output_tokens":2048,"max_tool_calls":null,"metadata":{},"model":"gpt-5.6-sol","moderation":null,"object":"response","output":[],"parallel_tool_calls":false,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"all_turns","effort":"high","mode":"standard","summary":"detailed"},"safety_identifier":null,"service_tier":"auto","status":"in_progress","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null}}
+
+      '
+    - '
+
+      '
+    - 'event: response.in_progress
+
+      '
+    - 'data: {"type":"response.in_progress","sequence_number":1,"response":{"background":false,"completed_at":null,"created_at":1788233724,"error":null,"frequency_penalty":0.0,"id":"resp_01a05b09-3062-7b32-8706-8e8a8b47def2","incomplete_details":null,"instructions":null,"max_output_tokens":2048,"max_tool_calls":null,"metadata":{},"model":"gpt-5.6-sol","moderation":null,"object":"response","output":[],"parallel_tool_calls":false,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"all_turns","effort":"high","mode":"standard","summary":"detailed"},"safety_identifier":null,"service_tier":"auto","status":"in_progress","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null}}
+
+      '
+    - '
+
+      '
+    - 'event: response.output_item.added
+
+      '
+    - 'data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"content":[],"encrypted_content":"gAAAAABqlkf9lrz1baDiwPcPKFwXZCGoR484KkLBIzkaw53tORP88BhzpE8RYSqDBOQm60U6itT5sPVLlKCzFQ6cLS2kytxdJrm37dBOTU8dCJ4z_CYV6sW62KpckhNZjdVFCslhiCPvNsNIcBDAP2M5bgPaCsAvfbpkv3qCDjxucdVlXUC3X43AgJyFEysMrtNngCC0fRKPKTOjbrql6CN8SF8zuzUEe7fUyfdUflSoa9Y09jaEcT6Gg5Re-siqiovkiD9FXabkjgk1zhADHSGvPQrp4uVflM2aw5ctOSF7VXDg_St4_iy5_6_yxBzxkaUXO7EipTw1XaEzdR43HhwWudScT2XEvgraQmDxYBNwBav1xxdOXz0J7Hb6Py_nMHGS9VNxa58jj9Nx9Sk8kOhdxsS72EROh5mwthaOIR5w1iMTybISvCWwR41hxR2BM0T4scgN90j5HbiFiWSGsYZNTaUsvDCHX7MtmPQixcPRorCbRPslk_yRCBBq3xIsD69JqltNp9ipeaU5bEttMy52-aPdjU4IgawFl6L-2BT-ojXC4jPw1myD75L1bJ-dsNUCt9RGsoVA9PTdesmdRoC-MoVvpPP6qHfYVnyNfbTvaQ7QneXhAP8-EqNU4xEXcojnOpLVkRxvg80A7L2ypMElyQoymMDLdKPiH-TuD7arxgd9ysQulyUsviMG7vhf6QasL5INWTaqCc2KZn4MnVzAj8pgbDpOkWoeV-Ad_2GA7Vh6EvmZjBkiwkEK3jVWa3y-hHRiUZS7b9pgbIja9FCkODz-ddjo4oz-KYIZhOMoimA_BaMA7weNXKuqK2ql9B5SrKS9TlPTsKVPbijUepnZscvIinlX6Gdum-pbL7ubrFav84x7zP4Oop_hOAW6WlOg6bq8WmxYpLlHdLLXx9tqQhtCi1vyY1mTNWGvMebGTbSUMiXzjcN0b5_ifmFbprRQFUMDV-6LZjWibk7it8RWx5R0GOtiumPA6ahkml1AQGtdok74rP5dOn-wY2IGAXMODt-eGm0E_Qz9u0XWi27F_QoOma_H8qZF7yz_-nUgjvoAZlLV7pLU-o5q2Cf9b2C40E-s0bVhovC0EByu8YP_Gg88GA2-mZNtkAAkc8oi2APlM0hj5d-ELvKV3ixIPvXZkb3heFDTTho73aBV7NGmfWx2NOoD9A==","id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","summary":[],"type":"reasoning"}}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_part.added
+
+      '
+    - 'data: {"type":"response.reasoning_summary_part.added","sequence_number":3,"output_index":0,"item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","part":{"text":"","type":"summary_text"},"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":4,"output_index":0,"delta":"**Analyzing
+      a unique problem**\n\nI","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"5HuklGHJRLDPNAU","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":5,"output_index":0,"delta":"
+      need","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"PDB9N2BhKIc","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":6,"output_index":0,"delta":"
+      to","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"5i5PagLMxxXtQ","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":7,"output_index":0,"delta":"
+      analyze","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"o0Aw3yRL","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":8,"output_index":0,"delta":"
+      a","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"oYVcFLl5fptRd0","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":9,"output_index":0,"delta":"
+      mathematical","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"Bsg","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":10,"output_index":0,"delta":"
+      relationship","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"SR5","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":11,"output_index":0,"delta":".","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"EiPaT7bRggJwmJ5","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":12,"output_index":0,"delta":"
+      Let","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"fBMhhp953ZIC","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":13,"output_index":0,"delta":"’s","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"oiVmbQiaohFRMs","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":14,"output_index":0,"delta":"
+      take","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"BZyd1bNFm85","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":15,"output_index":0,"delta":"
+      the","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"4R7gBcV67qrD","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":16,"output_index":0,"delta":"
+      number","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"5m10cyZ09","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":17,"output_index":0,"delta":"
+      as","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"vJP9Oop3jsOsD","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":18,"output_index":0,"delta":"
+      10","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"TGsHlKJ3u03lv","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":19,"output_index":0,"delta":"a","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"vkSZVhby8Q7Nk8s","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":20,"output_index":0,"delta":"
+      +","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"9ohS8jlbRpvcun","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":21,"output_index":0,"delta":"
+      b","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"DcuSaBmaurrvsS","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":22,"output_index":0,"delta":",","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"QGGrFKLZ97ITH7b","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":23,"output_index":0,"delta":"
+      which","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"IbNKmvljCP","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":24,"output_index":0,"delta":"
+      sums","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"237ljucvzLH","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":25,"output_index":0,"delta":"
+      to","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"DUG2R5OlsVkif","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":26,"output_index":0,"delta":"
+      11","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"Apwkc21BrnKe5","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":27,"output_index":0,"delta":".","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"c0R1P8zos5CxeiA","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":28,"output_index":0,"delta":"
+      When","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"wC5YjgDaZGL","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":29,"output_index":0,"delta":"
+      I","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"37d0zAqGexcndf","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":30,"output_index":0,"delta":"
+      reverse","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"iUPtJdkc","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":31,"output_index":0,"delta":"
+      it","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"yjGbqKpd24gSw","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":32,"output_index":0,"delta":"
+      to","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"P5j1QOW3hXIzf","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":33,"output_index":0,"delta":"
+      10","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"tMKwjNcBIqhlr","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":34,"output_index":0,"delta":"b","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"8lLBBbKDP9wTzPD","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":35,"output_index":0,"delta":"
+      +","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"DoA7Vt9OMFq2bt","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":36,"output_index":0,"delta":"
+      a","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"iogV92UOAkeYFl","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":37,"output_index":0,"delta":",","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"qUruUqFhaDpDmYo","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":38,"output_index":0,"delta":"
+      it","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"jWV0ptdFAnJgn","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":39,"output_index":0,"delta":"’s","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"BTuqwnYPlvtuUO","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":40,"output_index":0,"delta":"
+      stated","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"SqPg3YuZD","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":41,"output_index":0,"delta":"
+      to","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"Xd4saB2yjy4Qx","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":42,"output_index":0,"delta":"
+      be","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"odM545qYKyNuO","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":43,"output_index":0,"delta":"
+      27","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"nluA4d5Ez0tv7","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":44,"output_index":0,"delta":"
+      larger","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"i79D2j3dl","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":45,"output_index":0,"delta":".","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"dDr3rU0EdtRk7o3","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":46,"output_index":0,"delta":"
+      This","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"sAHSKsOufg3","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":47,"output_index":0,"delta":"
+      leads","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"Nmyaz4D9Jv","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":48,"output_index":0,"delta":"
+      me","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"WCrMDnICHAqQd","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":49,"output_index":0,"delta":"
+      to","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"b5ZIwCQsurOqr","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":50,"output_index":0,"delta":"
+      set","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"PvewmAYy0slZ","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":51,"output_index":0,"delta":"
+      up","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"3wHEtBsUCT0cQ","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":52,"output_index":0,"delta":"
+      the","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"ydRm63pl0PUx","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":53,"output_index":0,"delta":"
+      equation","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"fto2ZCA","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":54,"output_index":0,"delta":"
+      10","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"Ab5jS5u6SO8nh","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":55,"output_index":0,"delta":"b","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"AQbzZ6lTUh6m3Jh","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":56,"output_index":0,"delta":"
+      +","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"vcbeuTW5ljkvgp","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":57,"output_index":0,"delta":"
+      a","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"INKTa1ASjyrZij","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":58,"output_index":0,"delta":"
+      =","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"iine8LsDx7SQd2","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":59,"output_index":0,"delta":"
+      10","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"VyrgAbHxoUjWH","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":60,"output_index":0,"delta":"a","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"lw9V7Lq2R4VGRnR","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":61,"output_index":0,"delta":"
+      +","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"RCfMQFC1xgnYut","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":62,"output_index":0,"delta":"
+      b","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"mk5HSE7m3Kg30L","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":63,"output_index":0,"delta":"
+      +","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"T5Q1JxIFh4rs1L","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":64,"output_index":0,"delta":"
+      27","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"FuEEqz7cJ4J7x","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":65,"output_index":0,"delta":".","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"nmmttJuEZuAA8Vq","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":66,"output_index":0,"delta":"
+      From","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"hgtLwo11oCm","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":67,"output_index":0,"delta":"
+      simplifying","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"zadk","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":68,"output_index":0,"delta":",","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"FH7kXA6Oy3KJWBI","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":69,"output_index":0,"delta":"
+      I","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"ZsUJbAWqazcjLA","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":70,"output_index":0,"delta":"
+      find","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"1PwbuzMXwaU","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":71,"output_index":0,"delta":"
+      that","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"xsoBiOGfAUR","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":72,"output_index":0,"delta":"
+      9","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"kvoXlsdgCgQeDO","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":73,"output_index":0,"delta":"(b","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"kZlph1k8SgEvCO","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":74,"output_index":0,"delta":"
+      -","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"xunq51d0IXAmiM","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":75,"output_index":0,"delta":"
+      a","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"1tY1Ve89J7HAOZ","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":76,"output_index":0,"delta":")","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"ZwnuYp0degSjOo2","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":77,"output_index":0,"delta":"
+      =","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"NSTO1t6PmJuqix","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":78,"output_index":0,"delta":"
+      27","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"bfI3NXJiuCp60","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":79,"output_index":0,"delta":",","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"b56NtGGs43HZUmG","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":80,"output_index":0,"delta":"
+      which","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"PvpIc4BY4M","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":81,"output_index":0,"delta":"
+      gives","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"y2ndBBkKR6","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":82,"output_index":0,"delta":"
+      me","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"XcH18863aodVF","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":83,"output_index":0,"delta":"
+      b","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"XvReal4HBSVzd8","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":84,"output_index":0,"delta":"
+      -","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"4OuPwhdVD9tAqU","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":85,"output_index":0,"delta":"
+      a","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"h6AGkNlyV5YSEh","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":86,"output_index":0,"delta":"
+      =","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"tMBBvzkMqHCK7N","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":87,"output_index":0,"delta":"
+      3","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"XTJD4I7t331pTt","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":88,"output_index":0,"delta":".","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"hkcRbGLF6w2Vm0K","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":89,"output_index":0,"delta":"
+      \n\nThen","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"35g3txA61","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":90,"output_index":0,"delta":"
+      I","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"3tAE5hG33BUrSt","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":91,"output_index":0,"delta":"
+      get","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"rpagDIbiYWEW","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":92,"output_index":0,"delta":"
+      2","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"88r9QBHADkPK3S","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":93,"output_index":0,"delta":"b","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"gPQhzCdizcXNSAX","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":94,"output_index":0,"delta":",","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"NWectYgQnZ5bk2f","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":95,"output_index":0,"delta":"
+      and","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"sAvqcfb4k2qo","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":96,"output_index":0,"delta":"
+      since","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"kFbVlaoK0V","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":97,"output_index":0,"delta":"
+      a","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"r1h0cvKu4bAaeT","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":98,"output_index":0,"delta":"
+      +","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"sTHDKkLB2TgWQR","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":99,"output_index":0,"delta":"
+      b","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"lApRNIb4U0HGwC","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":100,"output_index":0,"delta":"
+      =","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"Uwv8PDSqJ2ILei","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":101,"output_index":0,"delta":"
+      11","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"SiV1AI6mRG1qd","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":102,"output_index":0,"delta":"
+      with","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"a0n5TEVdpdV","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":103,"output_index":0,"delta":"
+      b","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"smckbK1RhYoLO6","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":104,"output_index":0,"delta":"
+      =","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"KT5EUxOSJ91rZ4","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":105,"output_index":0,"delta":"
+      a","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"KkfVUCQVcxmRjT","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":106,"output_index":0,"delta":"
+      +","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"uW4XiXue6JPLwi","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":107,"output_index":0,"delta":"
+      3","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"7MYjtqOeHijHLa","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":108,"output_index":0,"delta":",","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"oS0dV4jejyzsPWU","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":109,"output_index":0,"delta":"
+      I","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"cklLqxsr8aYpxA","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":110,"output_index":0,"delta":"
+      solve","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"rN0m2AXwHe","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":111,"output_index":0,"delta":"
+      to","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"u6aDda5IfvL9S","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":112,"output_index":0,"delta":"
+      find","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"Cr2zsxtR7uN","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":113,"output_index":0,"delta":"
+      a","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"Myxj0V0waBh1Vz","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":114,"output_index":0,"delta":"
+      =","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"62Fv2eHcuLQQme","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":115,"output_index":0,"delta":"
+      4","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"CCZPvmPCJsap6J","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":116,"output_index":0,"delta":"
+      and","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"kDYYTmOdNNe9","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":117,"output_index":0,"delta":"
+      b","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"w0Y8rCVw8j4gdG","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":118,"output_index":0,"delta":"
+      =","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"xC59B6ayxw9rP2","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":119,"output_index":0,"delta":"
+      7","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"SxoqVbwVHqA6sG","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":120,"output_index":0,"delta":".","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"U4d3RPd7VUaYZhK","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":121,"output_index":0,"delta":"
+      It","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"1uu6eYAuIwZmR","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":122,"output_index":0,"delta":"
+      feels","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"h9Jjv8Gifv","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":123,"output_index":0,"delta":"
+      unique","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"VegkI54tR","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":124,"output_index":0,"delta":",","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"GvYZk4YHJjrEnFN","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":125,"output_index":0,"delta":"
+      and","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"N4B1eKpf270B","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":126,"output_index":0,"delta":"
+      everything","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"YpwKI","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":127,"output_index":0,"delta":"
+      checks","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"dkz1MMFV9","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":128,"output_index":0,"delta":"
+      out","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"dFbEYyQEPPvZ","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":129,"output_index":0,"delta":"
+      as","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"33vWrrwTaEl24","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":130,"output_index":0,"delta":"
+      valid","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"DtD2ffS1U8","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","sequence_number":131,"output_index":0,"delta":".","item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","obfuscation":"DVCkcNXgFj1zaGr","summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.done
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.done","sequence_number":132,"output_index":0,"item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","summary_index":0,"text":"**Analyzing
+      a unique problem**\n\nI need to analyze a mathematical relationship. Let’s take
+      the number as 10a + b, which sums to 11. When I reverse it to 10b + a, it’s
+      stated to be 27 larger. This leads me to set up the equation 10b + a = 10a +
+      b + 27. From simplifying, I find that 9(b - a) = 27, which gives me b - a =
+      3. \n\nThen I get 2b, and since a + b = 11 with b = a + 3, I solve to find a
+      = 4 and b = 7. It feels unique, and everything checks out as valid."}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_part.done
+
+      '
+    - 'data: {"type":"response.reasoning_summary_part.done","sequence_number":133,"output_index":0,"item_id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","part":{"text":"**Analyzing
+      a unique problem**\n\nI need to analyze a mathematical relationship. Let’s take
+      the number as 10a + b, which sums to 11. When I reverse it to 10b + a, it’s
+      stated to be 27 larger. This leads me to set up the equation 10b + a = 10a +
+      b + 27. From simplifying, I find that 9(b - a) = 27, which gives me b - a =
+      3. \n\nThen I get 2b, and since a + b = 11 with b = a + 3, I solve to find a
+      = 4 and b = 7. It feels unique, and everything checks out as valid.","type":"summary_text"},"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.output_item.done
+
+      '
+    - 'data: {"type":"response.output_item.done","sequence_number":134,"output_index":0,"item":{"content":[],"encrypted_content":"gAAAAABqlkf_AGUxfbPoDIzLf4m1h7vTpeSWLa4wC8BwJ8Lfm2uIZpe4vTuU-rTCGB96sh1y7SN_VkR6YTejqpaGqluhKhZsTGNE78IR7BeZEB4itQ0_3FiwpdPO1SUTu8GZNNPPbeSPsFSCinU9PJCZ3LBxEupcN3u0UT6jqH-Y_f9lZ-dm-WiNR7dfeo5abPohB1KwkS3uzhfGjqBjtoXP00x4SxqusZkmglxmLf6vNCXWNSuhx2xtH21qFcq-IOWs0DLxrys5uYOqtZJDbJvDEg9Ebq6FohRDxLgcDncE6b43zap6uMqqvRE3kKfTpdkB6tojPdFFb_3bkSfBjL-tsK-d2cEZLEqgRd-QtLEIrE_vsTTy8RNiQ9MgMDMWKYntMvdP-4vMsTiX-4F2YD72A60cv_Dqtql5ED7nBjVGvMmKrU_3XdlvjfJf2hUxqaqApTjf3lPeD8WjPE7a2EgwM1NI5scy97q800moLPxM3-daCJxMkWCnBUXz0KopQuAlIIbyjn6NgJvmWM2KMOxs94T1SmGG0SLKY1wIZ0s6t3BaA4mJbdP35KJoFw5lY7A8O6kEemtNRDY1HBhbtnxweN4QOr37yFruDSVXoPnoOaG-aHo_-FwIojopwSPillRLKiHYsLmaOlUUKyvPOV44-XbxKsjS_-D7wz7cqbF7u99fQwL2kcmrbyv10yVR0S0zZRNIkvYiNmcplm1TiJTri4Mxfi1rnqizOqiEiOPsG2pl-pLkHArIKxUAFC0nEejEOmymrhr92PQZUAFUEJiveEfpX72Z5FNEZf4rQqZVb3keSsQh6fos3wpHdTMvhNLWVaVF_5PVV72tOLQUb6HjCYZZjanj7mu37_EwG9XszxinSNRsL_h1ZHma5y1lj-lhbOmstoGgx_KWunCJZ77BVqv5iKHLB3UPaCeEjnlqh_F5lErTDO7tUKhxusO27EpsKjAD7OJ1eGDLnEbVqqgVHec6YyWnQqbw49ad05LzAfXdlspGf4QMwf1tDnAx4l-NNqyfY_fQBhEwOckmJTuY5aAlhrERluI9CZVI66AhIHH1ay3to4yP55XVH3AGw-Nzjvm7-ujQyDpNWwuoBBAUngtntQHeao-WTUr8XqbcuAYIKHxJORN4Ye2DspVoaAgrSKZyQClL24EwSABVy9DoscHXI1mGDVGbUxsIMCHtERGDfRcj0KQAZIpkOtCcqz9jwHvDbAVrfbxgfuvtgM9-A_ZkPFMzqWZ-8_ymvPv_4aCItFIt-67WQNdpAbHQQNZJOVJ2vufiQZDKY3-sjflg5Ts4iK6nEoI_M3iJJsyfS60Y75TvCVhiOyVhuNTORyBbPDO04EcADhb-3AZ2c-InvJdt_SMmitLWMOVGnIe459dvAOtKJVajr5bMF8bpcB-QtPZ1fBwGPeOjRIC6n2HC7IgQLWL00w==","id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","summary":[{"text":"**Analyzing
+      a unique problem**\n\nI need to analyze a mathematical relationship. Let’s take
+      the number as 10a + b, which sums to 11. When I reverse it to 10b + a, it’s
+      stated to be 27 larger. This leads me to set up the equation 10b + a = 10a +
+      b + 27. From simplifying, I find that 9(b - a) = 27, which gives me b - a =
+      3. \n\nThen I get 2b, and since a + b = 11 with b = a + 3, I solve to find a
+      = 4 and b = 7. It feels unique, and everything checks out as valid.","type":"summary_text"}],"type":"reasoning"}}
+
+      '
+    - '
+
+      '
+    - 'event: response.output_item.added
+
+      '
+    - 'data: {"type":"response.output_item.added","sequence_number":135,"output_index":1,"item":{"content":[],"id":"msg_0e8c30f7b7262587006a9647ffabec87d281e7996510857303","phase":"final_answer","role":"assistant","status":"in_progress","type":"message"}}
+
+      '
+    - '
+
+      '
+    - 'event: response.content_part.added
+
+      '
+    - 'data: {"type":"response.content_part.added","sequence_number":136,"output_index":1,"content_index":0,"item_id":"msg_0e8c30f7b7262587006a9647ffabec87d281e7996510857303","part":{"annotations":[],"logprobs":[],"text":"","type":"output_text"}}
+
+      '
+    - '
+
+      '
+    - 'event: response.output_text.delta
+
+      '
+    - 'data: {"type":"response.output_text.delta","sequence_number":137,"output_index":1,"content_index":0,"delta":"VALID","item_id":"msg_0e8c30f7b7262587006a9647ffabec87d281e7996510857303","logprobs":[],"obfuscation":"jy6u42bwHyJ"}
+
+      '
+    - '
+
+      '
+    - 'event: response.output_text.done
+
+      '
+    - 'data: {"type":"response.output_text.done","sequence_number":138,"output_index":1,"content_index":0,"item_id":"msg_0e8c30f7b7262587006a9647ffabec87d281e7996510857303","logprobs":[],"text":"VALID"}
+
+      '
+    - '
+
+      '
+    - 'event: response.content_part.done
+
+      '
+    - 'data: {"type":"response.content_part.done","sequence_number":139,"output_index":1,"content_index":0,"item_id":"msg_0e8c30f7b7262587006a9647ffabec87d281e7996510857303","part":{"annotations":[],"logprobs":[],"text":"VALID","type":"output_text"}}
+
+      '
+    - '
+
+      '
+    - 'event: response.output_item.done
+
+      '
+    - 'data: {"type":"response.output_item.done","sequence_number":140,"output_index":1,"item":{"content":[{"annotations":[],"logprobs":[],"text":"VALID","type":"output_text"}],"id":"msg_0e8c30f7b7262587006a9647ffabec87d281e7996510857303","phase":"final_answer","role":"assistant","status":"completed","type":"message"}}
+
+      '
+    - '
+
+      '
+    - 'event: response.completed
+
+      '
+    - 'data: {"type":"response.completed","sequence_number":141,"response":{"conversation_id":null,"created_at":1788233728,"error":null,"id":"resp_01a05b09-3062-7b32-8706-8e8a8b47def2","incomplete_details":null,"instructions":null,"model":"gpt-5.6","object":"response","output":[{"content":[],"encrypted_content":"gAAAAABqlkf_AGUxfbPoDIzLf4m1h7vTpeSWLa4wC8BwJ8Lfm2uIZpe4vTuU-rTCGB96sh1y7SN_VkR6YTejqpaGqluhKhZsTGNE78IR7BeZEB4itQ0_3FiwpdPO1SUTu8GZNNPPbeSPsFSCinU9PJCZ3LBxEupcN3u0UT6jqH-Y_f9lZ-dm-WiNR7dfeo5abPohB1KwkS3uzhfGjqBjtoXP00x4SxqusZkmglxmLf6vNCXWNSuhx2xtH21qFcq-IOWs0DLxrys5uYOqtZJDbJvDEg9Ebq6FohRDxLgcDncE6b43zap6uMqqvRE3kKfTpdkB6tojPdFFb_3bkSfBjL-tsK-d2cEZLEqgRd-QtLEIrE_vsTTy8RNiQ9MgMDMWKYntMvdP-4vMsTiX-4F2YD72A60cv_Dqtql5ED7nBjVGvMmKrU_3XdlvjfJf2hUxqaqApTjf3lPeD8WjPE7a2EgwM1NI5scy97q800moLPxM3-daCJxMkWCnBUXz0KopQuAlIIbyjn6NgJvmWM2KMOxs94T1SmGG0SLKY1wIZ0s6t3BaA4mJbdP35KJoFw5lY7A8O6kEemtNRDY1HBhbtnxweN4QOr37yFruDSVXoPnoOaG-aHo_-FwIojopwSPillRLKiHYsLmaOlUUKyvPOV44-XbxKsjS_-D7wz7cqbF7u99fQwL2kcmrbyv10yVR0S0zZRNIkvYiNmcplm1TiJTri4Mxfi1rnqizOqiEiOPsG2pl-pLkHArIKxUAFC0nEejEOmymrhr92PQZUAFUEJiveEfpX72Z5FNEZf4rQqZVb3keSsQh6fos3wpHdTMvhNLWVaVF_5PVV72tOLQUb6HjCYZZjanj7mu37_EwG9XszxinSNRsL_h1ZHma5y1lj-lhbOmstoGgx_KWunCJZ77BVqv5iKHLB3UPaCeEjnlqh_F5lErTDO7tUKhxusO27EpsKjAD7OJ1eGDLnEbVqqgVHec6YyWnQqbw49ad05LzAfXdlspGf4QMwf1tDnAx4l-NNqyfY_fQBhEwOckmJTuY5aAlhrERluI9CZVI66AhIHH1ay3to4yP55XVH3AGw-Nzjvm7-ujQyDpNWwuoBBAUngtntQHeao-WTUr8XqbcuAYIKHxJORN4Ye2DspVoaAgrSKZyQClL24EwSABVy9DoscHXI1mGDVGbUxsIMCHtERGDfRcj0KQAZIpkOtCcqz9jwHvDbAVrfbxgfuvtgM9-A_ZkPFMzqWZ-8_ymvPv_4aCItFIt-67WQNdpAbHQQNZJOVJ2vufiQZDKY3-sjflg5Ts4iK6nEoI_M3iJJsyfS60Y75TvCVhiOyVhuNTORyBbPDO04EcADhb-3AZ2c-InvJdt_SMmitLWMOVGnIe459dvAOtKJVajr5bMF8bpcB-QtPZ1fBwGPeOjRIC6n2HC7IgQLWL00w==","id":"rs_0e8c30f7b7262587006a9647fd6bf087d287d487751b5aacb7","status":null,"summary":[{"text":"**Analyzing
+      a unique problem**\n\nI need to analyze a mathematical relationship. Let’s take
+      the number as 10a + b, which sums to 11. When I reverse it to 10b + a, it’s
+      stated to be 27 larger. This leads me to set up the equation 10b + a = 10a +
+      b + 27. From simplifying, I find that 9(b - a) = 27, which gives me b - a =
+      3. \n\nThen I get 2b, and since a + b = 11 with b = a + 3, I solve to find a
+      = 4 and b = 7. It feels unique, and everything checks out as valid.","type":"summary_text"}],"type":"reasoning"},{"content":[{"annotations":[],"text":"VALID","type":"output_text"}],"id":"msg_0e8c30f7b7262587006a9647ffabec87d281e7996510857303","role":"assistant","status":"completed","type":"message"}],"previous_response_id":null,"status":"completed","usage":{"input_tokens":46,"input_tokens_details":{"cached_tokens":0},"output_tokens":90,"output_tokens_details":{"reasoning_tokens":83},"total_tokens":136}}}
+
+      '
+    - '
+
+      '
+    - 'data: [DONE]
+
+      '
+    - '
+
+      '
+    status_code: 200

--- a/crates/agentic-server-core/tests/cassettes/reasoning/responses/reasoning-openai-reference-gpt-5.6-nonstreaming.yaml
+++ b/crates/agentic-server-core/tests/cassettes/reasoning/responses/reasoning-openai-reference-gpt-5.6-nonstreaming.yaml
@@ -1,0 +1,115 @@
+turns:
+- filename: t1
+  request:
+    body:
+      input: 'Determine whether 47 is the unique two-digit positive integer whose
+        digits sum to 11 and whose reversal is 27 larger. Analyze the constraints,
+        then reply with exactly one word: VALID or INVALID.'
+      max_output_tokens: 2048
+      model: gpt-5.6
+      reasoning:
+        effort: high
+        summary: detailed
+      store: true
+      stream: false
+    headers:
+      accept: '*/*'
+      authorization: Bearer ***
+      content-type: application/json
+      user-agent: python-httpx/0.28.1
+    method: POST
+    path: /v1/responses
+    query_params: {}
+  response:
+    body:
+      background: false
+      billing:
+        payer: developer
+      completed_at: 1788232209
+      created_at: 1788232206
+      error: null
+      frequency_penalty: 0.0
+      id: resp_087c7e1d7c2b1f92006a96420e51f887d2809ca52e7aa75177
+      incomplete_details: null
+      instructions: null
+      max_output_tokens: 2048
+      max_tool_calls: null
+      metadata: {}
+      model: gpt-5.6-sol
+      moderation: null
+      object: response
+      output:
+      - content: []
+        encrypted_content: gAAAAABqlkIRweC9SFErp6hHED4tdJTx7Y8ynx4MNLdOE6uowMA5_IN5EGJ0PjOhHHAcpLs_eQqb5bTt3xMDP8KZxPbrO6pTU8mwnpRxbbrhb6MFGsi1H7dUaU-ISTQYunLMGkW9yt88RuBNGEzh_LLx3jLqFev8m38y2WWPeLGNWjFMe4pP1GdkSIJLITsu0b8NAeZKxY3xwFp2oGSf0w6-6fdPo2N9Wiu7Uf0PsKTj_91N0olwwQZ4_SB4YAnytJUzEgyhG8FAW8lNLPVCUWCQcBIQXycY5PIFe4D1QegfNoEgqwnnQmKuAv21M83Q86iSlikhoIWV4XVpMvW9Mr8ZkuLRJ1y-h251N44-kdbHnSRr21TeFIDpiDKtPqcsggb3BlXDcjJH2uNubNxmasoQTw3PUA5EORjmE__wNYQstPJzp0r8hpkt5rEuYxMqPaAv7Tkys8T19NX7dQdP4o_ZL2KbuaRjm1o1lv-4_bXFZjlvT7LHBuUyPMtAgtlKV86wUduRIbf_dVv365x-JAhWDM5IDCsa3WbHBioUAiCvDryCMV_vNHXv69Q7gTrGTkVI_zTcbm-lEhdn6SdtUkwPqNm25Knq7uErMMdhl9yE_bvDIrq1i-y_ePft0hxS_tMiVValQKBW7n48RPL3YlsoBG68pimNM1bK7sexi96RTyuMurq4LgtfTUcxs_-8YXxNcad-bwBgXhVWoh5Koc93guZn_lA_eyJE6nTu7ZNV0VPDL_PikSrU2NRHwotENuSAB0AJaZzjHrHZjTzyFMYnn9o56zkcG5I3MRcshZQPNs1oIkNvFaPc4pkltqsq0WEQ8d47j-FIhQMv3kln_b5cjPxaQAYTYY3UKEcIWs6nOOzccYYVTBgPEVNRSn8CDSu24uv36fsYVpzl4JyCooxN7Fnc9nnhvimcD4FbckuLldgICNwkyUDGuWIqRrTDrUUZT1m_qi8MgbZYv_QZPLunNFa4jNqsEm4JeGtb-R7Tdmupw6edi0pe9M1XrsWEqAaZCfPnVvqvNO-W4R2t6OZmBH3Q5MRvow8HvoMF5PcbLK0oXIwRtjc4Ggu2pquo4MDfX31eKWyZ7ZTUKixlfKkwPTcRgQh5pEm73Izhbwe0PuvUWJs1vUPCifGWTagOVFUARTS7YLu4cXsuAgVJSZuwTwltKZAKhDjvhrqSHsFt2TbKectbbeBbIqeLceZc7XW56Q29heXv5lOF8qOKTFIx3JuDNVka0dfvd_N7g1bGZqjHJYMk0PyJQkFGbufo0XGcpeJ6b25qA4vnVCHMSlJ0qOwcKnf_Ft8Vc1GiBCrrPsardG3kWhVaAHnoZB1LZmbZJVWr4RYNS9Qg56ABce6UWWDyUTU3oPxUptRBBnH2H7jBPnPcQqk=
+        id: rs_087c7e1d7c2b1f92006a96420f0d4487d2ae266ebdcbaabdde
+        summary:
+        - text: '**Solving a math puzzle**
+
+
+            I need to derive a relationship here. If I take the number as 10a + b,
+            and its sum equals 11, then reversing it gives me 10b + a, which is said
+            to be 27 more than the original number. That leads to the equation 9(b
+            - a) = 27, simplifying down to b - a = 3. Solving with a + b = 11 tells
+            me that b is 7 and a is 4. It seems unique and valid!'
+          type: summary_text
+        type: reasoning
+      - content:
+        - annotations: []
+          logprobs: []
+          text: VALID
+          type: output_text
+        id: msg_087c7e1d7c2b1f92006a96421113e087d2a55cce32d67d8c24
+        phase: final_answer
+        role: assistant
+        status: completed
+        type: message
+      parallel_tool_calls: true
+      presence_penalty: 0.0
+      previous_response_id: null
+      prompt_cache_key: null
+      prompt_cache_retention: 24h
+      reasoning:
+        context: all_turns
+        effort: high
+        mode: standard
+        summary: detailed
+      safety_identifier: null
+      service_tier: default
+      status: completed
+      store: true
+      temperature: 1.0
+      text:
+        format:
+          type: text
+        verbosity: medium
+      tool_choice: auto
+      tool_usage:
+        image_gen:
+          input_tokens: 0
+          input_tokens_details:
+            image_tokens: 0
+            text_tokens: 0
+          output_tokens: 0
+          output_tokens_details:
+            image_tokens: 0
+            text_tokens: 0
+          total_tokens: 0
+        web_search:
+          num_requests: 0
+      tools: []
+      top_logprobs: 0
+      top_p: 0.98
+      truncation: disabled
+      usage:
+        input_tokens: 46
+        input_tokens_details:
+          cache_write_tokens: 0
+          cached_tokens: 0
+        output_tokens: 74
+        output_tokens_details:
+          reasoning_tokens: 67
+        total_tokens: 120
+      user: null
+    headers:
+      content-type: application/json
+    status_code: 200

--- a/crates/agentic-server-core/tests/cassettes/reasoning/responses/reasoning-openai-reference-gpt-5.6-streaming.yaml
+++ b/crates/agentic-server-core/tests/cassettes/reasoning/responses/reasoning-openai-reference-gpt-5.6-streaming.yaml
@@ -1,0 +1,1114 @@
+turns:
+- filename: t1
+  request:
+    body:
+      input: 'Determine whether 47 is the unique two-digit positive integer whose
+        digits sum to 11 and whose reversal is 27 larger. Analyze the constraints,
+        then reply with exactly one word: VALID or INVALID.'
+      max_output_tokens: 2048
+      model: gpt-5.6
+      reasoning:
+        effort: high
+        summary: detailed
+      store: true
+      stream: true
+    headers:
+      accept: '*/*'
+      authorization: Bearer ***
+      content-type: application/json
+      user-agent: python-httpx/0.28.1
+    method: POST
+    path: /v1/responses
+    query_params: {}
+  response:
+    headers:
+      content-type: text/event-stream; charset=utf-8
+    sse:
+    - 'event: response.created
+
+      '
+    - 'data: {"type":"response.created","response":{"id":"resp_090fd500a44c59b0006a96420892f887d2816079d6c0e9824b","object":"response","created_at":1788232200,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":2048,"max_tool_calls":null,"model":"gpt-5.6-sol","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"all_turns","effort":"high","mode":"standard","summary":"detailed"},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.in_progress
+
+      '
+    - 'data: {"type":"response.in_progress","response":{"id":"resp_090fd500a44c59b0006a96420892f887d2816079d6c0e9824b","object":"response","created_at":1788232200,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":2048,"max_tool_calls":null,"model":"gpt-5.6-sol","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"all_turns","effort":"high","mode":"standard","summary":"detailed"},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
+
+      '
+    - '
+
+      '
+    - 'event: response.output_item.added
+
+      '
+    - 'data: {"type":"response.output_item.added","item":{"id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","type":"reasoning","content":[],"encrypted_content":"gAAAAABqlkIKOmd38d5vqmp57mSoi5u1sFcZQ_sVpAnfxGQtQ2BCs0Sn_qRzngAPNyA3gS3itOVVdV9ERqIfERi2DhClQ4VeOClCV36AVThE0UdHuYrVkWK8GALN6KnRPezvU1tT0JWUjt0C2XBGmdYEVbpGkcjnPJVScO0X75-HvtxZpyTK6TtQ9zvYz3sxMaLxYPP0kZPODszTVMOoH9f2ec-i0JPdBXVNWvnRORslCLESHPRR9iGIJ7IWkVCjskmgCIGNtEvS10E3gSEFASyUIAjoGqOeDP44_8QUKBlNVP3Hi8upVrx2Xb0J6mVeV-fga0wdINoO_FHFhmOc8BKiZ819wv7FiP_EyhTLRjOos6azCmGbyaijNkxnadHz4Z_QxYKAYXSbdmArqPMEcaESppUg_TnNrpQNhwLsQpCmOSjdWSGrXRWYD9o9FLH5XFArAKivAIt0l3G63JnCK4aVaGD7chkPdbfuwcV3cRiawrtsVS96i-vUyib2moVvreMKAnUgY3X6GH1913aVtryKb0hDVnuEc0TRZb6pl9rBCXQjIdSycDyiPHt7zVFwfgw8v-BJkVArAkA0ZLoxN6uUiSEShzWw5GKquKMg9XzWXraHajVexF9EuTp9fI7TBTic7xML4XiZYsIe97JEKqnUc1AfzidAyeBuCkWopWAA7SAEGkHnO0ieduruRkbfEotgm9NGeWdk6ULyWZH0iOuajWoWo4Ioq3ufEzMydpMdCiwxUiMBvrNDGXa4vOUtp6NHj18KVojAAUSJbQ7tBzecJ_ABxFQf2SBIdITSJHH9QsvYMMsoYeF40PrqYLRA4Qv44XZarc3uxwupNSUfdWJVchoL3zVVtVI8L6wGwXjN2vZU4MfJQdDIEqMuUes_u4XQOYq7wAQzBr6uII8DRUG_dsLmWDZoqW5DqHpHz13ikE1Xk2mbdiQetwo1v7VUDhBx5w7QUTV5HtrscI_6rRG7Ztb5O6QmOyZIrv0FSA7CH8Vc-HLPFY3m0qMr8AlsrJ6JNSs6Mzc0OEk8xY-tj_40eNlbr1BRDTlxVWdRVZO-G3v96KGYVw-J0Qvx5a7vVdQoVfJDMgp9ZFpVkjNWLsOQ__qBhS18P8ZvXQbB6xrePjjZJ0DClIq7tBfMR_6MkN9Ao_exubAFmVLlhioYZJhINR3gfzilAg==","summary":[]},"output_index":0,"sequence_number":2}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_part.added
+
+      '
+    - 'data: {"type":"response.reasoning_summary_part.added","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","output_index":0,"part":{"type":"summary_text","text":""},"sequence_number":3,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":"**Analyzing
+      a number puzzle**\n\nI","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"","output_index":0,"sequence_number":4,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" need","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"P5ALoavgZLx","output_index":0,"sequence_number":5,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" to","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"XxW2wuJENqvvT","output_index":0,"sequence_number":6,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" focus","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"R8dRT3tpk7","output_index":0,"sequence_number":7,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" on","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"TTUvxmnfsPvEd","output_index":0,"sequence_number":8,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" this","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"Wwj8fO7gGTU","output_index":0,"sequence_number":9,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" problem","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"6rVexsP9","output_index":0,"sequence_number":10,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" involving","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"imc5nj","output_index":0,"sequence_number":11,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" digits","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"Q3hv3ggog","output_index":0,"sequence_number":12,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" in","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"F87oJ8Yc4cTJv","output_index":0,"sequence_number":13,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" a","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"ujWaFXZw04tK5H","output_index":0,"sequence_number":14,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" number","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"8qxYfb2Y3","output_index":0,"sequence_number":15,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":".","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"GtJ63CCsU0zBgxS","output_index":0,"sequence_number":16,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" I''ve","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"T5rJfnwddD9","output_index":0,"sequence_number":17,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" identified","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"TpNBN","output_index":0,"sequence_number":18,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" that","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"1JZgjxZvJdf","output_index":0,"sequence_number":19,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" the","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"Psljk8BAU6TZ","output_index":0,"sequence_number":20,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" number","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"fakS5rwrO","output_index":0,"sequence_number":21,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":"''s","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"vYHnnCay4j6AmI","output_index":0,"sequence_number":22,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" format","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"dcr4d0ONo","output_index":0,"sequence_number":23,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" is","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"wDtk2MTfwfGYX","output_index":0,"sequence_number":24,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" 10","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"q5BlVt7oCO7AN","output_index":0,"sequence_number":25,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":"a","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"NtIcEq5LDXHDH5m","output_index":0,"sequence_number":26,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" +","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"ymIxL7fMu049oR","output_index":0,"sequence_number":27,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" b","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"g8yFtAqBjVuJvv","output_index":0,"sequence_number":28,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":",","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"aVMmiaxZAZA1QZu","output_index":0,"sequence_number":29,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" where","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"RTG6Yk1Q3p","output_index":0,"sequence_number":30,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" the","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"oGBCi5C2De8k","output_index":0,"sequence_number":31,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" digits","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"pftUSEDtr","output_index":0,"sequence_number":32,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" sum","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"3euawjvFfM2K","output_index":0,"sequence_number":33,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" to","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"tDOzywDV17q5T","output_index":0,"sequence_number":34,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" 11","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"iXYcGOT0B4hQP","output_index":0,"sequence_number":35,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":".","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"1A8lsuvS1YpzGPU","output_index":0,"sequence_number":36,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" There''s","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"WCxBU0QS","output_index":0,"sequence_number":37,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" a","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"2UkfI3IIMVxcn1","output_index":0,"sequence_number":38,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" reversal","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"ESW4txa","output_index":0,"sequence_number":39,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" aspect","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"wdjtdWN8b","output_index":0,"sequence_number":40,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":",","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"nRw5qj8d8Ha2pMe","output_index":0,"sequence_number":41,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" making","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"bPzYYZW7R","output_index":0,"sequence_number":42,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" it","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"AXXrprYEoE1XK","output_index":0,"sequence_number":43,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" 10","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"7O3LvqqAI3j9J","output_index":0,"sequence_number":44,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":"b","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"L13U3Qr6567Uzmn","output_index":0,"sequence_number":45,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" +","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"0zl4NQhg3McP7d","output_index":0,"sequence_number":46,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" a","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"bFMTsWkv0mFouZ","output_index":0,"sequence_number":47,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":",","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"FsJisFNMcNlcLa5","output_index":0,"sequence_number":48,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" and","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"nQFF6MSaGiom","output_index":0,"sequence_number":49,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" I","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"PUBbgYiGsYPNlD","output_index":0,"sequence_number":50,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" found","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"EhxrIVLghg","output_index":0,"sequence_number":51,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" that","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"nHdG04V3QJp","output_index":0,"sequence_number":52,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" it''s","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"sgrhqcWlwPi","output_index":0,"sequence_number":53,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" 27","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"J2Snt7bnVkUec","output_index":0,"sequence_number":54,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" larger","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"19ECCPDkp","output_index":0,"sequence_number":55,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":".","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"GFSqKYxjPPrCIc5","output_index":0,"sequence_number":56,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" This","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"vyuo5B6qOgV","output_index":0,"sequence_number":57,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" leads","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"aAuezCDPQh","output_index":0,"sequence_number":58,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" me","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"mFgjjsD8lOVz6","output_index":0,"sequence_number":59,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" to","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"gvT69Kx6qdTpJ","output_index":0,"sequence_number":60,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" the","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"SqOH52HVHlqC","output_index":0,"sequence_number":61,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" equation","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"3QtxnNi","output_index":0,"sequence_number":62,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" 9","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"2tLNA2yHT3wiW8","output_index":0,"sequence_number":63,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":"(b","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"WSnX0CA867XYRp","output_index":0,"sequence_number":64,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" -","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"A4nCoG3CfjtDjP","output_index":0,"sequence_number":65,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" a","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"wlt5cfjYoINyNs","output_index":0,"sequence_number":66,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":")","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"MaWHabH6dU418ha","output_index":0,"sequence_number":67,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" =","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"uMJbcTJDjFnAc7","output_index":0,"sequence_number":68,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" 27","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"uDnmXyLjslLJX","output_index":0,"sequence_number":69,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":",","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"mMMaqH9nGrhzqBd","output_index":0,"sequence_number":70,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" which","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"uJ7AHJEBJJ","output_index":0,"sequence_number":71,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" simplifies","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"9kaCt","output_index":0,"sequence_number":72,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" to","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"GYftWXPWunfyw","output_index":0,"sequence_number":73,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" b","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"SB7VTgU50flEfW","output_index":0,"sequence_number":74,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" -","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"820I6lIqaosKJN","output_index":0,"sequence_number":75,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" a","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"IHrocab7iC3YMJ","output_index":0,"sequence_number":76,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" =","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"sQFzccYzGCjSRM","output_index":0,"sequence_number":77,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" 3","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"fxD39JK8mGHHGy","output_index":0,"sequence_number":78,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":".","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"Qv9qtV2EnFWpovc","output_index":0,"sequence_number":79,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" Sol","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"x1qUCQyQnH2U","output_index":0,"sequence_number":80,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":"ving","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"nFgYqoFQhv7N","output_index":0,"sequence_number":81,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" a","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"uINFWXptoCsGGX","output_index":0,"sequence_number":82,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" +","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"TzO0FWFkVA29dX","output_index":0,"sequence_number":83,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" b","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"b9yaO7t6wbwRRQ","output_index":0,"sequence_number":84,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" =","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"vRZSDZ4QwrVn7j","output_index":0,"sequence_number":85,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" 11","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"cpNjSYHr5xTv1","output_index":0,"sequence_number":86,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" gives","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"Zvau9nSXsY","output_index":0,"sequence_number":87,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" me","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"UVPTbqidw2R5b","output_index":0,"sequence_number":88,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" b","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"Ozw1J3msDehTcN","output_index":0,"sequence_number":89,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" =","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"4HHnuj891JX69G","output_index":0,"sequence_number":90,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" 7","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"nazkOFP2uYgGzZ","output_index":0,"sequence_number":91,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" and","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"tV0WiKVQqSQs","output_index":0,"sequence_number":92,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" a","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"2CMydTiRFS0PxX","output_index":0,"sequence_number":93,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" =","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"WP6xGGX05Q9bkh","output_index":0,"sequence_number":94,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" 4","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"WF6fJ9ojKlT2FY","output_index":0,"sequence_number":95,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":",","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"r8c4l7YAzKlciOw","output_index":0,"sequence_number":96,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" leading","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"QJHW7P3k","output_index":0,"sequence_number":97,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" to","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"Pd4BRf1nQMFfV","output_index":0,"sequence_number":98,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" a","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"OyLMiclrPYlp1n","output_index":0,"sequence_number":99,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" unique","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"RbGNIfNmw","output_index":0,"sequence_number":100,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" number","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"Igt44q9g1","output_index":0,"sequence_number":101,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":":","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"LHj732utkAUY0Hn","output_index":0,"sequence_number":102,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" 47","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"dB461pnVpWBHm","output_index":0,"sequence_number":103,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":".","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"e5lGErzeXB2ESSJ","output_index":0,"sequence_number":104,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" It''s","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"dCTcLFCqqHY","output_index":0,"sequence_number":105,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":" valid","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"y2xU6o5b2I","output_index":0,"sequence_number":106,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.delta
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.delta","delta":"!","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","obfuscation":"irj7IihrFEkdUSP","output_index":0,"sequence_number":107,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_text.done
+
+      '
+    - 'data: {"type":"response.reasoning_summary_text.done","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","output_index":0,"sequence_number":108,"summary_index":0,"text":"**Analyzing
+      a number puzzle**\n\nI need to focus on this problem involving digits in a number.
+      I''ve identified that the number''s format is 10a + b, where the digits sum
+      to 11. There''s a reversal aspect, making it 10b + a, and I found that it''s
+      27 larger. This leads me to the equation 9(b - a) = 27, which simplifies to
+      b - a = 3. Solving a + b = 11 gives me b = 7 and a = 4, leading to a unique
+      number: 47. It''s valid!"}
+
+      '
+    - '
+
+      '
+    - 'event: response.reasoning_summary_part.done
+
+      '
+    - 'data: {"type":"response.reasoning_summary_part.done","item_id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","output_index":0,"part":{"type":"summary_text","text":"**Analyzing
+      a number puzzle**\n\nI need to focus on this problem involving digits in a number.
+      I''ve identified that the number''s format is 10a + b, where the digits sum
+      to 11. There''s a reversal aspect, making it 10b + a, and I found that it''s
+      27 larger. This leads me to the equation 9(b - a) = 27, which simplifies to
+      b - a = 3. Solving a + b = 11 gives me b = 7 and a = 4, leading to a unique
+      number: 47. It''s valid!"},"sequence_number":109,"summary_index":0}
+
+      '
+    - '
+
+      '
+    - 'event: response.output_item.done
+
+      '
+    - 'data: {"type":"response.output_item.done","item":{"id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","type":"reasoning","content":[],"encrypted_content":"gAAAAABqlkIMgfU-XASDalxxVzKZi08vAc-uL4BLMDjgfrYerqxd7A4C-5yzRTjogAYoa9mUF-uKTWetRrcaU73qOXT6qoXZHYg9eAyQY0J2aGO4dIyBkbY7ZGQ59HlGD3SfAqfB3tZrYZDPZwtvNk67u9DdcZA8uCr-Avse8NzuZf8zDmbXTw5s2KjNjCeNAqlCFPZ0v5lgn_0f3ch8nF1eFTvc4zA7dOfYvGhzAT5sSSJ70ChBTA39JsPJVKa16nKzGO2CUg5Ic2Ov_XqWCGXRxwStiunaddIIldtseG9X0Phat2oRJpiyl9l-hjyyoj7MlqcOCmX-Q2z1Q31upMjjrW8OpDM5qR4piCL0Q8D4izyX4XmUGvraSM3QPSYE7lNYAoMuv6LT9imtmVpBuNCwjmrN7C1mBnf75_iR-5bgJN9zStFc_ULECA5XwSZcdtTsO9Nbf2a2YS2_nuf8Ae4J4P_GKJhnwwuYJm9s_LBTEtTBDHsbuOELkv2dk_g8-6VsJxYeC_YHz-pQzVklbmaYZkipODIUNwtKvcvtHg-Loda21ndSfU-CVDJDyKeH5fevqxhDKJxO1pydm1MhpR3RhYDRnt5wcIF0v4RtIVcUg7HqGmQ-2cX5flW0f_YmefVnaGv4DtwGFMuVxp_9Q2uOgm3ciRsny_tXJENMFNqCYL7wYFmpoXJuOYbeNSZ908VFh_M1XfM79A27S5F4_E7p6v-3TzhIWuqnvGjqZvSg-nLYHdaE8J0okcBLyOJu3zPobPC7WGzShPsek5JzLF1fFtzk7JM8xVWrshnt18ndwsBquNWoOQqi9MAh4z8dou4qu2ToAEnzGCunHdXXHPzo0vIdEl2YW3oRe4kNbA7CwrdhcoWbvILXJYNRHrnCRIhgHQsNgDsxi3haPmvoXq0pzbOWF3zqQJqhpqr6z2zOaRyTH10GXn8f8hseEPcVjIUZTPDHm9RZYzxY-2QzyK5NVG9fPTxHei8gteLBjyg9yZPModcOiwbaLunr8QAp_yJMpmCpjBCu_6fkXEUdaTmvyLhzoHcBHY8Nu_kcxc5uv_XIoZPlqoDOGfFpl-Pu-dI8L9xm-efEAUGQcchtQqySPtyAVyvp5jBfLkT9hY_H9y4T5PpiHRg7w8T__Ql_x0G-48xi02Gd3ibAwv4LFuPdXWZr6MsfSDbsxGuwEEIWD0SXEcyAMoVCgXLKx_Oz2Y1d7By5UrUU4Gdk4P_Gp-45XkMax6oN0ALybQ_VPkVBlCirvENP7G_haSlj1sp4U5rDGPwtSY5n34U8slIYfRBLPAG6MfyHC2Y_6W-z6PTtMBfO7mMaeItBG57AtnZT7pX-rJCtjBtbUFizrYPCSeQ3hLe7NKyzlAxxfF4KrwQM1k03gs170SZKUPCoFyNXEZ1Wyn4jpTHQ","summary":[{"type":"summary_text","text":"**Analyzing
+      a number puzzle**\n\nI need to focus on this problem involving digits in a number.
+      I''ve identified that the number''s format is 10a + b, where the digits sum
+      to 11. There''s a reversal aspect, making it 10b + a, and I found that it''s
+      27 larger. This leads me to the equation 9(b - a) = 27, which simplifies to
+      b - a = 3. Solving a + b = 11 gives me b = 7 and a = 4, leading to a unique
+      number: 47. It''s valid!"}]},"output_index":0,"sequence_number":110}
+
+      '
+    - '
+
+      '
+    - 'event: response.output_item.added
+
+      '
+    - 'data: {"type":"response.output_item.added","item":{"id":"msg_090fd500a44c59b0006a96420c6bf087d2b230e90b83e5af8f","type":"message","status":"in_progress","content":[],"phase":"final_answer","role":"assistant"},"output_index":1,"sequence_number":111}
+
+      '
+    - '
+
+      '
+    - 'event: response.content_part.added
+
+      '
+    - 'data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_090fd500a44c59b0006a96420c6bf087d2b230e90b83e5af8f","output_index":1,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":112}
+
+      '
+    - '
+
+      '
+    - 'event: response.output_text.delta
+
+      '
+    - 'data: {"type":"response.output_text.delta","content_index":0,"delta":"VALID","item_id":"msg_090fd500a44c59b0006a96420c6bf087d2b230e90b83e5af8f","logprobs":[],"obfuscation":"yTlSRe5PIHD","output_index":1,"sequence_number":113}
+
+      '
+    - '
+
+      '
+    - 'event: response.output_text.done
+
+      '
+    - 'data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_090fd500a44c59b0006a96420c6bf087d2b230e90b83e5af8f","logprobs":[],"output_index":1,"sequence_number":114,"text":"VALID"}
+
+      '
+    - '
+
+      '
+    - 'event: response.content_part.done
+
+      '
+    - 'data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_090fd500a44c59b0006a96420c6bf087d2b230e90b83e5af8f","output_index":1,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"VALID"},"sequence_number":115}
+
+      '
+    - '
+
+      '
+    - 'event: response.output_item.done
+
+      '
+    - 'data: {"type":"response.output_item.done","item":{"id":"msg_090fd500a44c59b0006a96420c6bf087d2b230e90b83e5af8f","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"VALID"}],"phase":"final_answer","role":"assistant"},"output_index":1,"sequence_number":116}
+
+      '
+    - '
+
+      '
+    - 'event: response.completed
+
+      '
+    - 'data: {"type":"response.completed","response":{"id":"resp_090fd500a44c59b0006a96420892f887d2816079d6c0e9824b","object":"response","created_at":1788232200,"status":"completed","background":false,"completed_at":1788232204,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":2048,"max_tool_calls":null,"model":"gpt-5.6-sol","moderation":null,"output":[{"id":"rs_090fd500a44c59b0006a96420acb6887d29ca19ab43c621f90","type":"reasoning","content":[],"encrypted_content":"gAAAAABqlkIM4TS6EqJAcLo2a9uxqfPJOGj_2-lKMgl5FApTIOOoohI4QwXEpYh4Svux0yPpXYyKzvV9m6RqBISIdNmVQanq3sz57xpWfbXzrNTVyOgh6cj5sa0nqNBFu-F04dnBBs9AGsdgJ4SuBE-ZysemqMpsxNTBp54KZVJiv_QVhs04EOUgMWKtFvpMzNZJJBwVNl0ZW-AxBBuD99yvY4ib1xjkm5TfRepbSxXS80z5Mb-acsq8XbADtHEoDMjQgf-SxUndP69JrlwuCHP8Tu9XZ8fJ0kgvIfd4f07CIy8fTlBvhQ5Y-ZgdngPEqcPsZvitrSzt99cjt0QbeqgkzqB3LFeAR6WQ0ulXvRAahN9UaWVkyFmNxWZV55TU-GS2wKWI9v9YHJj78JUrbwPMVeKkL6MjVIbPjLwDlTpOsTGIZqF6srDchgP9Vz51T_TDgqnD3qjQAUZiROJ1D86CXMygDwqxmEJe85hDyHEZGb6PnnSDBO0Yng2UUrC0J20O4t4Bj7UEU1_u1q54vYiNFLqutHFB3dRFNOg6_dBZ72v1cWnp02VS5asaTMQ_RNeVH1Lj7_6zFmk62CGvF6TJa_45b_25rFDYqj8YbSioE2FUNLe0a338xWxhy4mPvPfE78vIIZosR2zw0nj5Iy_YSe0JKfrx8SOMMWNvGLqUgB2NMCSNkvDpU11cPfRi7MmLt--LKl4SmmCfnRh-Ik3gAAZl4Lox49sOGvvghBEAHdTGYZY40Ftkh_Yq8iA2m97krXG0u6yPZwJaW6MOmQ1VMl6SvSovHDxhSMx9xdw7BAoIdpBwLwSaBNcNmNBz8cVO46aQjKm1ocT9gZvbD3X5Lrt_ONOkWJu-GrnEmLaFt3GihVkEb4Y--_lGeSs3f4edP70ygB1Z-i678C8VnbkbI8OYuWgF0hV0ZWdjyoRDEFgV2Dot27-Pwk4A94N8BUsgJhIig3bxabX3MsutUFArioiKksVwuVQ61kPFaVZ6SGwF_Zo0hiGVghkIKo7wMPBtbVzC41gs_a2qLPvptN4rzFTIixF82oWCR2L0D2KOPOIsxnLo4ddwBIazK75AuCdWV4SbcfWk-47-4BM0AVdNEba24EmHrAF-q4LluVqxCGT12LAXjfrcsBncMAd6FBZjGPTGVv0uTKUK-V1C3vx24dHm3MxMlodBIG67oNehnD43ww6U2f5jJ_lHDZOaBrR5_KUZIFBvDRPJfravF55cvsRICv6sxX0ga1RSpS3a2x5WhqNCMCp2D9tRJWchjdxhfxz75jfgTWFC6Yaalp-q5-P9RCfwwIh7ehVh4p67l2P5pZmli0vcjvDgW_LqL9ow0qnKWb9i2nPbYm-mboY1Fsjhvgp2pCcST56k7qmwHuPOnyi9DD5rwCtDxU_GILv2MV4ht50b","summary":[{"type":"summary_text","text":"**Analyzing
+      a number puzzle**\n\nI need to focus on this problem involving digits in a number.
+      I''ve identified that the number''s format is 10a + b, where the digits sum
+      to 11. There''s a reversal aspect, making it 10b + a, and I found that it''s
+      27 larger. This leads me to the equation 9(b - a) = 27, which simplifies to
+      b - a = 3. Solving a + b = 11 gives me b = 7 and a = 4, leading to a unique
+      number: 47. It''s valid!"}]},{"id":"msg_090fd500a44c59b0006a96420c6bf087d2b230e90b83e5af8f","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"VALID"}],"phase":"final_answer","role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"all_turns","effort":"high","mode":"standard","summary":"detailed"},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":46,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":76,"output_tokens_details":{"reasoning_tokens":69},"total_tokens":122},"user":null,"metadata":{}},"sequence_number":117}
+
+      '
+    - '
+
+      '
+    status_code: 200

--- a/crates/agentic-server-core/tests/cassettes/record_cassette.py
+++ b/crates/agentic-server-core/tests/cassettes/record_cassette.py
@@ -646,6 +646,18 @@ def _load_response_input(path: str | None) -> str | list | None:
     return value
 
 
+def _parse_reasoning(raw: str | None) -> dict | None:
+    if raw is None:
+        return None
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise click.UsageError(f"--reasoning is not valid JSON: {error}") from error
+    if not isinstance(value, dict):
+        raise click.UsageError("--reasoning must contain a JSON object.")
+    return value
+
+
 def _inject_tools(body: dict, tools: list | None, tool_choice: Any) -> None:
     if tools is not None:
         body["tools"] = tools
@@ -928,6 +940,7 @@ def run_responses(
     tool_choice: Any = None,
     tool_outputs: dict[str, str] | None = None,
     max_output_tokens: int | None = None,
+    reasoning: dict | None = None,
     preset_input: str | list | None = None,
 ) -> None:
     response_ids: dict[int, str] = {}
@@ -975,6 +988,8 @@ def run_responses(
         body: dict = {"model": model, "input": input_value, "stream": stream, "store": store}
         if max_output_tokens is not None:
             body["max_output_tokens"] = max_output_tokens
+        if reasoning is not None:
+            body["reasoning"] = reasoning
         if previous_response_id and store:
             body["previous_response_id"] = previous_response_id
         _inject_tools(body, tools, tool_choice)
@@ -1026,6 +1041,8 @@ def run_responses(
         }
         if max_output_tokens is not None:
             body["max_output_tokens"] = max_output_tokens
+        if reasoning is not None:
+            body["reasoning"] = reasoning
         _inject_tools(body, tools, tool_choice)
         _send(
             client,
@@ -1152,6 +1169,13 @@ def run_responses(
     help="JSON file containing one Responses input value; requires HTTP --mode responses --turns 1.",
 )
 @click.option(
+    "--reasoning",
+    "reasoning_raw",
+    metavar="JSON",
+    default=None,
+    help='Responses reasoning settings as a JSON object, e.g. \'{"effort":"high","summary":"detailed"}\'.',
+)
+@click.option(
     "--max-output-tokens",
     type=int,
     default=1024,
@@ -1176,6 +1200,7 @@ def main(
     tool_choice_raw: str | None,
     tool_outputs_file: str | None,
     input_file: str | None,
+    reasoning_raw: str | None,
     max_output_tokens: int,
 ) -> None:
     """Interactive multi-turn cassette recorder (proxy embedded)."""
@@ -1207,7 +1232,10 @@ def main(
         raise click.UsageError(
             "--input-file requires HTTP --mode responses --turns 1 without branches."
         )
+    if reasoning_raw is not None and mode != "responses":
+        raise click.UsageError("--reasoning is only supported with --mode responses.")
     preset_input = _load_response_input(input_file)
+    reasoning = _parse_reasoning(reasoning_raw)
 
     tools: list | None = None
     if tools_file:
@@ -1285,6 +1313,7 @@ def main(
                 tool_choice,
                 tool_outputs,
                 response_max_output_tokens,
+                reasoning,
                 preset_input,
             )
     else:
@@ -1317,6 +1346,7 @@ def main(
                         tool_choice,
                         tool_outputs,
                         response_max_output_tokens,
+                        reasoning,
                         preset_input,
                     )
                 elif mode == "messages":

--- a/crates/agentic-server-core/tests/cassettes/record_reasoning_cassettes.sh
+++ b/crates/agentic-server-core/tests/cassettes/record_reasoning_cassettes.sh
@@ -1,77 +1,226 @@
 #!/usr/bin/env bash
-# record_reasoning_cassettes.sh
+# Records the same explicit Responses reasoning configuration against OpenAI
+# and the gateway, with optional direct-vLLM recordings for the legacy
+# accumulator fixtures.
 #
-# Records reasoning cassettes from a vLLM server (two-turn, streaming and non-streaming).
-# Uses --mode responses with --vllm, which is the only supported combination.
+# Each provider records one streaming and one non-streaming response. The
+# default `all` set records the OpenAI ground truth and its gateway counterpart.
 #
-# Prerequisites:
-#   - vLLM server must be running and accessible at VLLM_URL
-#
-# Usage:
-#   bash tests/cassettes/record_reasoning_cassettes.sh
-#   VLLM_URL=http://localhost:8000 MODEL=Qwen/Qwen3-30B-A3B-FP8 bash tests/cassettes/record_reasoning_cassettes.sh
+# Usage from the repository root:
+#   OPENAI_API_KEY=sk-... \
+#     bash crates/agentic-server-core/tests/cassettes/record_reasoning_cassettes.sh
+#   REASONING_RECORD_SET=gateway GATEWAY_URL=http://localhost:9000 \
+#     bash crates/agentic-server-core/tests/cassettes/record_reasoning_cassettes.sh
+#   REASONING_RECORD_SET=vllm VLLM_URL=http://localhost:5050 \
+#     bash crates/agentic-server-core/tests/cassettes/record_reasoning_cassettes.sh
 
 set -euo pipefail
 
 SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-BASE_DIR="$SCRIPTS_DIR/reasoning"
-RESPONSES_DIR="$BASE_DIR/responses"
-VLLM_URL="${VLLM_URL:-http://localhost:8000}"
-MODEL="${MODEL:-Qwen/Qwen3-30B-A3B-FP8}"
+BASE_DIR="$SCRIPTS_DIR/reasoning/responses"
+GATEWAY_URL="${GATEWAY_URL:-http://localhost:9000}"
+VLLM_URL="${VLLM_URL:-http://localhost:5050}"
+MODEL="${MODEL:-gpt-5.6}"
 MODEL_SLUG="$(echo "$MODEL" | tr '/: ' '---')"
+OPENAI_MODEL="${OPENAI_MODEL:-gpt-5.6}"
+OPENAI_MODEL_SLUG="$(echo "$OPENAI_MODEL" | tr '/: ' '---')"
+REASONING_RECORD_SET="${REASONING_RECORD_SET:-all}"
+REASONING_CONFIG="${REASONING_CONFIG:-{\"effort\":\"high\",\"summary\":\"detailed\"}}"
+PROMPT='Determine whether 47 is the unique two-digit positive integer whose digits sum to 11 and whose reversal is 27 larger. Analyze the constraints, then reply with exactly one word: VALID or INVALID.'
 
 green() { printf '\033[32m%s\033[0m\n' "$*"; }
 bold()  { printf '\033[1m%s\033[0m\n'  "$*"; }
 
-next_test() {
-    echo
-    read -rp "Press ENTER when ready for the next test..."
-    echo
+validate_reasoning_config() {
+  python - "$REASONING_CONFIG" <<'PY'
+import json
+import sys
+
+try:
+    value = json.loads(sys.argv[1])
+except json.JSONDecodeError as error:
+    raise SystemExit(f"ERROR: REASONING_CONFIG is not valid JSON: {error}") from error
+if not isinstance(value, dict):
+    raise SystemExit("ERROR: REASONING_CONFIG must contain a JSON object")
+PY
 }
 
-mkdir -p "$RESPONSES_DIR"
+validate_recorded_response() {
+  local file="$1"
+  local stream_flag="$2"
 
-bold "vLLM URL: $VLLM_URL"
-bold "Model:    $MODEL"
-echo
+  python - "$file" "$stream_flag" "$REASONING_CONFIG" <<'PY'
+import json
+import sys
+from pathlib import Path
 
-# ── Test 1: single-turn non-streaming ────────────────────────────
+import yaml
 
-bold "═══════════════════════════════════════════════════════════════"
-bold "Test 1 of 2 — reasoning-single-nonstreaming"
-bold "  1 turn, non-streaming"
-bold "═══════════════════════════════════════════════════════════════"
-bold "Prompts to enter:"
-echo "  Turn 1: Reply with exactly one word: HELLO"
-echo
-python "$SCRIPTS_DIR/record_cassette.py" \
-    --mode responses \
-    --turns 1 \
-    --no-stream \
-    --model "$MODEL" \
+path = Path(sys.argv[1])
+streaming = sys.argv[2] == "--stream"
+expected_reasoning = json.loads(sys.argv[3])
+document = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+turns = document.get("turns") or []
+if len(turns) != 1:
+    raise SystemExit(f"ERROR: expected one recorded turn in {path}, found {len(turns)}")
+
+turn = turns[0]
+request = (turn.get("request") or {}).get("body") or {}
+if request.get("reasoning") != expected_reasoning:
+    raise SystemExit(
+        f"ERROR: recorded reasoning configuration differs from REASONING_CONFIG: {request.get('reasoning')}"
+    )
+if request.get("stream") is not streaming:
+    raise SystemExit(f"ERROR: recorded stream mode differs from {streaming}")
+
+response = turn.get("response") or {}
+status_code = response.get("status_code")
+if status_code != 200:
+    raise SystemExit(f"ERROR: recording returned HTTP {status_code}: {response.get('body')}")
+
+if not streaming:
+    terminal = response.get("body") or {}
+else:
+    events = []
+    for raw in response.get("sse") or []:
+        for line in raw.splitlines():
+            if not line.startswith("data: ") or line == "data: [DONE]":
+                continue
+            try:
+                events.append(json.loads(line.removeprefix("data: ")))
+            except json.JSONDecodeError:
+                continue
+    errors = [event.get("error") for event in events if event.get("type") == "error"]
+    if errors:
+        raise SystemExit(f"ERROR: streaming recording returned an error event: {errors[0]}")
+    terminal = next(
+        (
+            event.get("response")
+            for event in reversed(events)
+            if event.get("type") == "response.completed"
+        ),
+        None,
+    ) or {}
+
+if terminal.get("status") != "completed":
+    raise SystemExit(f"ERROR: recording did not complete: {terminal}")
+output = terminal.get("output") or []
+output_types = [item.get("type") for item in output]
+if "reasoning" not in output_types:
+    raise SystemExit(f"ERROR: completed response has no reasoning item: {output_types}")
+if "message" not in output_types:
+    raise SystemExit(f"ERROR: completed response has no message item: {output_types}")
+message_text = "".join(
+    part.get("text", "")
+    for item in output
+    if item.get("type") == "message"
+    for part in item.get("content") or []
+    if part.get("type") == "output_text"
+)
+if message_text.strip() != "VALID":
+    raise SystemExit(f"ERROR: expected the deterministic answer VALID, got {message_text!r}")
+PY
+}
+
+record_single_turn() {
+  local endpoint_flag="$1"
+  local endpoint="$2"
+  local model="$3"
+  local output="$4"
+  local stream_flag="$5"
+  local temporary_output
+
+  temporary_output="$(mktemp "$BASE_DIR/.reasoning-cassette.XXXXXX")"
+
+  if ! printf '%s\n' "$PROMPT" \
+    | python "$SCRIPTS_DIR/record_cassette.py" \
+        --mode responses \
+        --turns 1 \
+        "$stream_flag" \
+        --model "$model" \
+        "$endpoint_flag" "$endpoint" \
+        --reasoning "$REASONING_CONFIG" \
+        --max-output-tokens 2048 \
+        --output "$temporary_output"
+  then
+    rm -f -- "$temporary_output"
+    return 1
+  fi
+
+  if ! validate_recorded_response "$temporary_output" "$stream_flag"; then
+    rm -f -- "$temporary_output"
+    return 1
+  fi
+  mv -- "$temporary_output" "$output"
+  green "✓ reasoning cassette recorded -> $output"
+}
+
+record_provider_suite() {
+  local provider="$1"
+  local endpoint_flag="$2"
+  local endpoint="$3"
+  local model="$4"
+  local output_prefix="$5"
+
+  bold "$provider reasoning cassettes"
+  bold "Endpoint:  $endpoint"
+  bold "Model:     $model"
+  bold "Reasoning: $REASONING_CONFIG"
+
+  bold "$provider streaming reasoning response"
+  record_single_turn \
+    "$endpoint_flag" "$endpoint" "$model" \
+    "$BASE_DIR/${output_prefix}-streaming.yaml" \
+    --stream
+
+  bold "$provider non-streaming reasoning response"
+  record_single_turn \
+    "$endpoint_flag" "$endpoint" "$model" \
+    "$BASE_DIR/${output_prefix}-nonstreaming.yaml" \
+    --no-stream
+}
+
+case "$REASONING_RECORD_SET" in
+  gateway|vllm|openai|all) ;;
+  *)
+    echo "ERROR: REASONING_RECORD_SET must be gateway, vllm, openai, or all" >&2
+    exit 1
+    ;;
+esac
+
+validate_reasoning_config
+
+# Validate OpenAI requirements before recording the gateway suite so a default
+# `all` run cannot leave only half of the comparison fixtures.
+if [[ "$REASONING_RECORD_SET" == "openai" || "$REASONING_RECORD_SET" == "all" ]]; then
+  if [[ -z "${OPENAI_API_KEY:-}" ]]; then
+    echo "ERROR: OPENAI_API_KEY must be set for REASONING_RECORD_SET=$REASONING_RECORD_SET" >&2
+    exit 1
+  fi
+fi
+
+mkdir -p "$BASE_DIR"
+
+if [[ "$REASONING_RECORD_SET" == "openai" || "$REASONING_RECORD_SET" == "all" ]]; then
+  record_provider_suite \
+    OpenAI \
+    --openai https://api.openai.com \
+    "$OPENAI_MODEL" \
+    "reasoning-openai-reference-${OPENAI_MODEL_SLUG}"
+fi
+
+if [[ "$REASONING_RECORD_SET" == "gateway" || "$REASONING_RECORD_SET" == "all" ]]; then
+  record_provider_suite \
+    Gateway \
+    --gateway "$GATEWAY_URL" \
+    "$MODEL" \
+    "reasoning-gateway-${MODEL_SLUG}"
+fi
+
+if [[ "$REASONING_RECORD_SET" == "vllm" ]]; then
+  record_provider_suite \
+    vLLM \
     --vllm "$VLLM_URL" \
-    --output "$RESPONSES_DIR/reasoning-single-${MODEL_SLUG}-nonstreaming.yaml"
-green "✓ Test 1 done."
-next_test
-
-# ── Test 2: single-turn streaming ────────────────────────────────
-
-bold "═══════════════════════════════════════════════════════════════"
-bold "Test 2 of 2 — reasoning-single-streaming"
-bold "  1 turn, streaming"
-bold "═══════════════════════════════════════════════════════════════"
-bold "Prompts to enter:"
-echo "  Turn 1: Reply with exactly one word: HELLO"
-echo
-python "$SCRIPTS_DIR/record_cassette.py" \
-    --mode responses \
-    --turns 1 \
-    --model "$MODEL" \
-    --vllm "$VLLM_URL" \
-    --output "$RESPONSES_DIR/reasoning-single-${MODEL_SLUG}-streaming.yaml"
-green "✓ Test 2 done."
-
-echo
-green "════════════════════════════════════════════════════════════════"
-green "All 2 reasoning cassettes recorded -> $RESPONSES_DIR"
-green "════════════════════════════════════════════════════════════════"
+    "$MODEL" \
+    "reasoning-single-${MODEL_SLUG}"
+fi

--- a/crates/agentic-server-core/tests/cassettes/record_reasoning_cassettes.sh
+++ b/crates/agentic-server-core/tests/cassettes/record_reasoning_cassettes.sh
@@ -17,7 +17,8 @@
 set -euo pipefail
 
 SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-BASE_DIR="$SCRIPTS_DIR/reasoning/responses"
+BASE_DIR="${REASONING_OUTPUT_DIR:-$SCRIPTS_DIR/reasoning/responses}"
+RECORDER="${RECORDER:-$SCRIPTS_DIR/record_cassette.py}"
 GATEWAY_URL="${GATEWAY_URL:-http://localhost:9000}"
 VLLM_URL="${VLLM_URL:-http://localhost:5050}"
 MODEL="${MODEL:-gpt-5.6}"
@@ -27,9 +28,20 @@ OPENAI_MODEL_SLUG="$(echo "$OPENAI_MODEL" | tr '/: ' '---')"
 REASONING_RECORD_SET="${REASONING_RECORD_SET:-all}"
 REASONING_CONFIG="${REASONING_CONFIG:-{\"effort\":\"high\",\"summary\":\"detailed\"}}"
 PROMPT='Determine whether 47 is the unique two-digit positive integer whose digits sum to 11 and whose reversal is 27 larger. Analyze the constraints, then reply with exactly one word: VALID or INVALID.'
+STAGING_DIR=""
+STAGED_OUTPUTS=()
+FINAL_OUTPUTS=()
 
 green() { printf '\033[32m%s\033[0m\n' "$*"; }
 bold()  { printf '\033[1m%s\033[0m\n'  "$*"; }
+
+cleanup_staging() {
+  if [[ -n "$STAGING_DIR" ]]; then
+    rm -rf -- "$STAGING_DIR"
+  fi
+}
+
+trap cleanup_staging EXIT
 
 validate_reasoning_config() {
   python - "$REASONING_CONFIG" <<'PY'
@@ -128,12 +140,14 @@ record_single_turn() {
   local model="$3"
   local output="$4"
   local stream_flag="$5"
+  local staged_output
   local temporary_output
 
-  temporary_output="$(mktemp "$BASE_DIR/.reasoning-cassette.XXXXXX")"
+  staged_output="$STAGING_DIR/$(basename "$output")"
+  temporary_output="$(mktemp "$STAGING_DIR/.reasoning-cassette.XXXXXX")"
 
   if ! printf '%s\n' "$PROMPT" \
-    | python "$SCRIPTS_DIR/record_cassette.py" \
+    | python "$RECORDER" \
         --mode responses \
         --turns 1 \
         "$stream_flag" \
@@ -151,8 +165,19 @@ record_single_turn() {
     rm -f -- "$temporary_output"
     return 1
   fi
-  mv -- "$temporary_output" "$output"
-  green "✓ reasoning cassette recorded -> $output"
+  mv -- "$temporary_output" "$staged_output"
+  STAGED_OUTPUTS+=("$staged_output")
+  FINAL_OUTPUTS+=("$output")
+  green "✓ reasoning cassette validated -> $output"
+}
+
+promote_recorded_suite() {
+  local index
+
+  for index in "${!STAGED_OUTPUTS[@]}"; do
+    mv -- "${STAGED_OUTPUTS[$index]}" "${FINAL_OUTPUTS[$index]}"
+    green "✓ reasoning cassette promoted -> ${FINAL_OUTPUTS[$index]}"
+  done
 }
 
 record_provider_suite() {
@@ -190,8 +215,8 @@ esac
 
 validate_reasoning_config
 
-# Validate OpenAI requirements before recording the gateway suite so a default
-# `all` run cannot leave only half of the comparison fixtures.
+# Validate OpenAI requirements before making any live requests. Final fixtures
+# remain unchanged until every selected recording has completed validation.
 if [[ "$REASONING_RECORD_SET" == "openai" || "$REASONING_RECORD_SET" == "all" ]]; then
   if [[ -z "${OPENAI_API_KEY:-}" ]]; then
     echo "ERROR: OPENAI_API_KEY must be set for REASONING_RECORD_SET=$REASONING_RECORD_SET" >&2
@@ -200,6 +225,7 @@ if [[ "$REASONING_RECORD_SET" == "openai" || "$REASONING_RECORD_SET" == "all" ]]
 fi
 
 mkdir -p "$BASE_DIR"
+STAGING_DIR="$(mktemp -d "$BASE_DIR/.reasoning-suite.XXXXXX")"
 
 if [[ "$REASONING_RECORD_SET" == "openai" || "$REASONING_RECORD_SET" == "all" ]]; then
   record_provider_suite \
@@ -224,3 +250,5 @@ if [[ "$REASONING_RECORD_SET" == "vllm" ]]; then
     "$MODEL" \
     "reasoning-single-${MODEL_SLUG}"
 fi
+
+promote_recorded_suite

--- a/crates/agentic-server-core/tests/dispatch_loop_cassette_test.rs
+++ b/crates/agentic-server-core/tests/dispatch_loop_cassette_test.rs
@@ -122,6 +122,7 @@ fn request(text: &str, tools: Option<Vec<ResponsesTool>>) -> RequestPayload {
         stream: false,
         store: true,
         include: None,
+        reasoning: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),

--- a/crates/agentic-server-core/tests/reasoning_test.rs
+++ b/crates/agentic-server-core/tests/reasoning_test.rs
@@ -11,6 +11,23 @@ const GATEWAY_MODEL_SLUG: &str = "gpt-5.6";
 const OPENAI_MODEL: &str = "gpt-5.6";
 const OPENAI_MODEL_SLUG: &str = "gpt-5.6";
 const PROMPT: &str = "Determine whether 47 is the unique two-digit positive integer whose digits sum to 11 and whose reversal is 27 larger. Analyze the constraints, then reply with exactly one word: VALID or INVALID.";
+const EXPECTED_STREAMING_LIFECYCLE: &[&str] = &[
+    "response.created",
+    "response.in_progress",
+    "response.output_item.added:reasoning",
+    "response.reasoning_summary_part.added",
+    "response.reasoning_summary_text.delta",
+    "response.reasoning_summary_text.done",
+    "response.reasoning_summary_part.done",
+    "response.output_item.done:reasoning",
+    "response.output_item.added:message",
+    "response.content_part.added",
+    "response.output_text.delta",
+    "response.output_text.done",
+    "response.content_part.done",
+    "response.output_item.done:message",
+    "response.completed",
+];
 
 fn expected_reasoning() -> Value {
     json!({"effort": "high", "summary": "detailed"})
@@ -51,6 +68,10 @@ fn assert_request_contract(openai: &support::Cassette, gateway: &support::Casset
 
     assert_eq!(openai.path, "/v1/responses");
     assert_eq!(gateway.path, openai.path);
+    assert_eq!(
+        gateway.body, openai.body,
+        "OpenAI and gateway recordings must contain the same complete request body"
+    );
     assert_eq!(openai.body.model.as_deref(), Some(OPENAI_MODEL));
     assert_eq!(gateway.body.model.as_deref(), Some(GATEWAY_MODEL));
     assert_eq!(openai.body.input, PROMPT);
@@ -63,6 +84,149 @@ fn assert_request_contract(openai: &support::Cassette, gateway: &support::Casset
     assert_eq!(gateway.body.max_output_tokens, openai.body.max_output_tokens);
     assert_eq!(openai.body.reasoning, Some(expected_reasoning()));
     assert_eq!(gateway.body.reasoning, openai.body.reasoning);
+}
+
+fn lifecycle_event_name(event: &Value) -> String {
+    let event_type = event["type"].as_str().expect("stream event should contain a type");
+    if matches!(event_type, "response.output_item.added" | "response.output_item.done") {
+        let item_type = event["item"]["type"]
+            .as_str()
+            .expect("output-item lifecycle event should contain an item type");
+        format!("{event_type}:{item_type}")
+    } else {
+        event_type.to_owned()
+    }
+}
+
+fn normalized_streaming_lifecycle(events: &[Value]) -> Vec<String> {
+    let mut lifecycle = Vec::new();
+    for event in events {
+        let event_name = lifecycle_event_name(event);
+        let is_text_delta = matches!(
+            event_name.as_str(),
+            "response.reasoning_summary_text.delta" | "response.output_text.delta"
+        );
+        if is_text_delta && lifecycle.last() == Some(&event_name) {
+            continue;
+        }
+        lifecycle.push(event_name);
+    }
+    lifecycle
+}
+
+fn assert_item_lifecycle(events: &[Value], item_type: &str, expected_output_index: u64) {
+    let added = events
+        .iter()
+        .find(|event| event["type"] == "response.output_item.added" && event["item"]["type"] == item_type)
+        .unwrap_or_else(|| panic!("stream should add a {item_type} output item"));
+    let item_id = added["item"]["id"]
+        .as_str()
+        .unwrap_or_else(|| panic!("{item_type} output item should contain an id"));
+    let mut lifecycle_event_count = 0;
+    let mut saw_done = false;
+
+    for event in events {
+        let event_item_id = event["item_id"].as_str().or_else(|| event["item"]["id"].as_str());
+        if event_item_id != Some(item_id) {
+            continue;
+        }
+        lifecycle_event_count += 1;
+        assert_eq!(
+            event["output_index"].as_u64(),
+            Some(expected_output_index),
+            "every {item_type} lifecycle event should retain one output index"
+        );
+        if event["type"] == "response.output_item.done" {
+            assert_eq!(event["item"]["type"], item_type);
+            saw_done = true;
+        }
+    }
+
+    assert!(
+        lifecycle_event_count >= 2,
+        "{item_type} should have a multi-event lifecycle"
+    );
+    assert!(saw_done, "{item_type} lifecycle should end with output_item.done");
+}
+
+fn assert_streamed_text_reconciles(events: &[Value], delta_type: &str, done_type: &str) -> String {
+    let delta_text = events
+        .iter()
+        .filter(|event| event["type"] == delta_type)
+        .map(|event| event["delta"].as_str().expect("text delta should contain delta text"))
+        .collect::<String>();
+    assert!(!delta_text.is_empty(), "{delta_type} events should contain text");
+
+    let done_events = events
+        .iter()
+        .filter(|event| event["type"] == done_type)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        done_events.len(),
+        1,
+        "stream should contain exactly one {done_type} event"
+    );
+    assert_eq!(
+        done_events[0]["text"].as_str(),
+        Some(delta_text.as_str()),
+        "the authoritative {done_type} text should equal the accumulated deltas"
+    );
+    delta_text
+}
+
+fn assert_streaming_contract(turn: &support::Turn) -> Vec<String> {
+    let events = support::recorded_named_sse_events(turn);
+    let sequence_numbers = events
+        .iter()
+        .map(|event| {
+            event["sequence_number"]
+                .as_u64()
+                .expect("every recorded stream event should contain a sequence number")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        sequence_numbers,
+        (0..u64::try_from(events.len()).expect("stream length should fit in u64")).collect::<Vec<_>>(),
+        "stream sequence numbers should be unique and contiguous"
+    );
+
+    let lifecycle = normalized_streaming_lifecycle(&events);
+    assert_eq!(lifecycle, EXPECTED_STREAMING_LIFECYCLE);
+    assert_item_lifecycle(&events, "reasoning", 0);
+    assert_item_lifecycle(&events, "message", 1);
+
+    let reasoning_text = assert_streamed_text_reconciles(
+        &events,
+        "response.reasoning_summary_text.delta",
+        "response.reasoning_summary_text.done",
+    );
+    let output_text =
+        assert_streamed_text_reconciles(&events, "response.output_text.delta", "response.output_text.done");
+    let terminal = terminal_response(turn);
+    let terminal_reasoning_text = terminal["output"]
+        .as_array()
+        .expect("completed response should contain output")
+        .iter()
+        .find(|item| item["type"] == "reasoning")
+        .and_then(|item| item["summary"].as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|part| part["text"].as_str())
+        .collect::<String>();
+    let terminal_output_text = terminal["output"]
+        .as_array()
+        .expect("completed response should contain output")
+        .iter()
+        .find(|item| item["type"] == "message")
+        .and_then(|item| item["content"].as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|part| part["text"].as_str())
+        .collect::<String>();
+    assert_eq!(terminal_reasoning_text, reasoning_text);
+    assert_eq!(terminal_output_text, output_text);
+
+    lifecycle
 }
 
 fn assert_terminal_contract(turn: &support::Turn) {
@@ -162,6 +326,9 @@ async fn recorded_streaming_reasoning_matches_openai_contract() {
     assert_request_contract(&openai, &gateway, true);
     assert_terminal_contract(&openai.turns[0]);
     assert_terminal_contract(&gateway.turns[0]);
+    let openai_lifecycle = assert_streaming_contract(&openai.turns[0]);
+    let gateway_lifecycle = assert_streaming_contract(&gateway.turns[0]);
+    assert_eq!(gateway_lifecycle, openai_lifecycle);
 
     assert_replayed_output(&replay_through_gateway(&openai.turns[0]).await);
     assert_replayed_output(&replay_through_gateway(&gateway.turns[0]).await);

--- a/crates/agentic-server-core/tests/reasoning_test.rs
+++ b/crates/agentic-server-core/tests/reasoning_test.rs
@@ -1,0 +1,168 @@
+use agentic_core::executor::ExecuteRequest;
+use agentic_core::types::io::OutputItem;
+use agentic_core::types::request_response::{RequestPayload, ResponsePayload};
+use serde_json::{Value, json};
+
+mod support;
+
+const CASSETTE_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/cassettes/reasoning/responses");
+const GATEWAY_MODEL: &str = "gpt-5.6";
+const GATEWAY_MODEL_SLUG: &str = "gpt-5.6";
+const OPENAI_MODEL: &str = "gpt-5.6";
+const OPENAI_MODEL_SLUG: &str = "gpt-5.6";
+const PROMPT: &str = "Determine whether 47 is the unique two-digit positive integer whose digits sum to 11 and whose reversal is 27 larger. Analyze the constraints, then reply with exactly one word: VALID or INVALID.";
+
+fn expected_reasoning() -> Value {
+    json!({"effort": "high", "summary": "detailed"})
+}
+
+fn load_recorded_pair(streaming: bool) -> (support::Cassette, support::Cassette) {
+    let mode = if streaming { "streaming" } else { "nonstreaming" };
+    let openai = support::load_cassette(&format!(
+        "{CASSETTE_DIR}/reasoning-openai-reference-{OPENAI_MODEL_SLUG}-{mode}.yaml"
+    ));
+    let gateway = support::load_cassette(&format!(
+        "{CASSETTE_DIR}/reasoning-gateway-{GATEWAY_MODEL_SLUG}-{mode}.yaml"
+    ));
+    (openai, gateway)
+}
+
+fn terminal_response(turn: &support::Turn) -> Value {
+    if let Some(body) = &turn.response.body {
+        return body.clone();
+    }
+
+    support::recorded_named_sse_events(turn)
+        .into_iter()
+        .rev()
+        .find_map(|event| {
+            (event["type"] == "response.completed")
+                .then(|| event.get("response").cloned())
+                .flatten()
+        })
+        .expect("streaming cassette should contain response.completed")
+}
+
+fn assert_request_contract(openai: &support::Cassette, gateway: &support::Cassette, streaming: bool) {
+    assert_eq!(openai.turns.len(), 1);
+    assert_eq!(gateway.turns.len(), 1);
+    let openai = &openai.turns[0].request;
+    let gateway = &gateway.turns[0].request;
+
+    assert_eq!(openai.path, "/v1/responses");
+    assert_eq!(gateway.path, openai.path);
+    assert_eq!(openai.body.model.as_deref(), Some(OPENAI_MODEL));
+    assert_eq!(gateway.body.model.as_deref(), Some(GATEWAY_MODEL));
+    assert_eq!(openai.body.input, PROMPT);
+    assert_eq!(gateway.body.input, openai.body.input);
+    assert!(openai.body.store);
+    assert_eq!(gateway.body.store, openai.body.store);
+    assert_eq!(openai.body.stream, streaming);
+    assert_eq!(gateway.body.stream, openai.body.stream);
+    assert_eq!(openai.body.max_output_tokens, Some(2048));
+    assert_eq!(gateway.body.max_output_tokens, openai.body.max_output_tokens);
+    assert_eq!(openai.body.reasoning, Some(expected_reasoning()));
+    assert_eq!(gateway.body.reasoning, openai.body.reasoning);
+}
+
+fn assert_terminal_contract(turn: &support::Turn) {
+    let response = terminal_response(turn);
+    assert_eq!(response["status"], "completed");
+    let output = response["output"]
+        .as_array()
+        .expect("completed response should contain output");
+    let reasoning = output
+        .iter()
+        .find(|item| item["type"] == "reasoning")
+        .expect("explicit reasoning request should produce a reasoning item");
+    let has_reasoning_text = ["content", "summary"].into_iter().any(|field| {
+        reasoning[field].as_array().is_some_and(|parts| {
+            parts
+                .iter()
+                .any(|part| part["text"].as_str().is_some_and(|text| !text.is_empty()))
+        })
+    });
+    let has_encrypted_reasoning = reasoning["encrypted_content"]
+        .as_str()
+        .is_some_and(|content| !content.is_empty());
+    assert!(
+        has_reasoning_text || has_encrypted_reasoning,
+        "reasoning item should contain recorded reasoning content"
+    );
+    let message = output
+        .iter()
+        .find(|item| item["type"] == "message")
+        .expect("completed response should contain a message");
+    assert_eq!(message["status"], "completed");
+    let text = message["content"]
+        .as_array()
+        .expect("message should contain content")
+        .iter()
+        .filter_map(|part| part["text"].as_str())
+        .collect::<String>();
+    assert_eq!(text.trim(), "VALID");
+}
+
+async fn replay_through_gateway(turn: &support::Turn) -> ResponsePayload {
+    let fixture = support::TestFixture::new(&[turn]).await;
+    let payload: RequestPayload = serde_json::from_value(json!({
+        "model": turn.request.body.model,
+        "input": turn.request.body.input,
+        "store": turn.request.body.store,
+        "stream": turn.request.body.stream,
+        "max_output_tokens": turn.request.body.max_output_tokens,
+        "reasoning": turn.request.body.reasoning,
+    }))
+    .expect("recorded request should satisfy the gateway request schema");
+    let streaming = payload.stream;
+
+    let result = ExecuteRequest::new(payload, fixture.exec_ctx.clone())
+        .run()
+        .await
+        .expect("recorded response should replay through the gateway");
+    let response = if streaming {
+        support::collect_stream(result).await
+    } else {
+        support::unwrap_blocking(result)
+    };
+
+    let requests = fixture.request_bodies().await;
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0]["reasoning"], expected_reasoning());
+    assert_eq!(requests[0]["stream"], streaming);
+    response
+}
+
+fn assert_replayed_output(response: &ResponsePayload) {
+    assert_eq!(response.status, "completed");
+    assert!(
+        response
+            .output
+            .iter()
+            .any(|item| matches!(item, OutputItem::Reasoning(_))),
+        "gateway replay should retain the reasoning item"
+    );
+    assert_eq!(support::output_text(response).trim(), "VALID");
+}
+
+#[tokio::test]
+async fn recorded_nonstreaming_reasoning_matches_openai_contract() {
+    let (openai, gateway) = load_recorded_pair(false);
+    assert_request_contract(&openai, &gateway, false);
+    assert_terminal_contract(&openai.turns[0]);
+    assert_terminal_contract(&gateway.turns[0]);
+
+    assert_replayed_output(&replay_through_gateway(&openai.turns[0]).await);
+    assert_replayed_output(&replay_through_gateway(&gateway.turns[0]).await);
+}
+
+#[tokio::test]
+async fn recorded_streaming_reasoning_matches_openai_contract() {
+    let (openai, gateway) = load_recorded_pair(true);
+    assert_request_contract(&openai, &gateway, true);
+    assert_terminal_contract(&openai.turns[0]);
+    assert_terminal_contract(&gateway.turns[0]);
+
+    assert_replayed_output(&replay_through_gateway(&openai.turns[0]).await);
+    assert_replayed_output(&replay_through_gateway(&gateway.turns[0]).await);
+}

--- a/crates/agentic-server-core/tests/support/mod.rs
+++ b/crates/agentic-server-core/tests/support/mod.rs
@@ -16,7 +16,7 @@ use axum::routing::post;
 use either::Either;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{Map, Value};
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 
@@ -42,7 +42,7 @@ pub struct TurnRequest {
     pub body: TurnBody,
 }
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Deserialize, Default, PartialEq)]
 pub struct TurnBody {
     #[serde(default)]
     pub model: Option<String>,
@@ -60,6 +60,8 @@ pub struct TurnBody {
     pub max_output_tokens: Option<u64>,
     #[serde(default)]
     pub reasoning: Option<Value>,
+    #[serde(flatten)]
+    pub extra: Map<String, Value>,
 }
 
 fn default_true() -> bool {

--- a/crates/agentic-server-core/tests/support/mod.rs
+++ b/crates/agentic-server-core/tests/support/mod.rs
@@ -423,6 +423,7 @@ pub fn make_request(
         stream,
         store,
         include: None,
+        reasoning: None,
         temperature: None,
         top_p: None,
         max_output_tokens: None,

--- a/crates/agentic-server-core/tests/support/mod.rs
+++ b/crates/agentic-server-core/tests/support/mod.rs
@@ -58,6 +58,8 @@ pub struct TurnBody {
     pub tool_choice: Option<Value>,
     #[serde(default)]
     pub max_output_tokens: Option<u64>,
+    #[serde(default)]
+    pub reasoning: Option<Value>,
 }
 
 fn default_true() -> bool {

--- a/crates/agentic-server-core/tests/web_search_tool_test.rs
+++ b/crates/agentic-server-core/tests/web_search_tool_test.rs
@@ -1058,6 +1058,9 @@ async fn execute_runs_web_search_and_sends_tool_output_back_to_model() {
         stream: false,
         store: true,
         include: None,
+        reasoning: Some(Box::new(
+            serde_json::from_value(serde_json::json!({"effort": "high"})).unwrap(),
+        )),
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),
@@ -1080,6 +1083,8 @@ async fn execute_runs_web_search_and_sends_tool_output_back_to_model() {
     assert_eq!(request_bodies.len(), 2);
     assert_eq!(request_bodies[0]["tools"][0]["name"], "web_search");
     assert_eq!(request_bodies[0]["max_output_tokens"], 1024);
+    assert_eq!(request_bodies[0]["reasoning"], serde_json::json!({"effort": "high"}));
+    assert_eq!(request_bodies[1]["reasoning"], serde_json::json!({"effort": "high"}));
     let second_input = request_bodies[1]["input"]
         .as_array()
         .expect("second request input array");
@@ -1144,6 +1149,7 @@ async fn execute_relaxes_forced_tool_choice_after_web_search_result() {
         stream: false,
         store: true,
         include: None,
+        reasoning: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),
@@ -1194,6 +1200,7 @@ async fn execute_returns_mixed_client_tool_calls_without_followup_model_request(
         stream: false,
         store: true,
         include: None,
+        reasoning: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),
@@ -1243,6 +1250,7 @@ async fn execute_returns_mixed_client_tool_calls_without_followup_model_request(
         stream: false,
         store: true,
         include: None,
+        reasoning: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),
@@ -1263,12 +1271,8 @@ async fn execute_returns_mixed_client_tool_calls_without_followup_model_request(
         .iter()
         .find(|item| item["type"] == "function_call_output" && item["call_id"] == "call_search")
         .expect("continuation includes persisted web_search output");
-    assert!(
-        tool_output["output"]
-            .as_str()
-            .unwrap()
-            .contains("https://example.com/rust")
-    );
+    let tool_output = tool_output["output"].as_str().unwrap();
+    assert!(tool_output.contains("https://example.com/rust"));
 }
 
 #[tokio::test]
@@ -1315,6 +1319,7 @@ async fn execute_accumulates_usage_across_web_search_model_rounds() {
         stream: false,
         store: true,
         include: None,
+        reasoning: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),
@@ -1360,6 +1365,7 @@ async fn stream_emits_web_search_lifecycle_events_before_final_payload() {
         stream: true,
         store: true,
         include: None,
+        reasoning: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),
@@ -1480,6 +1486,7 @@ async fn multi_round_stream_has_single_lifecycle_and_monotonic_public_sequence()
         stream: true,
         store: true,
         include: None,
+        reasoning: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),
@@ -1555,6 +1562,7 @@ async fn stream_hides_web_search_function_events_when_name_arrives_on_done() {
         stream: true,
         store: true,
         include: None,
+        reasoning: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),
@@ -1619,6 +1627,7 @@ async fn stream_orders_gateway_lifecycle_before_later_client_function_events() {
         stream: true,
         store: true,
         include: None,
+        reasoning: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),
@@ -1702,6 +1711,7 @@ async fn execute_runs_multiple_web_search_calls_concurrently() {
         stream: false,
         store: true,
         include: None,
+        reasoning: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),
@@ -1752,6 +1762,7 @@ async fn execute_feeds_web_search_execution_errors_back_to_model() {
         stream: false,
         store: true,
         include: None,
+        reasoning: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),
@@ -1804,6 +1815,7 @@ async fn execute_returns_incomplete_after_max_gateway_tool_rounds() {
         stream: false,
         store: true,
         include: None,
+        reasoning: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),
@@ -1856,6 +1868,7 @@ async fn execute_feeds_invalid_web_search_arguments_back_to_model() {
         stream: false,
         store: true,
         include: None,
+        reasoning: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),
@@ -1915,6 +1928,7 @@ async fn execute_runs_large_gateway_fanout_without_hard_cap() {
         stream: false,
         store: true,
         include: None,
+        reasoning: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),
@@ -1982,6 +1996,7 @@ async fn stream_error_events_escape_error_messages() {
         stream: true,
         store: true,
         include: None,
+        reasoning: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),
@@ -2056,6 +2071,7 @@ async fn incomplete_turn_persists_a_consistent_conversation_for_continuation() {
         stream: false,
         store: true,
         include: None,
+        reasoning: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),
@@ -2084,6 +2100,7 @@ async fn incomplete_turn_persists_a_consistent_conversation_for_continuation() {
         stream: false,
         store: true,
         include: None,
+        reasoning: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),
@@ -2156,6 +2173,7 @@ async fn stream_returns_incomplete_after_max_gateway_tool_rounds() {
         stream: true,
         store: true,
         include: None,
+        reasoning: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),

--- a/crates/agentic-server/tests/compaction_test.rs
+++ b/crates/agentic-server/tests/compaction_test.rs
@@ -326,6 +326,7 @@ async fn automatic_compaction_runs_above_threshold_and_accumulates_usage() {
             "input": [{"role": "user", "content": "x".repeat(200)}],
             "store": false,
             "stream": false,
+            "reasoning": {"effort": "high"},
             "context_management": [{"type": "compaction", "compact_threshold": 10}]
         }))
         .send()
@@ -346,6 +347,7 @@ async fn automatic_compaction_runs_above_threshold_and_accumulates_usage() {
     assert_eq!(requests[1]["input"][0]["role"], "user");
     assert_eq!(requests[1]["input"][1]["role"], "assistant");
     assert_eq!(requests[1]["input"][1]["content"][0]["text"], "automatic summary");
+    assert_eq!(requests[1]["reasoning"], serde_json::json!({"effort": "high"}));
 }
 
 #[tokio::test]

--- a/crates/agentic-server/tests/responses_test.rs
+++ b/crates/agentic-server/tests/responses_test.rs
@@ -459,6 +459,38 @@ async fn test_store_false_with_web_search_reaches_executor() {
 }
 
 #[tokio::test]
+async fn test_stateful_request_forwards_reasoning_configuration() {
+    let (llm_url, requests, _llm) = spawn_mock_vllm_json_capture().await;
+    let fixture = storage_backed_state(&llm_url).await;
+    let (gateway_url, _gateway) = spawn_gateway(fixture.state.clone()).await;
+    let reasoning = serde_json::json!({
+        "context": "all_turns",
+        "effort": "high",
+        "generate_summary": "concise",
+        "mode": "pro",
+        "summary": "detailed"
+    });
+
+    let response = reqwest::Client::new()
+        .post(format!("{gateway_url}/v1/responses"))
+        .json(&serde_json::json!({
+            "model": "test",
+            "input": "hi",
+            "reasoning": reasoning,
+            "store": true,
+            "stream": false
+        }))
+        .send()
+        .await
+        .expect("stateful response request");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let requests = requests.lock().await;
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0]["reasoning"], reasoning);
+}
+
+#[tokio::test]
 async fn test_gateway_normalization_preserves_parallel_tool_calls() {
     // Arrange
     let (llm_url, requests, _h1) = spawn_mock_vllm_json_capture().await;

--- a/crates/agentic-server/tests/responses_websocket_test.rs
+++ b/crates/agentic-server/tests/responses_websocket_test.rs
@@ -838,6 +838,7 @@ async fn test_websocket_first_turn_forwards_incremental_events_and_final_payload
             "type": "response.create",
             "model": "test-model",
             "input": [{"type": "message", "role": "user", "content": "hi"}],
+            "reasoning": {"effort": "high"},
             "store": true,
             "stream": true
         }),
@@ -868,6 +869,7 @@ async fn test_websocket_first_turn_forwards_incremental_events_and_final_payload
     assert_eq!(requests.len(), 1);
     assert_eq!(requests[0]["stream"], true);
     assert_eq!(requests[0]["input"][0]["content"], "hi");
+    assert_eq!(requests[0]["reasoning"], json!({"effort": "high"}));
     assert!(requests[0].get("type").is_none());
 }
 


### PR DESCRIPTION
## Summary

Stateful Responses requests deserialize through `RequestPayload`. Before this change, that type did not model `reasoning`, so the executor silently dropped the complete reasoning configuration before constructing the upstream request. This affected stored requests, continuations, gateway-tool requests, context-managed requests, and Responses WebSocket mode; the `store: false` transparent proxy path already forwarded the original body unchanged.

This PR adds a typed `ReasoningConfig` for the current Responses fields (`context`, `effort`, `generate_summary`, `mode`, and `summary`) and borrows it into `UpstreamRequest`. The optional nested object is boxed so requests without reasoning do not inflate executor futures. The same per-request configuration now survives rehydration, automatic compaction of the input, streaming, and repeated gateway-tool rounds.

The modeled fields match the current [OpenAI Responses API](https://developers.openai.com/api/reference/cli/resources/responses/methods/create) and the `Reasoning` object accepted by current [vLLM `ResponsesRequest`](https://github.com/vllm-project/vllm/blob/82936c409d17321d5a791796296790508605aaed/vllm/entrypoints/openai/responses/protocol.py#L137-L178).

## Recorded behavior

The cassette recorder now accepts a validated `--reasoning` JSON object and applies it to ordinary and branched Responses requests. `record_reasoning_cassettes.sh` records matching streaming and non-streaming pairs from OpenAI and through the gateway, with an optional direct-vLLM mode. The script stages and validates the complete selected suite before replacing any checked-in fixture, so a later provider failure cannot leave a partially refreshed comparison set.

The four checked-in fixtures were generated by `record_cassette.py` from live `gpt-5.6` requests. The direct and gateway-facing request bodies are exactly equal, including unmodeled keys: same deterministic prompt, `max_output_tokens: 2048`, and `reasoning: {effort: high, summary: detailed}`. Every terminal response contains substantive reasoning and the exact final answer `VALID`. Streaming coverage checks the documented reasoning-summary and message lifecycles, contiguous sequence numbers, stable item IDs and output indexes, authoritative done text, and terminal-response reconciliation before replaying both recordings through the gateway.

The four recorder-generated YAML fixtures account for 2,737 of the PR's 3,557 added lines; they contain 260 captured SSE events. The functional production change remains confined to typed request parsing and upstream serialization.

Recording the gateway pair against the same OpenAI model exposed one pre-existing serialization inconsistency: an absent vLLM-only `cache_salt` was emitted upstream as `null`, which OpenAI rejects as an unknown parameter. The follow-up omits only `None`, matching every neighboring optional upstream field, while preserving non-empty cache salts verbatim; a regression covers both cases.

## Compatibility

- Missing or `null` reasoning remains absent upstream; an empty object remains `{}`.
- Current field values are forwarded verbatim so model-specific validation remains with the upstream service.
- Malformed non-object configurations and non-string known fields fail during typed request parsing.
- Reasoning stays a per-request generation setting. Persistence metadata, response payload shape, and internal compaction-summary policy are unchanged; the client configuration is retained for the final response call.
- A present `cache_salt` is unchanged; only an absent value is omitted instead of serialized as JSON `null`.

## Test plan

Negative controls:

- Unmodified `main` drops the five-field reasoning object from the upstream request.
- The former PR head emits `cache_salt: null`; the live OpenAI-backed gateway request fails with `Unknown parameter: 'cache_salt'`.
- An injected unmodeled request mismatch and an injected non-contiguous stream sequence each make the new integration test fail at the intended assertion.
- A forced failure on the third recording leaves all four pre-existing fixtures byte-identical and removes the staging directory; a successful four-recording stub run promotes exactly the selected suite.
- Malformed reasoning JSON, non-object JSON, unsupported recorder modes, an invalid record set, a missing OpenAI key, and an unreachable gateway fail closed.

Exact head `4270f60d5cd386ddae77bf9fbd57b686949d695b`, based on current `main` `b1dbce5e1f72c8d3058b437f371c0bbdf89fc4b5`:

- live direct-OpenAI and gateway recording: streaming and non-streaming pairs passed validation;
- four-fixture structural audit: complete request-pair equality, HTTP 200, 260 parseable SSE events, contiguous sequence numbers, completed reasoning and message items, exact `VALID` output, and zero supplied-credential matches;
- focused reasoning cassette replay: 2 passed;
- `cargo test --workspace --all-features`: 812 passed, 9 repository-declared PostgreSQL/core/doctest cases ignored, repeated at the exact SHA in a detached clean worktree;
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: passed;
- Python suite: 111 passed, 3 installation-only cases skipped;
- all configured pre-commit hooks: passed in the detached exact-SHA worktree;
- `cargo fmt --all -- --check` and `git diff --check`: passed;
- range-diff confirms the two previously reviewed commits are unchanged by the current-main rebase; the third commit contains only the cassette guardrail hardening.
- all 13 fresh GitHub checks on the exact head passed, including DCO, Rust, PostgreSQL, Python 3.10-3.13, pre-commit, container smoke, Kubernetes, Dynamo, and both harness integrations.
