### PR TITLE
fix: preserve Responses text compatibility

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -147,12 +147,12 @@ Handlers make a request-scoped decision between two paths:
   `previous_response_id`, `conversation_id`, compaction, or a gateway-owned tool).
   Builds an `ExecuteRequest` (Responses) or calls `run_messages_loop`/
   `run_messages_stream` (Messages) against `state.exec_ctx`.
-- **Transparent proxy path** — everything else is forwarded to vLLM unchanged via
+- **Pass-through path** — everything else is forwarded to vLLM unchanged via
   `agentic_core::proxy`, with no state, no persistence.
 
 The HTTP Responses handler first parses `RequestPayload<RawValue>` so routing fields
-remain typed while provider-specific `text` formats stay opaque on the transparent
-proxy path. Executor routes convert that raw field to `ResponseTextConfig` before
+remain typed while provider-specific `text` formats stay opaque on the pass-through
+path. Executor routes convert that raw field to `ResponseTextConfig` before
 building `ExecuteRequest`, preserving strict validation for in-process execution.
 
 ### WebSocket transport (`handler/websocket/`)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -150,6 +150,11 @@ Handlers make a request-scoped decision between two paths:
 - **Transparent proxy path** — everything else is forwarded to vLLM unchanged via
   `agentic_core::proxy`, with no state, no persistence.
 
+The HTTP Responses handler first parses `RequestPayload<RawValue>` so routing fields
+remain typed while provider-specific `text` formats stay opaque on the transparent
+proxy path. Executor routes convert that raw field to `ResponseTextConfig` before
+building `ExecuteRequest`, preserving strict validation for in-process execution.
+
 ### WebSocket transport (`handler/websocket/`)
 
 `GET /v1/responses` upgrades to a WebSocket. Structurally this is not a one-shot
@@ -165,9 +170,9 @@ not attempt to write a response.
 
 ### `handler/common.rs`
 
-Transport-agnostic helpers shared by both HTTP and WS handlers: body reading with a
-shared size cap, `RequestPayload` parsing, bearer-token extraction, SSE response
-wrapping, and rendering an `ExecutorError` as a JSON error body.
+Transport helpers shared by the HTTP and WS handlers: body reading with a shared size
+cap, generic JSON parsing, bearer-token extraction, SSE response wrapping, and
+rendering an `ExecutorError` as a JSON error body.
 
 ### `auth.rs`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@ All notable changes to Agentic API are documented here.
 
 ### Fixed
 
-- Forwarded Responses `text` generation settings, including structured output
-  formats and verbosity, through typed HTTP, WebSocket, and gateway-tool paths.
+- Forwarded Responses `text` generation settings through typed execution paths while preserving provider-specific
+  text formats on stateless proxy requests and JSON Schema property order.
+- Prevented extension fields from overriding modeled Responses text configuration fields during serialization.
 - Replaced `WebSearchActionSearch::new` and `WebSearchCall::new` with fallible
   `try_new(...)` constructors; callers now handle `WebSearchActionError` for
   empty query lists instead of risking a panic.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ All notable changes to Agentic API are documented here.
   validation, bounded hydrate and persist payloads, stable error envelopes, and graceful shutdown error propagation.
 - Forwarded Responses `text` generation settings through typed execution paths while preserving provider-specific
   text formats on stateless proxy requests and JSON Schema property order.
-- Prevented extension fields from overriding modeled Responses text configuration fields during serialization.
 - Replaced `WebSearchActionSearch::new` and `WebSearchCall::new` with fallible
   `try_new(...)` constructors; callers now handle `WebSearchActionError` for
   empty query lists instead of risking a panic.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2644,6 +2644,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,8 @@ reqwest = { version = "0.12", default-features = false }
 rmcp-reqwest = { package = "reqwest", version = "0.13.2", default-features = false, features = ["json", "stream", "rustls"] }
 rmcp = { version = "1.8", default-features = false }
 serde = { version = "1", features = ["derive"] }
-serde_json = { version = "1", features = ["raw_value"] }
+# Structured Outputs emit object keys in JSON Schema declaration order.
+serde_json = { version = "1", features = ["preserve_order", "raw_value"] }
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"

