### PR TITLE
fix: apply streaming timeout consistently

### DIFF
--- a/crates/agentic-server-core/src/executor/messages_stream.rs
+++ b/crates/agentic-server-core/src/executor/messages_stream.rs
@@ -16,7 +16,6 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
-use std::time::Duration;
 
 use async_stream::stream;
 use futures::StreamExt;
@@ -35,10 +34,6 @@ use crate::utils::common::{deserialize_from_str, serialize_to_string};
 use crate::executor::messages_loop::{
     GATEWAY_TOOL_TIMEOUT, MAX_GATEWAY_TOOL_ROUNDS, MessagesResponse, MessagesUpstream,
 };
-/// vLLM streaming chunk timeout (per line). Generous — the loop's own budget is
-/// the round cap, not this.
-const CHUNK_TIMEOUT: Duration = Duration::from_secs(600);
-
 /// Drive the streaming Messages-native loop, yielding Anthropic SSE lines for
 /// the client. Owns the multi-round → single-message accumulation.
 ///
@@ -93,7 +88,7 @@ pub async fn run_messages_stream(
                     Err(e) => { yield executor_error_sse(&e); return; }
                 }
             };
-            let mut response_stream = Box::pin(response_lines(response, CHUNK_TIMEOUT));
+            let mut response_stream = Box::pin(response_lines(response, exec_ctx.streaming_timeout));
 
             acc.begin_round();
             while let Some(line) = response_stream.next().await {

--- a/crates/agentic-server-core/src/executor/messages_stream.rs
+++ b/crates/agentic-server-core/src/executor/messages_stream.rs
@@ -37,7 +37,7 @@ use crate::executor::messages_loop::{
 };
 /// vLLM streaming chunk timeout (per line). Generous — the loop's own budget is
 /// the round cap, not this.
-const CHUNK_TIMEOUT: Duration = Duration::from_secs(120);
+const CHUNK_TIMEOUT: Duration = Duration::from_secs(600);
 
 /// Drive the streaming Messages-native loop, yielding Anthropic SSE lines for
 /// the client. Owns the multi-round → single-message accumulation.

--- a/crates/agentic-server-core/src/executor/request.rs
+++ b/crates/agentic-server-core/src/executor/request.rs
@@ -99,7 +99,7 @@ impl ExecutionContext {
             gateway_executors,
             messages_gateway_tools: messages_gateway_tools_from_env(),
             llm_base_url,
-            streaming_timeout: Duration::from_secs(30),
+            streaming_timeout: streaming_timeout_from_env(),
             storage_pool: None,
         }
     }
@@ -170,10 +170,17 @@ impl ExecutionContext {
                 .map(GatewayToolMap::from_env_str)
                 .unwrap_or_default(),
             llm_base_url: cfg.llm_api_base.clone(),
-            streaming_timeout: Duration::from_secs(30),
+            streaming_timeout: streaming_timeout_from_env(),
             storage_pool: Some(pool),
         })
     }
+}
+
+fn streaming_timeout_from_env() -> Duration {
+    std::env::var("STREAMING_CHUNK_TIMEOUT_S")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map_or(Duration::from_secs(600), Duration::from_secs)
 }
 
 fn database_open_error(database_backend: DatabaseBackend, error: &sqlx::Error) -> Error {

--- a/crates/agentic-server-core/src/executor/request.rs
+++ b/crates/agentic-server-core/src/executor/request.rs
@@ -66,7 +66,7 @@ pub struct ExecutionContext {
     /// Base URL for the LLM backend, e.g. `"http://localhost:8000"`.
     pub llm_base_url: String,
     /// Maximum wait time for the next SSE chunk.  `Duration::ZERO` disables the timeout.
-    /// Sourced from [`Config::streaming_chunk_timeout_s`](crate::config::Config::streaming_chunk_timeout_s).
+    /// Sourced from the `STREAMING_CHUNK_TIMEOUT_S` environment variable, defaulting to 600 seconds.
     pub streaming_timeout: Duration,
     storage_pool: Option<Arc<crate::storage::DbPool>>,
 }
@@ -177,9 +177,12 @@ impl ExecutionContext {
 }
 
 fn streaming_timeout_from_env() -> Duration {
-    std::env::var("STREAMING_CHUNK_TIMEOUT_S")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
+    streaming_timeout_from_value(std::env::var("STREAMING_CHUNK_TIMEOUT_S").ok().as_deref())
+}
+
+fn streaming_timeout_from_value(value: Option<&str>) -> Duration {
+    value
+        .and_then(|value| value.parse::<u64>().ok())
         .map_or(Duration::from_secs(600), Duration::from_secs)
 }
 
@@ -222,7 +225,7 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use super::{ExecutionContext, database_open_error};
+    use super::{ExecutionContext, database_open_error, streaming_timeout_from_value};
     use crate::executor::{ConversationHandler, ResponseHandler};
     use crate::storage::{ConversationStore, DatabaseBackend, ResponseStore, create_pool_with_schema};
 
@@ -276,6 +279,17 @@ mod tests {
         assert!(message.contains("failed to open PostgreSQL database"));
         assert!(message.contains("postgresql://[redacted]"));
         assert!(!message.contains("postgres-secret"));
+    }
+
+    #[test]
+    fn streaming_timeout_from_value_uses_default_and_supports_disabling() {
+        assert_eq!(streaming_timeout_from_value(None), Duration::from_secs(600));
+        assert_eq!(
+            streaming_timeout_from_value(Some("not-a-number")),
+            Duration::from_secs(600)
+        );
+        assert_eq!(streaming_timeout_from_value(Some("0")), Duration::ZERO);
+        assert_eq!(streaming_timeout_from_value(Some("42")), Duration::from_secs(42));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Summary

- Route /v1/messages streaming chunk reads through ExecutionContext.streaming_timeout.
- Document STREAMING_CHUNK_TIMEOUT_S as the timeout source.
- Add coverage for unset, invalid, zero, and valid timeout values.

Test Plan

- cargo fmt -- --check
- cargo test
- cargo clippy --all-targets -- -D warnings