### PR TITLE
fix: forward Responses text configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to Agentic API are documented here.
 
 ### Fixed
 
+- Forwarded Responses `text` generation settings, including structured output
+  formats and verbosity, through typed HTTP, WebSocket, and gateway-tool paths.
 - Replaced `WebSearchActionSearch::new` and `WebSearchCall::new` with fallible
   `try_new(...)` constructors; callers now handle `WebSearchActionError` for
   empty query lists instead of risking a panic.

--- a/crates/agentic-server-core/benches/executor_throughput.rs
+++ b/crates/agentic-server-core/benches/executor_throughput.rs
@@ -141,6 +141,7 @@ fn make_request(input: &str, stream: bool, prev_id: Option<String>) -> RequestPa
         store: true,
         include: None,
         reasoning: None,
+        text: None,
         temperature: None,
         top_p: None,
         max_output_tokens: None,

--- a/crates/agentic-server-core/src/executor/compaction.rs
+++ b/crates/agentic-server-core/src/executor/compaction.rs
@@ -147,6 +147,7 @@ fn request_payload(model: String, input: ResponsesInput, instructions: Option<St
         store: false,
         include: None,
         reasoning: None,
+        text: None,
         temperature: None,
         top_p: None,
         max_output_tokens: None,

--- a/crates/agentic-server-core/src/executor/modes/conversation.rs
+++ b/crates/agentic-server-core/src/executor/modes/conversation.rs
@@ -161,6 +161,7 @@ mod tests {
             store: true,
             include: None,
             reasoning: None,
+            text: None,
             temperature: None,
             top_p: None,
             max_output_tokens: None,

--- a/crates/agentic-server-core/src/executor/modes/response.rs
+++ b/crates/agentic-server-core/src/executor/modes/response.rs
@@ -117,6 +117,7 @@ mod tests {
             store: true,
             include: None,
             reasoning: None,
+            text: None,
             temperature: None,
             top_p: None,
             max_output_tokens: None,

--- a/crates/agentic-server-core/src/executor/rehydrate.rs
+++ b/crates/agentic-server-core/src/executor/rehydrate.rs
@@ -347,6 +347,7 @@ mod tests {
             store: true,
             include: None,
             reasoning: None,
+            text: None,
             temperature: None,
             top_p: None,
             max_output_tokens: None,

--- a/crates/agentic-server-core/src/executor/upstream.rs
+++ b/crates/agentic-server-core/src/executor/upstream.rs
@@ -314,6 +314,7 @@ mod tests {
             store: false,
             include: None,
             reasoning: None,
+            text: None,
             temperature: None,
             top_p: None,
             max_output_tokens: None,

--- a/crates/agentic-server-core/src/lib.rs
+++ b/crates/agentic-server-core/src/lib.rs
@@ -26,9 +26,9 @@ pub use types::{
     InputFunctionToolCall, InputImageContent, InputItem, InputMessage, InputMessageContent, InputTextContent,
     InputTokenDetails, McpCall, McpCallStatus, McpToolParam, NonEmptyToolName, OutputItem, OutputMessage,
     OutputTextContent, OutputTokenDetails, ReasoningConfig, ReasoningOutput, ReasoningTextContent, RequestPayload,
-    ResponsePayload, ResponseUsage, ResponsesInput, ResponsesTool, ToolCallOutput, ToolChoice, ToolOutputContent,
-    UpstreamRequest, UpstreamTool, WebSearchAction, WebSearchActionFindInPage, WebSearchActionOpenPage,
-    WebSearchActionSearch, WebSearchCall, WebSearchCallStatus, WebSearchContextSize, WebSearchFilters, WebSearchSource,
-    WebSearchToolParam, WebSearchUserLocation,
+    ResponsePayload, ResponseTextConfig, ResponseTextFormat, ResponseUsage, ResponsesInput, ResponsesTool,
+    ToolCallOutput, ToolChoice, ToolOutputContent, UpstreamRequest, UpstreamTool, WebSearchAction,
+    WebSearchActionFindInPage, WebSearchActionOpenPage, WebSearchActionSearch, WebSearchCall, WebSearchCallStatus,
+    WebSearchContextSize, WebSearchFilters, WebSearchSource, WebSearchToolParam, WebSearchUserLocation,
 };
 pub use utils::{utcnow_str, uuid7_str};

--- a/crates/agentic-server-core/src/types/mod.rs
+++ b/crates/agentic-server-core/src/types/mod.rs
@@ -16,7 +16,7 @@ pub use io::{
 };
 pub use request_response::{
     CompactRequest, CompactedResponse, ContextManagement, IncompleteDetails, ReasoningConfig, RequestPayload,
-    ResponsePayload, UpstreamRequest, UpstreamTool,
+    ResponsePayload, ResponseTextConfig, ResponseTextFormat, UpstreamRequest, UpstreamTool,
 };
 pub use tools::{
     CodeInterpreterToolParam, CodexNamespaceMember, CodexNamespaceToolParam, CustomToolParam, EmptyToolNameError,

--- a/crates/agentic-server-core/src/types/request_response.rs
+++ b/crates/agentic-server-core/src/types/request_response.rs
@@ -26,6 +26,50 @@ pub struct ReasoningConfig {
     pub summary: Option<String>,
 }
 
+/// Responses text-generation settings forwarded to the upstream service.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResponseTextConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub format: Option<ResponseTextFormat>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verbosity: Option<String>,
+    /// Unmodeled extension fields preserved for upstream compatibility.
+    #[serde(default)]
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// Output format requested through [`ResponseTextConfig`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ResponseTextFormat {
+    Text {
+        /// Unmodeled extension fields preserved for upstream compatibility.
+        #[serde(default)]
+        #[serde(flatten)]
+        extra: HashMap<String, Value>,
+    },
+    JsonObject {
+        /// Unmodeled extension fields preserved for upstream compatibility.
+        #[serde(default)]
+        #[serde(flatten)]
+        extra: HashMap<String, Value>,
+    },
+    JsonSchema {
+        name: String,
+        schema: serde_json::Map<String, Value>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        strict: Option<bool>,
+        /// Unmodeled extension fields preserved for upstream compatibility.
+        #[serde(default)]
+        #[serde(flatten)]
+        extra: HashMap<String, Value>,
+    },
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RequestPayload {
     pub model: String,
@@ -43,6 +87,8 @@ pub struct RequestPayload {
     pub include: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<Box<ReasoningConfig>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text: Option<Box<ResponseTextConfig>>,
     pub temperature: Option<f64>,
     pub top_p: Option<f64>,
     pub max_output_tokens: Option<u32>,
@@ -80,6 +126,8 @@ pub struct UpstreamRequest<'a> {
     pub include: Option<&'a Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<&'a ReasoningConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<&'a ResponseTextConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -179,6 +227,7 @@ impl RequestPayload {
             tool_choice: Some(tool_choice),
             include: self.include.as_ref(),
             reasoning: self.reasoning.as_deref(),
+            text: self.text.as_deref(),
             temperature: self.temperature,
             top_p: self.top_p,
             max_output_tokens: self.max_output_tokens,
@@ -400,6 +449,96 @@ mod tests {
 
             assert_eq!(upstream["reasoning"], reasoning);
             assert_eq!(upstream["stream"], stream);
+        }
+    }
+
+    #[test]
+    fn request_payload_forwards_text_configuration_upstream() {
+        let text = serde_json::json!({
+            "format": {
+                "type": "json_schema",
+                "name": "weather",
+                "description": "A weather report",
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "city": {"type": "string"},
+                        "temperature": {"type": "number"}
+                    },
+                    "required": ["city", "temperature"],
+                    "additionalProperties": false
+                },
+                "strict": true
+            },
+            "verbosity": "low"
+        });
+        let payload: RequestPayload = serde_json::from_value(serde_json::json!({
+            "model": "test-model",
+            "input": "hello",
+            "text": text
+        }))
+        .expect("request should deserialize");
+
+        for stream in [false, true] {
+            let upstream = serde_json::to_value(payload.to_upstream_request(stream).expect("request should normalize"))
+                .expect("upstream request should serialize");
+
+            assert_eq!(upstream["text"], text);
+            assert_eq!(upstream["stream"], stream);
+        }
+    }
+
+    #[test]
+    fn request_payload_handles_text_configuration_boundaries() {
+        for text in [
+            serde_json::json!({}),
+            serde_json::json!({"format": {"type": "text"}}),
+            serde_json::json!({"format": {"type": "json_object"}}),
+            serde_json::json!({"verbosity": "medium"}),
+            serde_json::json!({
+                "format": {"type": "text", "x-format-extension": true},
+                "x-text-extension": {"enabled": true}
+            }),
+        ] {
+            let payload: RequestPayload = serde_json::from_value(serde_json::json!({
+                "model": "test-model",
+                "input": "hello",
+                "text": text
+            }))
+            .expect("valid text configuration should deserialize");
+            let upstream = serde_json::to_value(payload.to_upstream_request(false).expect("request should normalize"))
+                .expect("upstream request should serialize");
+
+            assert_eq!(upstream["text"], text);
+        }
+
+        let payload: RequestPayload = serde_json::from_value(serde_json::json!({
+            "model": "test-model",
+            "input": "hello",
+            "text": null
+        }))
+        .expect("null text configuration should remain absent");
+        let upstream = serde_json::to_value(payload.to_upstream_request(false).expect("request should normalize"))
+            .expect("upstream request should serialize");
+        assert!(upstream.get("text").is_none());
+
+        for text in [
+            serde_json::json!("json_object"),
+            serde_json::json!({"format": "json_object"}),
+            serde_json::json!({"format": {"type": 7}}),
+            serde_json::json!({"format": {"type": "unknown"}}),
+            serde_json::json!({"format": {"type": "json_schema", "schema": {}}}),
+            serde_json::json!({"format": {"type": "json_schema", "name": "missing_schema"}}),
+            serde_json::json!({"format": {"type": "json_schema", "schema": []}}),
+            serde_json::json!({"verbosity": 1}),
+        ] {
+            let parsed = serde_json::from_value::<RequestPayload>(serde_json::json!({
+                "model": "test-model",
+                "input": "hello",
+                "text": text
+            }));
+
+            assert!(parsed.is_err(), "malformed text configuration should fail: {text}");
         }
     }
 

--- a/crates/agentic-server-core/tests/dispatch_loop_cassette_test.rs
+++ b/crates/agentic-server-core/tests/dispatch_loop_cassette_test.rs
@@ -123,6 +123,7 @@ fn request(text: &str, tools: Option<Vec<ResponsesTool>>) -> RequestPayload {
         store: true,
         include: None,
         reasoning: None,
+        text: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),

--- a/crates/agentic-server-core/tests/support/mod.rs
+++ b/crates/agentic-server-core/tests/support/mod.rs
@@ -432,6 +432,7 @@ pub fn make_request(
         store,
         include: None,
         reasoning: None,
+        text: None,
         temperature: None,
         top_p: None,
         max_output_tokens: None,

--- a/crates/agentic-server-core/tests/web_search_tool_test.rs
+++ b/crates/agentic-server-core/tests/web_search_tool_test.rs
@@ -10,7 +10,7 @@ use agentic_core::tool::{GatewayExecutor, WebSearchHandler};
 use agentic_core::types::io::{
     FunctionToolResultMessage, InputItem, OutputItem, ResponsesInput, ToolCallOutput, ToolChoice,
 };
-use agentic_core::types::request_response::RequestPayload;
+use agentic_core::types::request_response::{RequestPayload, ResponseTextConfig};
 use agentic_core::types::tools::{ResponsesTool, WebSearchToolParam};
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode, Uri};
@@ -1039,6 +1039,24 @@ async fn build_exec_ctx(llm_url: &str, you_url: String) -> Arc<ExecutionContext>
     )
 }
 
+fn json_object_text_config() -> ResponseTextConfig {
+    serde_json::from_value(serde_json::json!({
+        "format": {"type": "json_object"},
+        "verbosity": "low"
+    }))
+    .unwrap()
+}
+
+fn assert_generation_config_is_preserved(request_bodies: &[serde_json::Value]) {
+    assert_eq!(request_bodies[0]["reasoning"], serde_json::json!({"effort": "high"}));
+    assert_eq!(request_bodies[1]["reasoning"], request_bodies[0]["reasoning"]);
+    assert_eq!(
+        request_bodies[0]["text"],
+        serde_json::to_value(json_object_text_config()).unwrap()
+    );
+    assert_eq!(request_bodies[1]["text"], request_bodies[0]["text"]);
+}
+
 #[tokio::test]
 async fn execute_runs_web_search_and_sends_tool_output_back_to_model() {
     let (you_url, mut captured_you, _you_handle) = spawn_mock_you().await;
@@ -1063,6 +1081,7 @@ async fn execute_runs_web_search_and_sends_tool_output_back_to_model() {
         reasoning: Some(Box::new(
             serde_json::from_value(serde_json::json!({"effort": "high"})).unwrap(),
         )),
+        text: Some(Box::new(json_object_text_config())),
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),
@@ -1085,8 +1104,7 @@ async fn execute_runs_web_search_and_sends_tool_output_back_to_model() {
     assert_eq!(request_bodies.len(), 2);
     assert_eq!(request_bodies[0]["tools"][0]["name"], "web_search");
     assert_eq!(request_bodies[0]["max_output_tokens"], 1024);
-    assert_eq!(request_bodies[0]["reasoning"], serde_json::json!({"effort": "high"}));
-    assert_eq!(request_bodies[1]["reasoning"], serde_json::json!({"effort": "high"}));
+    assert_generation_config_is_preserved(&request_bodies);
     let second_input = request_bodies[1]["input"]
         .as_array()
         .expect("second request input array");
@@ -1168,6 +1186,7 @@ async fn execute_relaxes_forced_tool_choice_after_web_search_result() {
         store: true,
         include: None,
         reasoning: None,
+        text: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),
@@ -1201,6 +1220,7 @@ fn base_payload(input: ResponsesInput) -> RequestPayload {
         store: true,
         include: None,
         reasoning: None,
+        text: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),
@@ -1334,6 +1354,7 @@ async fn execute_accumulates_usage_across_web_search_model_rounds() {
         store: true,
         include: None,
         reasoning: None,
+        text: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),
@@ -1380,6 +1401,7 @@ async fn stream_emits_web_search_lifecycle_events_before_final_payload() {
         store: true,
         include: None,
         reasoning: None,
+        text: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),
@@ -1501,6 +1523,7 @@ async fn multi_round_stream_has_single_lifecycle_and_monotonic_public_sequence()
         store: true,
         include: None,
         reasoning: None,
+        text: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),
@@ -1577,6 +1600,7 @@ async fn stream_hides_web_search_function_events_when_name_arrives_on_done() {
         store: true,
         include: None,
         reasoning: None,
+        text: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),
@@ -1642,6 +1666,7 @@ async fn stream_orders_gateway_lifecycle_before_later_client_function_events() {
         store: true,
         include: None,
         reasoning: None,
+        text: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),
@@ -1726,6 +1751,7 @@ async fn execute_runs_multiple_web_search_calls_concurrently() {
         store: true,
         include: None,
         reasoning: None,
+        text: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),
@@ -1777,6 +1803,7 @@ async fn execute_feeds_web_search_execution_errors_back_to_model() {
         store: true,
         include: None,
         reasoning: None,
+        text: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),
@@ -1830,6 +1857,7 @@ async fn execute_returns_incomplete_after_max_gateway_tool_rounds() {
         store: true,
         include: None,
         reasoning: None,
+        text: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),
@@ -1883,6 +1911,7 @@ async fn execute_feeds_invalid_web_search_arguments_back_to_model() {
         store: true,
         include: None,
         reasoning: None,
+        text: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),
@@ -1943,6 +1972,7 @@ async fn execute_runs_large_gateway_fanout_without_hard_cap() {
         store: true,
         include: None,
         reasoning: None,
+        text: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),
@@ -2011,6 +2041,7 @@ async fn stream_error_events_escape_error_messages() {
         store: true,
         include: None,
         reasoning: None,
+        text: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),
@@ -2086,6 +2117,7 @@ async fn incomplete_turn_persists_a_consistent_conversation_for_continuation() {
         store: true,
         include: None,
         reasoning: None,
+        text: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),
@@ -2115,6 +2147,7 @@ async fn incomplete_turn_persists_a_consistent_conversation_for_continuation() {
         store: true,
         include: None,
         reasoning: None,
+        text: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),
@@ -2188,6 +2221,7 @@ async fn stream_returns_incomplete_after_max_gateway_tool_rounds() {
         store: true,
         include: None,
         reasoning: None,
+        text: None,
         temperature: None,
         top_p: None,
         max_output_tokens: Some(1024),

--- a/crates/agentic-server/tests/responses_test.rs
+++ b/crates/agentic-server/tests/responses_test.rs
@@ -491,6 +491,73 @@ async fn test_stateful_request_forwards_reasoning_configuration() {
 }
 
 #[tokio::test]
+async fn test_stateful_request_forwards_text_configuration() {
+    let (llm_url, requests, _llm) = spawn_mock_vllm_json_capture().await;
+    let fixture = storage_backed_state(&llm_url).await;
+    let (gateway_url, _gateway) = spawn_gateway(fixture.state.clone()).await;
+    let text = serde_json::json!({
+        "format": {
+            "type": "json_schema",
+            "name": "weather",
+            "schema": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+                "additionalProperties": false
+            },
+            "strict": true,
+            "x-format-extension": "kept"
+        },
+        "verbosity": "low",
+        "x-text-extension": {"enabled": true}
+    });
+
+    let response = reqwest::Client::new()
+        .post(format!("{gateway_url}/v1/responses"))
+        .json(&serde_json::json!({
+            "model": "test",
+            "input": "hi",
+            "text": text,
+            "store": true,
+            "stream": false
+        }))
+        .send()
+        .await
+        .expect("stateful response request");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let requests = requests.lock().await;
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0]["text"], text);
+}
+
+#[tokio::test]
+async fn test_stateful_request_rejects_malformed_text_configuration_before_upstream() {
+    let (llm_url, requests, _llm) = spawn_mock_vllm_json_capture().await;
+    let fixture = storage_backed_state(&llm_url).await;
+    let (gateway_url, _gateway) = spawn_gateway(fixture.state.clone()).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{gateway_url}/v1/responses"))
+        .json(&serde_json::json!({
+            "model": "test",
+            "input": "hi",
+            "text": {"format": {"type": "json_schema", "name": "missing_schema"}},
+            "store": true,
+            "stream": false
+        }))
+        .send()
+        .await
+        .expect("malformed stateful response request");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert!(
+        requests.lock().await.is_empty(),
+        "invalid request must not reach upstream"
+    );
+}
+
+#[tokio::test]
 async fn test_gateway_normalization_preserves_parallel_tool_calls() {
     // Arrange
     let (llm_url, requests, _h1) = spawn_mock_vllm_json_capture().await;

--- a/crates/agentic-server/tests/responses_websocket_test.rs
+++ b/crates/agentic-server/tests/responses_websocket_test.rs
@@ -839,6 +839,7 @@ async fn test_websocket_first_turn_forwards_incremental_events_and_final_payload
             "model": "test-model",
             "input": [{"type": "message", "role": "user", "content": "hi"}],
             "reasoning": {"effort": "high"},
+            "text": {"format": {"type": "json_object"}, "verbosity": "high"},
             "store": true,
             "stream": true
         }),
@@ -870,6 +871,10 @@ async fn test_websocket_first_turn_forwards_incremental_events_and_final_payload
     assert_eq!(requests[0]["stream"], true);
     assert_eq!(requests[0]["input"][0]["content"], "hi");
     assert_eq!(requests[0]["reasoning"], json!({"effort": "high"}));
+    assert_eq!(
+        requests[0]["text"],
+        json!({"format": {"type": "json_object"}, "verbosity": "high"})
+    );
     assert!(requests[0].get("type").is_none());
 }
 