--- a/crates/agentic-server-core/src/types/request_response.rs
+++ b/crates/agentic-server-core/src/types/request_response.rs
@@ -1,9 +1,8 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 
-use serde::ser::SerializeMap;
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
+use serde_json::{Map, Value, json};
 
 use super::io::{
     FunctionTool, InputItem, InputMessage, InputMessageContent, OutputItem, ResponseUsage, ResponsesInput, ToolChoice,
@@ -28,20 +27,20 @@ pub struct ReasoningConfig {
 }
 
 /// Responses text-generation settings forwarded to the upstream service.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResponseTextConfig {
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub format: Option<ResponseTextFormat>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub verbosity: Option<String>,
     /// Unmodeled extension fields preserved for upstream compatibility.
     #[serde(default)]
     #[serde(flatten)]
-    pub extra: HashMap<String, Value>,
+    pub extra: Map<String, Value>,
 }
 
 /// Output format requested through [`ResponseTextConfig`].
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum ResponseTextFormat {
@@ -49,132 +48,26 @@ pub enum ResponseTextFormat {
         /// Unmodeled extension fields preserved for upstream compatibility.
         #[serde(default)]
         #[serde(flatten)]
-        extra: HashMap<String, Value>,
+        extra: Map<String, Value>,
     },
     JsonObject {
         /// Unmodeled extension fields preserved for upstream compatibility.
         #[serde(default)]
         #[serde(flatten)]
-        extra: HashMap<String, Value>,
+        extra: Map<String, Value>,
     },
     JsonSchema {
         name: String,
         schema: serde_json::Map<String, Value>,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         description: Option<String>,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         strict: Option<bool>,
         /// Unmodeled extension fields preserved for upstream compatibility.
         #[serde(default)]
         #[serde(flatten)]
-        extra: HashMap<String, Value>,
+        extra: Map<String, Value>,
     },
-}
-
-const FORMAT_FIELD: &str = "format";
-const VERBOSITY_FIELD: &str = "verbosity";
-const TYPE_FIELD: &str = "type";
-const NAME_FIELD: &str = "name";
-const SCHEMA_FIELD: &str = "schema";
-const DESCRIPTION_FIELD: &str = "description";
-const STRICT_FIELD: &str = "strict";
-
-const TEXT_CONFIG_FIELDS: &[&str] = &[FORMAT_FIELD, VERBOSITY_FIELD];
-const TEXT_FORMAT_FIELDS: &[&str] = &[TYPE_FIELD];
-const JSON_SCHEMA_FORMAT_FIELDS: &[&str] = &[TYPE_FIELD, NAME_FIELD, SCHEMA_FIELD, DESCRIPTION_FIELD, STRICT_FIELD];
-
-fn reserved_extension_key<'a>(extra: &HashMap<String, Value>, reserved: &'a [&'a str]) -> Option<&'a str> {
-    reserved.iter().copied().find(|key| extra.contains_key(*key))
-}
-
-impl Serialize for ResponseTextConfig {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        if let Some(key) = reserved_extension_key(&self.extra, TEXT_CONFIG_FIELDS) {
-            return Err(serde::ser::Error::custom(format!(
-                "text configuration extension key `{key}` conflicts with a modeled field"
-            )));
-        }
-
-        let field_count = self.extra.len() + usize::from(self.format.is_some()) + usize::from(self.verbosity.is_some());
-        let mut map = serializer.serialize_map(Some(field_count))?;
-        if let Some(format) = &self.format {
-            map.serialize_entry(FORMAT_FIELD, format)?;
-        }
-        if let Some(verbosity) = &self.verbosity {
-            map.serialize_entry(VERBOSITY_FIELD, verbosity)?;
-        }
-        for (key, value) in &self.extra {
-            map.serialize_entry(key, value)?;
-        }
-        map.end()
-    }
-}
-
-impl Serialize for ResponseTextFormat {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        match self {
-            Self::Text { extra } => {
-                if let Some(key) = reserved_extension_key(extra, TEXT_FORMAT_FIELDS) {
-                    return Err(serde::ser::Error::custom(format!(
-                        "text format extension key `{key}` conflicts with a modeled field"
-                    )));
-                }
-                let mut map = serializer.serialize_map(Some(extra.len() + 1))?;
-                map.serialize_entry(TYPE_FIELD, "text")?;
-                for (key, value) in extra {
-                    map.serialize_entry(key, value)?;
-                }
-                map.end()
-            }
-            Self::JsonObject { extra } => {
-                if let Some(key) = reserved_extension_key(extra, TEXT_FORMAT_FIELDS) {
-                    return Err(serde::ser::Error::custom(format!(
-                        "text format extension key `{key}` conflicts with a modeled field"
-                    )));
-                }
-                let mut map = serializer.serialize_map(Some(extra.len() + 1))?;
-                map.serialize_entry(TYPE_FIELD, "json_object")?;
-                for (key, value) in extra {
-                    map.serialize_entry(key, value)?;
-                }
-                map.end()
-            }
-            Self::JsonSchema {
-                name,
-                schema,
-                description,
-                strict,
-                extra,
-            } => {
-                if let Some(key) = reserved_extension_key(extra, JSON_SCHEMA_FORMAT_FIELDS) {
-                    return Err(serde::ser::Error::custom(format!(
-                        "text format extension key `{key}` conflicts with a modeled field"
-                    )));
-                }
-                let optional_fields = usize::from(description.is_some()) + usize::from(strict.is_some());
-                let mut map = serializer.serialize_map(Some(extra.len() + optional_fields + 3))?;
-                map.serialize_entry(TYPE_FIELD, "json_schema")?;
-                map.serialize_entry(NAME_FIELD, name)?;
-                map.serialize_entry(SCHEMA_FIELD, schema)?;
-                if let Some(description) = description {
-                    map.serialize_entry(DESCRIPTION_FIELD, description)?;
-                }
-                if let Some(strict) = strict {
-                    map.serialize_entry(STRICT_FIELD, strict)?;
-                }
-                for (key, value) in extra {
-                    map.serialize_entry(key, value)?;
-                }
-                map.end()
-            }
-        }
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -717,48 +610,43 @@ mod tests {
     }
 
     #[test]
-    fn text_configuration_rejects_reserved_extension_keys() {
-        for reserved in ["format", "verbosity"] {
-            let config = ResponseTextConfig {
-                format: Some(ResponseTextFormat::Text { extra: HashMap::new() }),
-                verbosity: Some("low".to_owned()),
-                extra: HashMap::from([(reserved.to_owned(), serde_json::json!("override"))]),
-            };
+    fn text_configuration_preserves_extension_field_order() {
+        let config: ResponseTextConfig = serde_json::from_str(
+            r#"{
+                "format": {
+                    "type": "json_schema",
+                    "name": "ordered",
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "second": {"type": "string"},
+                            "first": {"type": "number"}
+                        }
+                    },
+                    "x-format-first": 1,
+                    "x-format-second": 2,
+                    "x-format-third": 3,
+                    "x-format-fourth": 4,
+                    "x-format-fifth": 5,
+                    "x-format-sixth": 6
+                },
+                "verbosity": "low",
+                "x-text-first": 1,
+                "x-text-second": 2,
+                "x-text-third": 3,
+                "x-text-fourth": 4,
+                "x-text-fifth": 5,
+                "x-text-sixth": 6
+            }"#,
+        )
+        .expect("text configuration should deserialize");
 
-            assert!(
-                serde_json::to_value(config).is_err(),
-                "reserved text configuration key should fail: {reserved}"
-            );
-        }
+        let serialized = serde_json::to_string(&config).expect("text configuration should serialize");
 
