### PR TITLE
fix: allow resolved tool call IDs to be reused

### DIFF
--- a/crates/agentic-server-core/src/executor/pending_calls.rs
+++ b/crates/agentic-server-core/src/executor/pending_calls.rs
@@ -5,7 +5,7 @@
 //! after scanning a full item sequence is, by construction, something the
 //! *client* owed a resolution for.
 
-use std::collections::HashSet;
+use std::collections::HashMap;
 
 use indexmap::IndexMap;
 
@@ -42,19 +42,21 @@ pub(super) struct PendingCall {
 }
 
 /// Scans `items` in order and returns every call left unresolved, in emission
-/// order. Calls and outputs must have non-empty IDs and form a one-to-one,
-/// same-kind relationship. Namespace member calls are represented as
-/// `InputItem::FunctionCall`, so they're covered by the plain function check.
+/// order. Outstanding calls must have non-empty, unique IDs and form a
+/// one-to-one, same-kind relationship with their outputs. Once an output
+/// resolves a call, a later call of the same kind may reuse that ID. Namespace
+/// member calls are represented as `InputItem::FunctionCall`, so they're
+/// covered by the plain function check.
 pub(super) fn pending_calls(items: &[InputItem]) -> ExecutorResult<Vec<PendingCall>> {
-    let mut seen_call_ids = HashSet::new();
+    let mut call_kinds = HashMap::new();
     let mut pending = IndexMap::new();
     for item in items {
         match item {
             InputItem::FunctionCall(call) => {
-                add_call(&call.call_id, CallKind::Function, &mut seen_call_ids, &mut pending)?;
+                add_call(&call.call_id, CallKind::Function, &mut call_kinds, &mut pending)?;
             }
             InputItem::CustomToolCall(call) => {
-                add_call(&call.call_id, CallKind::Custom, &mut seen_call_ids, &mut pending)?;
+                add_call(&call.call_id, CallKind::Custom, &mut call_kinds, &mut pending)?;
             }
             InputItem::FunctionCallOutput(output) => {
                 resolve_call(&output.call_id, CallKind::Function, &mut pending)?;
@@ -76,7 +78,7 @@ pub(super) fn pending_calls(items: &[InputItem]) -> ExecutorResult<Vec<PendingCa
 fn add_call(
     call_id: &str,
     kind: CallKind,
-    seen_call_ids: &mut HashSet<String>,
+    call_kinds: &mut HashMap<String, CallKind>,
     pending: &mut IndexMap<String, CallKind>,
 ) -> ExecutorResult<()> {
     if call_id.is_empty() {
@@ -85,12 +87,17 @@ fn add_call(
             kind.call_item_name()
         )));
     }
-    if !seen_call_ids.insert(call_id.to_owned()) {
+    if pending.contains_key(call_id)
+        || call_kinds
+            .get(call_id)
+            .is_some_and(|previous_kind| *previous_kind != kind)
+    {
         return Err(ExecutorError::InvalidRequest(format!(
             "duplicate call_id '{call_id}' in {}",
             kind.call_item_name()
         )));
     }
+    call_kinds.insert(call_id.to_owned(), kind);
     pending.insert(call_id.to_owned(), kind);
     Ok(())
 }
@@ -167,6 +174,29 @@ mod tests {
         assert!(pending_calls(&items).expect("valid call/output pair").is_empty());
     }
 
+    /// Kimi K2 native tool-call IDs are derived from the function name and
+    /// per-response index, so the same call position can recur in later turns.
+    #[test]
+    fn resolved_call_id_can_be_reused_by_a_later_call() {
+        let mut items = vec![
+            function_call("functions.get_weather:0"),
+            function_call_output("functions.get_weather:0"),
+            function_call("functions.get_weather:0"),
+        ];
+
+        let pending = pending_calls(&items).expect("a resolved call ID can be reused by a later turn");
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].call_id, "functions.get_weather:0");
+
+        items.push(function_call_output("functions.get_weather:0"));
+
+        assert!(
+            pending_calls(&items)
+                .expect("a resolved call ID can be reused by a later turn")
+                .is_empty()
+        );
+    }
+
     #[test]
     fn unresolved_function_call_is_reported_in_order() {
         let items = vec![
@@ -204,7 +234,7 @@ mod tests {
     }
 
     #[test]
-    fn empty_and_duplicate_call_ids_are_rejected() {
+    fn empty_overlapping_and_cross_kind_call_ids_are_rejected() {
         assert_invalid(&[function_call("")], "function_call call_id must not be empty");
         assert_invalid(&[custom_tool_call("")], "custom_tool_call call_id must not be empty");
         assert_invalid(

--- a/crates/agentic-server-core/tests/stateful_responses_integration.rs
+++ b/crates/agentic-server-core/tests/stateful_responses_integration.rs
@@ -446,6 +446,73 @@ async fn test_previous_response_id_rehydrates_function_call_before_tool_output()
 }
 
 #[tokio::test]
+async fn test_previous_response_id_allows_reused_resolved_call_id() {
+    assert_reused_resolved_call_id(false).await;
+}
+
+#[tokio::test]
+async fn test_conversation_allows_reused_resolved_call_id() {
+    assert_reused_resolved_call_id(true).await;
+}
+
+async fn assert_reused_resolved_call_id(conversation: bool) {
+    let call_id = "functions.get_weather:0";
+    let conversation_id = conversation.then(|| "conv_reused_call_id".to_owned());
+    let fixture = TestFixture::new_with_responses(vec![
+        client_function_call_response("resp_tool_1", "fc_1", call_id),
+        client_function_call_response("resp_tool_2", "fc_2", call_id),
+        text_response("both tool outputs handled"),
+    ])
+    .await;
+
+    let first = unwrap_blocking(
+        execute(
+            make_request("weather in Boston", true, false, None, conversation_id.clone()),
+            Arc::clone(&fixture.exec_ctx),
+        )
+        .await
+        .expect("first turn"),
+    );
+
+    let previous_response_id = (!conversation).then_some(first.id);
+    let mut second = make_request("ignored", true, false, previous_response_id, conversation_id.clone());
+    second.input = ResponsesInput::Items(vec![tool_output(call_id, "sunny")]);
+    let second = unwrap_blocking(
+        execute(second, Arc::clone(&fixture.exec_ctx))
+            .await
+            .expect("first tool output"),
+    );
+
+    let previous_response_id = (!conversation).then_some(second.id);
+    let mut third = make_request("ignored", true, false, previous_response_id, conversation_id);
+    third.input = ResponsesInput::Items(vec![tool_output(call_id, "rainy")]);
+    let third = unwrap_blocking(
+        execute(third, Arc::clone(&fixture.exec_ctx))
+            .await
+            .expect("a resolved call ID can be reused by a later turn"),
+    );
+
+    assert_eq!(output_text(&third), "both tool outputs handled");
+    let requests = fixture.request_bodies().await;
+    assert_eq!(requests.len(), 3);
+    let input = requests[2]["input"].as_array().expect("rehydrated input array");
+    let repeated_items = input
+        .iter()
+        .filter(|item| item["call_id"].as_str() == Some(call_id))
+        .map(|item| item["type"].as_str().expect("typed call item"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        repeated_items,
+        vec![
+            "function_call",
+            "function_call_output",
+            "function_call",
+            "function_call_output"
+        ]
+    );
+}
+
+#[tokio::test]
 async fn test_previous_response_id_replays_plaintext_reasoning_without_opaque_state() {
     assert_plaintext_reasoning_replay(false, false, true).await;
 }
@@ -844,6 +911,33 @@ fn upstream_mcp_fixture_call(id: &str, call_id: &str, name: &str, arguments: &st
         "arguments": arguments,
         "status": "completed"
     })
+}
+
+fn client_function_call_response(response_id: &str, item_id: &str, call_id: &str) -> MockResponse {
+    MockResponse::Json(
+        serde_json::json!({
+            "id": response_id,
+            "object": "response",
+            "created_at": 0,
+            "model": "test-model",
+            "status": "completed",
+            "output": [{
+                "id": item_id,
+                "type": "function_call",
+                "call_id": call_id,
+                "name": "get_weather",
+                "arguments": "{}",
+                "status": "completed"
+            }],
+            "usage": null,
+            "incomplete_details": null,
+            "error": null,
+            "previous_response_id": null,
+            "conversation_id": null,
+            "instructions": null
+        })
+        .to_string(),
+    )
 }
 
 fn tool_output(call_id: &str, output: &str) -> InputItem {


### PR DESCRIPTION
## Summary

- scope duplicate `call_id` rejection to overlapping calls while retaining the historical call kind
- allow a later function/custom call to reuse an ID only after the prior same-kind call has a matching output
- cover both `previous_response_id` chains and conversation-backed rehydration

## Problem

The pending-call validation added in #214 retains every historical `call_id` in a `HashSet`. A third request is therefore rejected with `duplicate call_id` when a model legitimately reuses an ID after the earlier call/output pair completed.

This is reproducible with vLLM's Kimi K2-family tool-call contract. Its parser preserves native IDs such as `functions.get_weather:0`, and the Responses adapter forwards that parser ID as `call_id` ([parser regression coverage](https://github.com/vllm-project/vllm/blob/41848caa63b131f931618055d3ece0b487ce8edb/tests/tool_parsers/test_kimi_k2_tool_parser.py#L178-L205), [Responses conversion](https://github.com/vllm-project/vllm/blob/41848caa63b131f931618055d3ece0b487ce8edb/vllm/entrypoints/openai/responses/utils.py#L93-L107)). Since the native suffix is a per-response position, calling the same function in the same position on a later turn repeats the ID. vLLM's Harmony path also explicitly resolves an output against the most recent matching call when prior calls share an ID ([test](https://github.com/vllm-project/vllm/blob/41848caa63b131f931618055d3ece0b487ce8edb/tests/entrypoints/openai/responses/test_response_input_to_harmony.py#L210-L237)).

The validator now separates historical kind tracking from the currently pending calls. Empty IDs, overlapping duplicates, function/custom kind changes, orphan outputs, repeated outputs, wrong-kind outputs, and unresolved calls remain rejected.

## Red/green evidence

Both new regressions failed on current `main` (`98325a81`) before the implementation change with:

```text
InvalidRequest("duplicate call_id 'functions.get_weather:0' in function_call")
```

Commands used for the red control and green verification:

```bash
cargo test -p agentic-server-core executor::pending_calls::tests::resolved_call_id_can_be_reused_by_a_later_call -- --exact
cargo test -p agentic-server-core --test stateful_responses_integration test_previous_response_id_allows_reused_resolved_call_id -- --exact
cargo test -p agentic-server-core --test stateful_responses_integration reused_resolved_call_id
cargo test --workspace -- --test-threads=1
cargo build --workspace --bins
cargo clippy --all-targets -- -D warnings
cargo fmt --all -- --check
uvx --from 'pre-commit>=4.4.0' pre-commit run --all-files
bash scripts/tests/agentic-launchers-test.sh
AGENTIC_BIN="$(cargo metadata --format-version 1 --no-deps | jq -r .target_directory)/debug/agentic" python3 scripts/tests/agentic-cli-e2e-test.py
python3 scripts/validate-cassettes.py
```

The exact commit was verified from a clean worktree. Cassette validation covered 108 cassettes / 238 turns. Five PostgreSQL integration tests remained ignored because `TEST_POSTGRES_URL` was not configured; the changed validation is exercised with the repository's SQLite-backed stateful fixtures and a deterministic mock upstream.
