### PR TITLE
fix: make web search action construction fallible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ All notable changes to Agentic API are documented here.
 - Preserved MCP list-tools records in continuation history for registry lifecycle
   decisions while excluding them from model input, preventing repeated public
   list-tools emission on later turns.
+- Aligned the Codex integration design with the preferred client-executed and
+  gateway-executed tool terminology.
+
+### Fixed
+
+- Made web-search action construction return a typed error for empty query lists
+  instead of panicking.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,14 @@ All notable changes to Agentic API are documented here.
 - Preserved MCP list-tools records in continuation history for registry lifecycle
   decisions while excluding them from model input, preventing repeated public
   list-tools emission on later turns.
-- Aligned the Codex integration design with the preferred client-executed and
-  gateway-executed tool terminology.
+- Clarified Codex tool execution roles by replacing ambiguous ownership language
+  with the preferred client-executed and gateway-executed terminology.
 
 ### Fixed
 
-- Made web-search action construction return a typed error for empty query lists
-  instead of panicking.
+- Replaced `WebSearchActionSearch::new` and `WebSearchCall::new` with fallible
+  `try_new(...)` constructors; callers now handle `WebSearchActionError` for
+  empty query lists instead of risking a panic.
 
 ### Added
 

--- a/crates/agentic-server-core/src/executor/gateway.rs
+++ b/crates/agentic-server-core/src/executor/gateway.rs
@@ -696,7 +696,7 @@ mod tests {
         }
 
         fn plan_gateway_events(&self, call: &FunctionToolCall, _params: &WebSearchToolParam) -> GatewayToolEventPlan {
-            GatewayToolEventPlan::new(Some(crate::tool::web_search::started_output_item(call)))
+            GatewayToolEventPlan::new(crate::tool::web_search::started_output_item(call))
         }
 
         fn public_output(
@@ -706,7 +706,7 @@ mod tests {
             status: GatewayCallStatus,
             _params: &WebSearchToolParam,
         ) -> Option<OutputItem> {
-            Some(crate::tool::web_search::output_item(call, output, status))
+            crate::tool::web_search::output_item(call, output, status)
         }
     }
 

--- a/crates/agentic-server-core/src/tool/web_search.rs
+++ b/crates/agentic-server-core/src/tool/web_search.rs
@@ -98,7 +98,11 @@ pub(crate) fn web_search_function_tool() -> FunctionTool {
 }
 
 #[must_use]