-        for reserved in ["type", "name", "schema", "description", "strict"] {
-            let format = ResponseTextFormat::JsonSchema {
-                name: "ordered".to_owned(),
-                schema: serde_json::Map::new(),
-                description: None,
-                strict: Some(true),
-                extra: HashMap::from([(reserved.to_owned(), serde_json::json!("override"))]),
-            };
-
-            assert!(
-                serde_json::to_value(format).is_err(),
-                "reserved text format key should fail: {reserved}"
-            );
-        }
-
-        for format in [
-            ResponseTextFormat::Text {
-                extra: HashMap::from([("type".to_owned(), serde_json::json!("override"))]),
-            },
-            ResponseTextFormat::JsonObject {
-                extra: HashMap::from([("type".to_owned(), serde_json::json!("override"))]),
-            },
-        ] {
-            assert!(
-                serde_json::to_value(format).is_err(),
-                "reserved type key should fail for every text format variant"
-            );
-        }
+        assert_eq!(
+            serialized,
+            r#"{"format":{"type":"json_schema","name":"ordered","schema":{"type":"object","properties":{"second":{"type":"string"},"first":{"type":"number"}}},"x-format-first":1,"x-format-second":2,"x-format-third":3,"x-format-fourth":4,"x-format-fifth":5,"x-format-sixth":6},"verbosity":"low","x-text-first":1,"x-text-second":2,"x-text-third":3,"x-text-fourth":4,"x-text-fifth":5,"x-text-sixth":6}"#
+        );
     }
 
     #[test]

--- a/crates/agentic-server-core/src/types/request_response.rs
+++ b/crates/agentic-server-core/src/types/request_response.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 
+use serde::ser::SerializeMap;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
@@ -27,11 +28,11 @@ pub struct ReasoningConfig {
 }
 
 /// Responses text-generation settings forwarded to the upstream service.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct ResponseTextConfig {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub format: Option<ResponseTextFormat>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub verbosity: Option<String>,
     /// Unmodeled extension fields preserved for upstream compatibility.
     #[serde(default)]