@@ -1507,6 +1512,7 @@ async fn test_websocket_continuation_rehydrates_previous_response() {
     let mock = MockResponsesServer::start(vec![
         sse_response("resp_upstream_1", "msg_upstream_1", "HELLO"),
         sse_response("resp_upstream_2", "msg_upstream_2", "WORLD"),
+        sse_response("resp_upstream_3", "msg_upstream_3", "AGAIN"),
     ])
     .await;
     let fixture = storage_backed_state(&mock.url).await;
@@ -1519,6 +1525,7 @@ async fn test_websocket_continuation_rehydrates_previous_response() {
             "type": "response.create",
             "model": "test-model",
             "input": [{"type": "message", "role": "user", "content": "hi"}],
+            "text": {"verbosity": "low"},
             "store": true,
             "stream": true
         }),
@@ -1535,6 +1542,7 @@ async fn test_websocket_continuation_rehydrates_previous_response() {
             "model": "test-model",
             "previous_response_id": previous_response_id,
             "input": [{"type": "message", "role": "user", "content": "continue"}],
+            "text": {"verbosity": "high"},
             "store": true,
             "stream": true
         }),
@@ -1562,8 +1570,30 @@ async fn test_websocket_continuation_rehydrates_previous_response() {
     assert_eq!(response["output"][0]["content"][0]["text"], "WORLD");
     assert_eq!(response["previous_response_id"], previous_response_id);
 
+    let second_response_id = response["id"].as_str().unwrap();
+    send_json(
+        &mut ws,
+        json!({
+            "type": "response.create",
+            "model": "test-model",
+            "previous_response_id": second_response_id,
+            "input": [{"type": "message", "role": "user", "content": "again"}],
+            "store": true,
+            "stream": true
+        }),
+    )
+    .await;
+    let third = recv_until_completed(&mut ws).await;
+    assert_eq!(
+        third.last().unwrap()["response"]["output"][0]["content"][0]["text"],
+        "AGAIN"
+    );
+
     let requests = mock.request_bodies().await;
-    assert_eq!(requests.len(), 2);
+    assert_eq!(requests.len(), 3);
+    assert_eq!(requests[0]["text"], json!({"verbosity": "low"}));
+    assert_eq!(requests[1]["text"], json!({"verbosity": "high"}));
+    assert!(requests[2].get("text").is_none());
     assert!(requests[1].get("previous_response_id").is_none());
     assert_eq!(requests[1]["input"][0]["content"], "hi");
     assert_eq!(requests[1]["input"][1]["role"], "assistant");


### PR DESCRIPTION
## Summary

- Preserve the Responses `text` generation configuration when requests enter the typed executor used by stateful HTTP, WebSocket, compaction-aware, and gateway-tool flows.
- Model the current plain-text, JSON-object, and flattened JSON-schema request shapes while retaining unmodeled extension fields for forward compatibility.
- Keep `text` request-scoped: it survives every model round in one request, while a later continuation uses only its own configuration and does not inherit a stale value.
- Reject malformed known shapes before contacting the upstream service and document the compatibility fix in the Unreleased changelog.

## Reproduction

On unmodified main at `f20cd2b`, a stateful `POST /v1/responses` with:

```json
{
  "model": "test",
  "input": "hi",
  "text": {
    "format": {"type": "json_object"},
    "verbosity": "low"
  },
  "store": true,
  "stream": false
}
```

returns successfully, but the captured upstream request has `text: null` instead of the supplied object. The regression test fails on main with `left: Null` and passes with this commit.

## Compatibility

- `store: false` raw proxy behavior is unchanged.
- No persistence schema or response wire format changes.
- Supported `text.format` values are `text`, `json_object`, and flattened `json_schema` with required `name` and `schema`; absent and null `text` remain omitted upstream.
- Outer and format-level extension fields are preserved.

## Test Plan

- [x] Red control on unmodified `f20cd2b`
- [x] Focused typed serialization and malformed-boundary tests
- [x] Stateful HTTP forwarding and pre-upstream rejection tests
- [x] WebSocket streaming and low → high → omitted continuation tests
- [x] Multi-round gateway web-search preservation test
- [x] `cargo fmt --all -- --check`
- [x] `cargo check --workspace --all-targets --all-features`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `RUST_TEST_THREADS=1 cargo test --workspace --all-features`
- [x] Python suite: 111 passed, 3 skipped
- [x] Cassette validation: 108 cassettes, 238 turns
- [x] `mkdocs build --strict`
- [x] `pre-commit run --all-files`

A new live reference cassette was not recorded because this environment has neither an OpenAI credential nor a live vLLM service. The emitted upstream bodies are asserted at HTTP, WebSocket, and multi-round mock boundaries, and the request shapes were checked against the current primary OpenAI SDK and vLLM contracts.