-pub(crate) fn output_item(call: &FunctionToolCall, output: &ToolOutput, status: WebSearchCallStatus) -> OutputItem {
+pub(crate) fn output_item(
+    call: &FunctionToolCall,
+    output: &ToolOutput,
+    status: WebSearchCallStatus,
+) -> Option<OutputItem> {
     let parsed_output = serde_json::from_str::<Value>(&output.output).ok();
     let queries = parsed_output
         .as_ref()
@@ -106,17 +110,21 @@ pub(crate) fn output_item(call: &FunctionToolCall, output: &ToolOutput, status: 
         .or_else(|| queries_from_arguments(&call.arguments))
         .unwrap_or_else(|| vec![String::new()]);
     let sources = parsed_output.as_ref().map(sources_from_output).unwrap_or_default();
-    OutputItem::WebSearchCall(WebSearchCall::new(call_output_id(call), status, queries, sources))
+    WebSearchCall::try_new(call_output_id(call), status, queries, sources)
+        .map(OutputItem::WebSearchCall)
+        .ok()
 }
 
 #[must_use]
-pub(crate) fn started_output_item(call: &FunctionToolCall) -> OutputItem {
-    OutputItem::WebSearchCall(WebSearchCall::new(
+pub(crate) fn started_output_item(call: &FunctionToolCall) -> Option<OutputItem> {
+    WebSearchCall::try_new(
         call_output_id(call),
         WebSearchCallStatus::InProgress,
         queries_from_arguments(&call.arguments).unwrap_or_else(|| vec![String::new()]),
         Vec::new(),
-    ))
+    )
+    .map(OutputItem::WebSearchCall)
+    .ok()
 }
 
 #[derive(Debug, Clone)]
@@ -380,7 +388,7 @@ impl GatewayExecutor for WebSearchHandler {
     }
 
     fn plan_gateway_events(&self, call: &FunctionToolCall, _params: &WebSearchToolParam) -> GatewayToolEventPlan {
-        GatewayToolEventPlan::new(Some(started_output_item(call)))
+        GatewayToolEventPlan::new(started_output_item(call))
     }
 
     fn public_output(
@@ -390,7 +398,7 @@ impl GatewayExecutor for WebSearchHandler {
         status: WebSearchCallStatus,
         _params: &WebSearchToolParam,
     ) -> Option<OutputItem> {
-        Some(output_item(call, output, status))
+        output_item(call, output, status)
     }
 }
 

--- a/crates/agentic-server-core/src/types/io/mod.rs
+++ b/crates/agentic-server-core/src/types/io/mod.rs
@@ -11,8 +11,8 @@ pub use input::{
 pub use output::{
     ApplyDone, CustomToolCall, FunctionToolCall, GatewayCallStatus, McpCall, McpCallError, McpCallStatus,
     McpToolExecutionError, McpToolExecutionErrorContent, OutputItem, OutputMessage, OutputTextContent, ReasoningOutput,
-    ReasoningTextContent, WebSearchAction, WebSearchActionFindInPage, WebSearchActionOpenPage, WebSearchActionSearch,
-    WebSearchCall, WebSearchCallStatus, WebSearchSource,
+    ReasoningTextContent, WebSearchAction, WebSearchActionError, WebSearchActionFindInPage, WebSearchActionOpenPage,
+    WebSearchActionSearch, WebSearchCall, WebSearchCallStatus, WebSearchSource,
 };
 pub use tools::{AllowedTool, AllowedToolsMode, FunctionTool, ToolChoice};
 pub(crate) use tools::{resolve_tool_choice, resolve_tools};

--- a/crates/agentic-server-core/src/types/io/output.rs
+++ b/crates/agentic-server-core/src/types/io/output.rs
@@ -277,23 +277,31 @@ pub struct WebSearchActionSearch {
     pub sources: Vec<WebSearchSource>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum WebSearchActionError {
+    #[error("web search action requires at least one query")]
+    EmptyQueries,
+}
+
 fn default_web_search_action_search_type() -> String {
     "search".to_owned()
 }
 
 impl WebSearchActionSearch {
-    /// # Panics
+    /// Builds a search action from a non-empty query list.
     ///
-    /// Panics if `queries` is empty.
-    #[must_use]
-    pub fn new(queries: Vec<String>, sources: Vec<WebSearchSource>) -> Self {
-        let query = queries.first().expect("queries must have at least one entry").clone();
-        Self {
+    /// # Errors
+    ///
+    /// Returns [`WebSearchActionError::EmptyQueries`] if `queries` is empty.
+    pub fn try_new(queries: Vec<String>, sources: Vec<WebSearchSource>) -> Result<Self, WebSearchActionError> {
+        let query = queries.first().cloned().ok_or(WebSearchActionError::EmptyQueries)?;
+        Ok(Self {
             type_: default_web_search_action_search_type(),
             query,
             queries,
             sources,
-        }
+        })
     }
 }
 
@@ -345,18 +353,22 @@ pub struct WebSearchCall {
 }
 
 impl WebSearchCall {
-    #[must_use]
-    pub fn new(
+    /// Builds a web-search call from a non-empty query list.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WebSearchActionError::EmptyQueries`] if `queries` is empty.
+    pub fn try_new(
         id: impl Into<String>,
         status: WebSearchCallStatus,
         queries: Vec<String>,
         sources: Vec<WebSearchSource>,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, WebSearchActionError> {
+        Ok(Self {
             id: id.into(),
             status,
-            action: WebSearchAction::Search(WebSearchActionSearch::new(queries, sources)),
-        }
+            action: WebSearchAction::Search(WebSearchActionSearch::try_new(queries, sources)?),
+        })
     }
 }
 
@@ -900,13 +912,47 @@ mod tests {
     }
 
     #[test]
-    fn gateway_public_tool_outputs_are_not_replayed_as_model_input() {
-        let web_search = OutputItem::WebSearchCall(WebSearchCall::new(
+    fn web_search_call_rejects_empty_queries() {
+        let error = WebSearchCall::try_new("ws_1", WebSearchCallStatus::Completed, Vec::new(), Vec::new()).unwrap_err();
+
+        assert_eq!(error, WebSearchActionError::EmptyQueries);
+    }
+
+    #[test]
+    fn web_search_call_preserves_valid_search_action_wire_shape() {
+        let call = WebSearchCall::try_new(
             "ws_1",
             WebSearchCallStatus::Completed,
             vec!["rust async".to_owned()],
             Vec::new(),
-        ));
+        )
+        .unwrap();
+
+        assert_eq!(
+            serde_json::to_value(call).unwrap(),
+            serde_json::json!({
+                "id": "ws_1",
+                "status": "completed",
+                "action": {
+                    "type": "search",
+                    "query": "rust async",
+                    "queries": ["rust async"]
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn gateway_public_tool_outputs_are_not_replayed_as_model_input() {
+        let web_search = OutputItem::WebSearchCall(
+            WebSearchCall::try_new(
+                "ws_1",
+                WebSearchCallStatus::Completed,
+                vec!["rust async".to_owned()],
+                Vec::new(),
+            )
+            .unwrap(),
+        );
         let mcp = OutputItem::McpCall(McpCall::new(
             "mcp_1",
             "counter",

--- a/crates/agentic-server-core/src/types/io/output.rs
+++ b/crates/agentic-server-core/src/types/io/output.rs
@@ -841,8 +841,8 @@ impl OutputItem {
     }
 
     /// Shapes a stored output item as continuation input.
-    /// Gateway-owned public tool output is omitted because its model-facing
-    /// function call and result are persisted separately as input items. MCP
+    /// Public output for gateway-executed built-in tools is omitted because the model-facing
+    /// function call and output are persisted separately as input items. MCP
     /// list metadata is retained here and removed by `ResponsesInput::model_input`.
     #[must_use]
     pub fn to_input_item(&self) -> Option<InputItem> {

--- a/crates/agentic-server-core/src/types/mod.rs
+++ b/crates/agentic-server-core/src/types/mod.rs
@@ -11,8 +11,8 @@ pub use io::{
     InputTokenDetails, McpCall, McpCallError, McpCallStatus, McpToolExecutionError, McpToolExecutionErrorContent,
     OutputItem, OutputMessage, OutputTextContent, OutputTokenDetails, ReasoningOutput, ReasoningTextContent,
     ResponseUsage, ResponsesInput, ToolCallOutput, ToolChoice, ToolOutputContent, WebSearchAction,
-    WebSearchActionFindInPage, WebSearchActionOpenPage, WebSearchActionSearch, WebSearchCall, WebSearchCallStatus,
-    WebSearchSource,
+    WebSearchActionError, WebSearchActionFindInPage, WebSearchActionOpenPage, WebSearchActionSearch, WebSearchCall,
+    WebSearchCallStatus, WebSearchSource,
 };
 pub use request_response::{
     CompactRequest, CompactedResponse, ContextManagement, IncompleteDetails, ReasoningConfig, RequestPayload,

--- a/docs/design/codex-integration.md
+++ b/docs/design/codex-integration.md
@@ -155,7 +155,7 @@ For response items:
 
 ## Continuation
 
-Codex-owned tool calls must survive response-store continuation.
+Codex tool calls returned for client execution must survive response-store continuation.
 
 Expected rehydration shape:
 

--- a/docs/design/codex-integration.md
+++ b/docs/design/codex-integration.md
@@ -36,7 +36,7 @@ The current integration supports the typed executor path:
 - `ToolRegistry` builds a request-scoped namespace map once and uses it for final payload and streaming event
   restoration.
 - `GatewayExecutors` provides the shared web-search handler and builds request-scoped MCP handlers. The gateway executes
-  those tools while namespace and custom calls remain client-owned.
+  those tools while namespace and custom calls remain client-executed.
 - Stateful continuation stores effective tools, tool choice, instructions, and response/conversation linkage for later
   `previous_response_id` or `conversation_id` turns.
 - WebSocket Responses execution uses the same typed executor path and restores namespace tool-call events before sending
@@ -44,7 +44,7 @@ The current integration supports the typed executor path:
 
 Stateless `store=false` requests containing only ordinary `function` declarations remain byte-transparent raw proxy
 requests. Requests with continuation IDs or any non-function tool use the typed executor, where namespace and
-gateway-owned tool normalization occurs.
+gateway-executed built-in tool normalization occurs.
 
 ---
 
@@ -133,11 +133,11 @@ Responses tool shapes and execution semantics, so it can be always on.
 
 | Shape | Behavior |
 |-------|----------|
-| `function` | Client-owned. Preserve the declaration and return matching calls to the client. |
-| `namespace` | Client-owned Codex grouping for function tools. Flatten members only for upstream requests, then restore returned calls. |
-| `custom` | Client-owned freeform tool. Preserve its opaque format and forward it natively. |
-| `web_search_preview` | Gateway-owned and normalized to the web-search function tool. Without a usable provider, execution produces a failed tool result instead of changing ownership. |
-| `mcp` | Gateway-owned. Normalize discovered MCP tools to model-visible function tools, execute calls with request-scoped MCP bindings, and expose public `mcp_call` items. Streaming emits `response.output_item.added`, `response.mcp_call.in_progress`, `response.mcp_call_arguments.delta`/`.done`, `response.mcp_call.completed` or `.failed`, and `response.output_item.done`. |
+| `function` | Client-executed function tool. Preserve the declaration and return matching calls to the client. |
+| `namespace` | Client-executed Codex grouping for function tools. Flatten members only for upstream requests, then restore returned calls. |
+| `custom` | Client-executed custom tool. Preserve its opaque format and forward it natively. |
+| `web_search_preview` | Gateway-executed built-in tool normalized to the web-search function tool. Without a usable provider, execution produces a failed tool result instead of returning the call for client execution. |
+| `mcp` | Gateway-executed built-in tool. Normalize discovered MCP tools to model-visible function tools, execute calls with request-scoped MCP bindings, and expose public `mcp_call` items. Streaming emits `response.output_item.added`, `response.mcp_call.in_progress`, `response.mcp_call_arguments.delta`/`.done`, `response.mcp_call.completed` or `.failed`, and `response.output_item.done`. |
 | `file_search`, `code_interpreter` | Accepted by the typed request parser but skipped during upstream normalization because no gateway handler is registered yet. |
 | Unknown tool | Recognized and skipped on the typed path; opaque fields are not preserved or executed. Eligible raw-proxy requests remain byte-transparent. |
 
@@ -147,8 +147,8 @@ For response items:
 |---------------|----------|
 | `function_call` | Preserve optional `namespace`; restore flat namespace calls before returning to Codex. |
 | `custom_tool_call` | Preserve raw `input`; return it to Codex for local execution. |
-| `web_search_call` | Gateway-owned result from the web-search executor. |
-| `mcp_call` | Gateway-owned MCP execution result with `server_label`, discovered tool `name`, JSON-string `arguments`, and `status`; successful calls contain `output`, while failures contain a structured `mcp_tool_execution_error`. |
+| `web_search_call` | Result from the gateway-executed web-search tool. |
+| `mcp_call` | Result from a gateway-executed MCP tool with `server_label`, discovered tool `name`, JSON-string `arguments`, and `status`; successful calls contain `output`, while failures contain a structured `mcp_tool_execution_error`. |
 | Unknown output item | Recognized as an unknown unit variant on the typed path; opaque fields are not preserved or executed. |
 
 ---
@@ -163,11 +163,11 @@ Expected rehydration shape:
 prior context + assistant tool call + Codex tool output + new input
 ```
 
-On a turn that returns client-owned tool calls, storage keeps the assistant call item. On the next turn, Codex submits
+On a turn that returns client-executed tool calls, storage keeps the assistant call item. On the next turn, Codex submits
 the matching tool output item, and `previous_response_id` rebuilds the full sequence while preserving effective tool
 metadata from the previous response unless the client explicitly overrides it.
 
-Gateway-owned web-search and MCP public output items are not reconstructed as model input during continuation. Their
+Public output items for gateway-executed web search and MCP tools are not reconstructed as model input during continuation. Their
 internal `function_call` and matching `function_call_output` records are persisted as the canonical model-visible pair.
 MCP list-tools output is different: it rehydrates as an internal `InputItem::McpListTools` record so the request-scoped
 registry can avoid repeating that server label's public discovery lifecycle. `ResponsesInput::model_input()` removes


### PR DESCRIPTION
## Summary

- Follow up on review feedback from #214 by replacing the panic-prone `WebSearchActionSearch::new` and `WebSearchCall::new` constructors with fallible `try_new(...)` APIs backed by a typed `WebSearchActionError`.
- Preserve the existing valid web-search wire shape and adapt gateway output construction to the fallible API.
- Align the Codex integration docs and Rustdoc with the preferred client-executed and gateway-executed tool terminology.
- Record the constructor migration and terminology cleanup in the Unreleased changelog.

## Test Coverage

All 13 changed code paths are covered, including empty-query rejection, valid serialization, gateway start/completion output, and streaming/non-streaming integration flows.

## Pre-Landing Review

No blocking issues found. The adversarial review noted one unreachable swallowed-error path guarded by the existing non-empty query fallback.

## Documentation

- `CHANGELOG.md`: clarified tool-execution terminology and documented the fallible constructor migration.
- `output.rs`: aligned Rustdoc with gateway-executed built-in tool terminology.
- `codex-integration.md`: clarified client-executed continuation behavior.

Coverage is adequate for the shipped public surface; no architecture diagram drift was found.

## Test Plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `pre-commit run --all-files`
- [x] `mkdocs build --strict`