@@ -40,7 +41,7 @@ pub struct ResponseTextConfig {
 }
 
 /// Output format requested through [`ResponseTextConfig`].
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum ResponseTextFormat {
@@ -59,9 +60,9 @@ pub enum ResponseTextFormat {
     JsonSchema {
         name: String,
         schema: serde_json::Map<String, Value>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[serde(default)]
         description: Option<String>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[serde(default)]
         strict: Option<bool>,
         /// Unmodeled extension fields preserved for upstream compatibility.
         #[serde(default)]
@@ -70,8 +71,115 @@ pub enum ResponseTextFormat {
     },
 }
 
+const FORMAT_FIELD: &str = "format";
+const VERBOSITY_FIELD: &str = "verbosity";
+const TYPE_FIELD: &str = "type";
+const NAME_FIELD: &str = "name";
+const SCHEMA_FIELD: &str = "schema";
+const DESCRIPTION_FIELD: &str = "description";
+const STRICT_FIELD: &str = "strict";
+
+const TEXT_CONFIG_FIELDS: &[&str] = &[FORMAT_FIELD, VERBOSITY_FIELD];
+const TEXT_FORMAT_FIELDS: &[&str] = &[TYPE_FIELD];
+const JSON_SCHEMA_FORMAT_FIELDS: &[&str] = &[TYPE_FIELD, NAME_FIELD, SCHEMA_FIELD, DESCRIPTION_FIELD, STRICT_FIELD];
+
+fn reserved_extension_key<'a>(extra: &HashMap<String, Value>, reserved: &'a [&'a str]) -> Option<&'a str> {
+    reserved.iter().copied().find(|key| extra.contains_key(*key))
+}
+
+impl Serialize for ResponseTextConfig {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if let Some(key) = reserved_extension_key(&self.extra, TEXT_CONFIG_FIELDS) {
+            return Err(serde::ser::Error::custom(format!(
+                "text configuration extension key `{key}` conflicts with a modeled field"
+            )));
+        }
+
+        let field_count = self.extra.len() + usize::from(self.format.is_some()) + usize::from(self.verbosity.is_some());
+        let mut map = serializer.serialize_map(Some(field_count))?;
+        if let Some(format) = &self.format {
+            map.serialize_entry(FORMAT_FIELD, format)?;
+        }
+        if let Some(verbosity) = &self.verbosity {
+            map.serialize_entry(VERBOSITY_FIELD, verbosity)?;
+        }
+        for (key, value) in &self.extra {
+            map.serialize_entry(key, value)?;
+        }
+        map.end()
+    }
+}
+
+impl Serialize for ResponseTextFormat {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Text { extra } => {
+                if let Some(key) = reserved_extension_key(extra, TEXT_FORMAT_FIELDS) {
+                    return Err(serde::ser::Error::custom(format!(
+                        "text format extension key `{key}` conflicts with a modeled field"
+                    )));
+                }
+                let mut map = serializer.serialize_map(Some(extra.len() + 1))?;
+                map.serialize_entry(TYPE_FIELD, "text")?;
+                for (key, value) in extra {
+                    map.serialize_entry(key, value)?;
+                }
+                map.end()
+            }
+            Self::JsonObject { extra } => {
+                if let Some(key) = reserved_extension_key(extra, TEXT_FORMAT_FIELDS) {
+                    return Err(serde::ser::Error::custom(format!(
+                        "text format extension key `{key}` conflicts with a modeled field"
+                    )));
+                }
+                let mut map = serializer.serialize_map(Some(extra.len() + 1))?;
+                map.serialize_entry(TYPE_FIELD, "json_object")?;
+                for (key, value) in extra {
+                    map.serialize_entry(key, value)?;
+                }
+                map.end()
+            }
+            Self::JsonSchema {
+                name,
+                schema,
+                description,
+                strict,
+                extra,
+            } => {
+                if let Some(key) = reserved_extension_key(extra, JSON_SCHEMA_FORMAT_FIELDS) {
+                    return Err(serde::ser::Error::custom(format!(
+                        "text format extension key `{key}` conflicts with a modeled field"
+                    )));
+                }
+                let optional_fields = usize::from(description.is_some()) + usize::from(strict.is_some());
+                let mut map = serializer.serialize_map(Some(extra.len() + optional_fields + 3))?;
+                map.serialize_entry(TYPE_FIELD, "json_schema")?;
+                map.serialize_entry(NAME_FIELD, name)?;
+                map.serialize_entry(SCHEMA_FIELD, schema)?;
+                if let Some(description) = description {
+                    map.serialize_entry(DESCRIPTION_FIELD, description)?;
+                }
+                if let Some(strict) = strict {
+                    map.serialize_entry(STRICT_FIELD, strict)?;
+                }
+                for (key, value) in extra {
+                    map.serialize_entry(key, value)?;
+                }
+                map.end()
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RequestPayload {
+#[serde(bound(serialize = "Box<T>: Serialize", deserialize = "Box<T>: Deserialize<'de>"))]
+pub struct RequestPayload<T: ?Sized = ResponseTextConfig> {
     pub model: String,
     pub input: ResponsesInput,
     pub instructions: Option<String>,
@@ -88,7 +196,7 @@ pub struct RequestPayload {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<Box<ReasoningConfig>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub text: Option<Box<ResponseTextConfig>>,
+    pub text: Option<Box<T>>,
     pub temperature: Option<f64>,
     pub top_p: Option<f64>,
     pub max_output_tokens: Option<u32>,
@@ -173,7 +281,7 @@ where
         .serialize(serializer)
 }
 
-impl RequestPayload {
+impl<T: ?Sized> RequestPayload<T> {
     /// Names the feature in this request that only the in-process executor
     /// implements, if any — neither the passthrough proxy nor split execution
     /// can serve it.
@@ -202,6 +310,44 @@ impl RequestPayload {
         None
     }
 
+    /// Transform the text configuration while moving all other request fields
+    /// without reparsing or reallocating them.
+    ///
+    /// # Errors
+    ///
+    /// Returns the mapping function's error when the text configuration cannot
+    /// be transformed.
+    pub fn try_map_text<U: ?Sized, E>(
+        self,
+        map: impl FnOnce(Box<T>) -> Result<Box<U>, E>,
+    ) -> Result<RequestPayload<U>, E> {
+        let text = self.text.map(map).transpose()?;
+        Ok(RequestPayload {
+            model: self.model,
+            input: self.input,
+            instructions: self.instructions,
+            previous_response_id: self.previous_response_id,
+            conversation_id: self.conversation_id,
+            tools: self.tools,
+            tool_choice: self.tool_choice,
+            stream: self.stream,
+            store: self.store,
+            include: self.include,
+            reasoning: self.reasoning,
+            text,
+            temperature: self.temperature,
+            top_p: self.top_p,
+            max_output_tokens: self.max_output_tokens,
+            truncation: self.truncation,
+            metadata: self.metadata,
+            parallel_tool_calls: self.parallel_tool_calls,
+            cache_salt: self.cache_salt,
+            context_management: self.context_management,
+        })
+    }
+}
+
+impl RequestPayload {
     /// Construct an `UpstreamRequest` suitable for forwarding to vLLM.
     ///
     /// Codex `namespace` tools' members are first renamed to their flat,
@@ -567,6 +713,51 @@ mod tests {
             }));
 
             assert!(parsed.is_err(), "malformed text configuration should fail: {text}");
+        }
+    }
+
+    #[test]
+    fn text_configuration_rejects_reserved_extension_keys() {
+        for reserved in ["format", "verbosity"] {
+            let config = ResponseTextConfig {
+                format: Some(ResponseTextFormat::Text { extra: HashMap::new() }),
+                verbosity: Some("low".to_owned()),
+                extra: HashMap::from([(reserved.to_owned(), serde_json::json!("override"))]),
+            };
+
+            assert!(
+                serde_json::to_value(config).is_err(),
+                "reserved text configuration key should fail: {reserved}"
+            );
+        }
+
+        for reserved in ["type", "name", "schema", "description", "strict"] {
+            let format = ResponseTextFormat::JsonSchema {
+                name: "ordered".to_owned(),
+                schema: serde_json::Map::new(),
+                description: None,
+                strict: Some(true),
+                extra: HashMap::from([(reserved.to_owned(), serde_json::json!("override"))]),
+            };
+
+            assert!(
+                serde_json::to_value(format).is_err(),
+                "reserved text format key should fail: {reserved}"
+            );
+        }
+
+        for format in [
+            ResponseTextFormat::Text {
+                extra: HashMap::from([("type".to_owned(), serde_json::json!("override"))]),
+            },
+            ResponseTextFormat::JsonObject {
+                extra: HashMap::from([("type".to_owned(), serde_json::json!("override"))]),
+            },
+        ] {
+            assert!(
+                serde_json::to_value(format).is_err(),
+                "reserved type key should fail for every text format variant"
+            );
         }
     }
 

--- a/crates/agentic-server-core/tests/stateful_responses_integration.rs
+++ b/crates/agentic-server-core/tests/stateful_responses_integration.rs
@@ -447,29 +447,29 @@ async fn test_previous_response_id_rehydrates_function_call_before_tool_output()
 
 #[tokio::test]
 async fn test_previous_response_id_replays_plaintext_reasoning_without_opaque_state() {
-    assert_plaintext_reasoning_replay(false, false, true).await;
+    Box::pin(assert_plaintext_reasoning_replay(false, false, true)).await;
 }
 
 #[tokio::test]
 async fn test_streaming_previous_response_id_replays_plaintext_reasoning_without_opaque_state() {
-    assert_plaintext_reasoning_replay(true, false, true).await;
+    Box::pin(assert_plaintext_reasoning_replay(true, false, true)).await;
 }
 
 #[tokio::test]
 async fn test_conversation_replays_plaintext_reasoning_without_opaque_state() {
-    assert_plaintext_reasoning_replay(false, true, true).await;
+    Box::pin(assert_plaintext_reasoning_replay(false, true, true)).await;
 }
 
 #[tokio::test]
 async fn test_streaming_conversation_replays_plaintext_reasoning_with_null_state() {
-    assert_plaintext_reasoning_replay(true, true, false).await;
+    Box::pin(assert_plaintext_reasoning_replay(true, true, false)).await;
 }
 
 #[tokio::test]
 async fn test_summary_only_reasoning_is_not_replayed() {
     for stream in [false, true] {
         for conversation in [false, true] {
-            assert_summary_only_reasoning_not_replayed(stream, conversation).await;
+            Box::pin(assert_summary_only_reasoning_not_replayed(stream, conversation)).await;
         }
     }
 }

--- a/crates/agentic-server/src/handler/common.rs
+++ b/crates/agentic-server/src/handler/common.rs
@@ -9,7 +9,6 @@ use tracing::warn;
 
 use agentic_core::executor::{BoxStream, ExecutorError};
 use agentic_core::proxy::{ProxyAuth, ProxyBody, ProxyResponse, error_response_for_auth};
-use agentic_core::types::request_response::RequestPayload;
 
 pub(super) const MAX_BODY_SIZE: usize = 10 * 1024 * 1024;
 
@@ -55,14 +54,6 @@ pub(super) async fn read_bytes_with_auth(body: Body, auth: ProxyAuth) -> Result<
             auth,
         ))
     })
-}
-
-#[allow(clippy::result_large_err)]
-pub(super) async fn read_and_parse(body: Body) -> Result<(Bytes, RequestPayload), Response> {
-    let bytes = read_bytes(body).await?;
-    let payload = serde_json::from_slice::<RequestPayload>(&bytes)
-        .map_err(|e| executor_error_response(ExecutorError::from(e)))?;
-    Ok((bytes, payload))
 }
 
 #[allow(clippy::result_large_err)]

--- a/crates/agentic-server/src/handler/http/responses.rs
+++ b/crates/agentic-server/src/handler/http/responses.rs
@@ -3,18 +3,21 @@ use axum::http::request::Parts;
 use axum::response::{IntoResponse, Response};
 use bytes::Bytes;
 use either::Either;
+use serde_json::value::RawValue;
 use tracing::debug;
 
 use std::sync::Arc;
 
 use agentic_core::executor::{ExecuteRequest, compact_response as execute_compaction};
 use agentic_core::proxy::{ProxyRequest, proxy_request};
-use agentic_core::types::request_response::{CompactRequest, RequestPayload};
+use agentic_core::types::request_response::{CompactRequest, RequestPayload, ResponseTextConfig};
 
 use super::super::common::{
-    convert_response, executor_error_response, extract_bearer, read_and_parse, read_json, sse_response,
+    convert_response, executor_error_response, extract_bearer, read_bytes, read_json, sse_response,
 };
 use crate::app::AppState;
+
+type RoutingPayload = RequestPayload<RawValue>;
 
 async fn proxy_responses(state: &AppState, parts: Parts, body: Bytes) -> Response {
     let proxy_req = ProxyRequest {
@@ -40,27 +43,38 @@ async fn execute_responses(state: &AppState, parts: Parts, payload: RequestPaylo
 
 pub async fn responses(State(state): State<AppState>, req: Request) -> Response {
     let (parts, body) = req.into_parts();
-    let (bytes, payload) = match read_and_parse(body).await {
-        Ok(v) => v,
-        Err(e) => return e,
+    let bytes = match read_bytes(body).await {
+        Ok(bytes) => bytes,
+        Err(response) => return response,
+    };
+    let routing_payload = match serde_json::from_slice::<RoutingPayload>(&bytes) {
+        Ok(payload) => payload,
+        Err(error) => return executor_error_response(error.into()),
     };
 
-    let should_execute =
-        payload.store || payload.previous_response_id.is_some() || payload.in_process_feature().is_some();
+    let should_execute = routing_payload.store
+        || routing_payload.previous_response_id.is_some()
+        || routing_payload.in_process_feature().is_some();
     debug!(
         route = if should_execute { "executor" } else { "proxy" },
-        store = payload.store,
-        stream = payload.stream,
-        has_previous_response_id = payload.previous_response_id.is_some(),
-        has_conversation_id = payload.conversation_id.is_some(),
-        has_compaction = payload.input.contains_compaction(),
-        has_compaction_trigger = payload.input.has_compaction_trigger(),
-        context_management = payload.context_management.as_ref().map_or(0, Vec::len),
-        tools = payload.tools.as_ref().map_or(0, Vec::len),
+        store = routing_payload.store,
+        stream = routing_payload.stream,
+        has_previous_response_id = routing_payload.previous_response_id.is_some(),
+        has_conversation_id = routing_payload.conversation_id.is_some(),
+        has_compaction = routing_payload.input.contains_compaction(),
+        has_compaction_trigger = routing_payload.input.has_compaction_trigger(),
+        context_management = routing_payload.context_management.as_ref().map_or(0, Vec::len),
+        tools = routing_payload.tools.as_ref().map_or(0, Vec::len),
         "routing HTTP responses request"
     );
 
     if should_execute {
+        let payload = match routing_payload
+            .try_map_text(|text| serde_json::from_str::<ResponseTextConfig>(text.get()).map(Box::new))
+        {
+            Ok(payload) => payload,
+            Err(error) => return executor_error_response(error.into()),
+        };
         execute_responses(&state, parts, payload).await
     } else {
         proxy_responses(&state, parts, bytes).await

--- a/crates/agentic-server/src/handler/websocket/responses.rs
+++ b/crates/agentic-server/src/handler/websocket/responses.rs
@@ -51,7 +51,7 @@ fn upgrade_responses_ws(
         .max_frame_size(MAX_BODY_SIZE)
         .on_upgrade(move |socket| async move {
             let _websocket_guard = websocket_guard;
-            responses_ws_loop(socket, state, headers, principal).await;
+            Box::pin(responses_ws_loop(socket, state, headers, principal)).await;
         })
 }
 

--- a/crates/agentic-server/tests/responses_test.rs
+++ b/crates/agentic-server/tests/responses_test.rs
@@ -653,7 +653,7 @@ async fn test_stateful_request_preserves_json_schema_property_order() {
 }
 
 #[tokio::test]
-async fn test_stateful_request_rejects_malformed_text_configuration_before_upstream() {
+async fn test_executor_route_rejects_malformed_text_configuration_before_upstream() {
     let (llm_url, requests, _llm) = spawn_mock_vllm_json_capture().await;
     let fixture = storage_backed_state(&llm_url).await;
     let (gateway_url, _gateway) = spawn_gateway(fixture.state.clone()).await;
@@ -670,7 +670,7 @@ async fn test_stateful_request_rejects_malformed_text_configuration_before_upstr
         }))
         .send()
         .await
-        .expect("malformed stateful response request");
+        .expect("malformed executor-bound response request");
 
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert!(

--- a/crates/agentic-server/tests/responses_test.rs
+++ b/crates/agentic-server/tests/responses_test.rs
@@ -387,6 +387,33 @@ async fn spawn_mock_vllm_json_capture() -> (String, Arc<Mutex<Vec<serde_json::Va
     (format!("http://{addr}"), requests, handle)
 }
 
+async fn spawn_mock_vllm_json_capture_body() -> (String, Arc<Mutex<Vec<Bytes>>>, tokio::task::JoinHandle<()>) {
+    let requests = Arc::new(Mutex::new(Vec::new()));
+    let route_requests = Arc::clone(&requests);
+    let app = Router::new().route(
+        "/v1/responses",
+        post(move |body: Bytes| {
+            let route_requests = Arc::clone(&route_requests);
+            async move {
+                route_requests.lock().await.push(body);
+                axum::response::Response::builder()
+                    .status(200)
+                    .header("Content-Type", "application/json")
+                    .body(axum::body::Body::from(
+                        r#"{"id":"mock_id","object":"response","status":"completed",
+                            "model":"test","output":[],"created_at":0}"#,
+                    ))
+                    .unwrap()
+                    .into_response()
+            }
+        }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    (format!("http://{addr}"), requests, handle)
+}
+
 /// Spawn a mock vLLM that returns an SSE stream.
 async fn spawn_mock_vllm_sse() -> (String, tokio::task::JoinHandle<()>) {
     let app = Router::new().route(
@@ -426,6 +453,66 @@ async fn test_store_false_proxies_json_to_vllm() {
     assert_eq!(resp.status(), 200);
     let body: serde_json::Value = resp.json().await.unwrap();
     assert_eq!(body["id"], "mock_id");
+}
+
+#[tokio::test]
+async fn test_store_false_proxies_unknown_text_format_verbatim() {
+    let (llm_url, requests, _llm) = spawn_mock_vllm_json_capture_body().await;
+    let (gateway_url, _gateway) = spawn_gateway(test_state(&test_config(&llm_url))).await;
+    let request_body = r#"{"model":"test","input":"hi","store":false,"stream":false,"text":{"format":{"type":"provider_format","provider_option":true}}}"#;
+
+    let response = reqwest::Client::new()
+        .post(format!("{gateway_url}/v1/responses"))
+        .header("Content-Type", "application/json")
+        .body(request_body)
+        .send()
+        .await
+        .expect("stateless response request");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let requests = requests.lock().await;
+    assert_eq!(requests.as_slice(), [Bytes::from_static(request_body.as_bytes())]);
+}
+
+#[tokio::test]
+async fn test_duplicate_routing_field_is_rejected_before_upstream() {
+    let (llm_url, requests, _llm) = spawn_mock_vllm_json_capture_body().await;
+    let (gateway_url, _gateway) = spawn_gateway(test_state(&test_config(&llm_url))).await;
+    let request_body = r#"{"model":"test","input":"hi","store":true,"store":false}"#;
+
+    let response = reqwest::Client::new()
+        .post(format!("{gateway_url}/v1/responses"))
+        .header("Content-Type", "application/json")
+        .body(request_body)
+        .send()
+        .await
+        .expect("response request with a duplicate routing field");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert!(
+        requests.lock().await.is_empty(),
+        "invalid request must not reach upstream"
+    );
+}
+
+#[tokio::test]
+async fn test_invalid_json_is_rejected_before_upstream() {
+    let (llm_url, requests, _llm) = spawn_mock_vllm_json_capture_body().await;
+    let (gateway_url, _gateway) = spawn_gateway(test_state(&test_config(&llm_url))).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{gateway_url}/v1/responses"))
+        .header("Content-Type", "application/json")
+        .body(r#"{"model":"test","store":false"#)
+        .send()
+        .await
+        .expect("syntactically invalid response request");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert!(
+        requests.lock().await.is_empty(),
+        "invalid request must not reach upstream"
+    );
 }
 
 #[tokio::test]
@@ -532,6 +619,40 @@ async fn test_stateful_request_forwards_text_configuration() {
 }
 
 #[tokio::test]
+async fn test_stateful_request_preserves_json_schema_property_order() {
+    let (llm_url, requests, _llm) = spawn_mock_vllm_json_capture_body().await;
+    let fixture = storage_backed_state(&llm_url).await;
+    let (gateway_url, _gateway) = spawn_gateway(fixture.state.clone()).await;
+    let request_body = r#"{"model":"test","input":"hi","store":true,"stream":false,"text":{"format":{"type":"json_schema","name":"ordered","schema":{"type":"object","properties":{"outer_z":{"type":"object","properties":{"inner_z":{"type":"string"},"inner_a":{"type":"string"}}},"outer_a":{"type":"string"}},"required":["outer_z","outer_a"],"additionalProperties":false},"strict":true}}}"#;
+
+    let response = reqwest::Client::new()
+        .post(format!("{gateway_url}/v1/responses"))
+        .header("Content-Type", "application/json")
+        .body(request_body)
+        .send()
+        .await
+        .expect("stateful response request");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let requests = requests.lock().await;
+    let upstream = std::str::from_utf8(&requests[0]).expect("upstream request should be UTF-8 JSON");
+    let outer_z = upstream
+        .find("\"outer_z\"")
+        .expect("outer_z property should be forwarded");
+    let outer_a = upstream
+        .find("\"outer_a\"")
+        .expect("outer_a property should be forwarded");
+    let inner_z = upstream
+        .find("\"inner_z\"")
+        .expect("inner_z property should be forwarded");
+    let inner_a = upstream
+        .find("\"inner_a\"")
+        .expect("inner_a property should be forwarded");
+    assert!(outer_z < outer_a, "outer schema property order changed: {upstream}");
+    assert!(inner_z < inner_a, "nested schema property order changed: {upstream}");
+}
+
+#[tokio::test]
 async fn test_stateful_request_rejects_malformed_text_configuration_before_upstream() {
     let (llm_url, requests, _llm) = spawn_mock_vllm_json_capture().await;
     let fixture = storage_backed_state(&llm_url).await;
@@ -543,7 +664,8 @@ async fn test_stateful_request_rejects_malformed_text_configuration_before_upstr
             "model": "test",
             "input": "hi",
             "text": {"format": {"type": "json_schema", "name": "missing_schema"}},
-            "store": true,
+            "tools": [{"type": "web_search_preview"}],
+            "store": false,
             "stream": false
         }))
         .send()


### PR DESCRIPTION
## Summary

Follow-up to [#231](https://github.com/vllm-project/agentic-api/pull/231), addressing compatibility issues found after it merged.

- Preserve byte-for-byte stateless Responses proxying for provider-specific `text` formats while retaining typed routing validation and duplicate-field rejection.
- Preserve JSON Schema and `text` extension-field order recursively on executor-bound requests.
- Keep strict Clippy clean under the current Rust toolchain by boxing oversized futures inherited from `main`.
- Document the raw-text routing boundary using the repository's pass-through terminology.

## Test Plan

- [x] `cargo test`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
