### PR TITLE
fix: harden split execution contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to Agentic API are documented here.
 
 ### Fixed
 
+- Hardened split execution with atomic duplicate persistence, strict relayed-response validation, independent secret
+  validation, bounded hydrate and persist payloads, stable error envelopes, and graceful shutdown error propagation.
 - Forwarded Responses `text` generation settings, including structured output
   formats and verbosity, through typed HTTP, WebSocket, and gateway-tool paths.
 - Replaced `WebSearchActionSearch::new` and `WebSearchCall::new` with fallible

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
+ "tower",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ serde_json = { version = "1", features = ["raw_value"] }
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"
+tower = { version = "0.5", features = ["util"] }
 tower-http = { version = "0.6", features = ["cors"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/agentic-llm-d/Cargo.toml
+++ b/crates/agentic-llm-d/Cargo.toml
@@ -28,3 +28,4 @@ agentic-core = { workspace = true, features = [] }
 reqwest = { workspace = true, features = ["json"] }
 serde_json.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tower.workspace = true

--- a/crates/agentic-llm-d/src/context.rs
+++ b/crates/agentic-llm-d/src/context.rs
@@ -14,6 +14,8 @@ use agentic_core::types::io::{ResponsesInput, ToolChoice};
 use agentic_core::types::request_response::RequestPayload;
 use agentic_core::types::tools::ResponsesTool;
 
+use crate::SigningKey;
+
 /// What `hydrate` returns. Raw JSON: the caller forwards it uninterpreted.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Hydration {
@@ -95,7 +97,7 @@ struct SealedClaims {
 ///
 /// # Errors
 /// [`ExecutorError::InvalidRequest`] if the token cannot be produced.
-pub fn seal(context: SplitContext, key: &[u8]) -> ExecutorResult<String> {
+pub fn seal(context: SplitContext, key: &SigningKey) -> ExecutorResult<String> {
     let expires = SystemTime::now()
         .checked_add(CONTEXT_TTL)
         .and_then(|at| at.duration_since(UNIX_EPOCH).ok())
@@ -105,8 +107,12 @@ pub fn seal(context: SplitContext, key: &[u8]) -> ExecutorResult<String> {
         aud: AUDIENCE.to_owned(),
         ctx: context,
     };
-    encode(&Header::new(Algorithm::HS256), &claims, &EncodingKey::from_secret(key))
-        .map_err(|error| ExecutorError::InvalidRequest(format!("cannot seal context: {error}")))
+    encode(
+        &Header::new(Algorithm::HS256),
+        &claims,
+        &EncodingKey::from_secret(key.as_bytes()),
+    )
+    .map_err(|error| ExecutorError::InvalidRequest(format!("cannot seal context: {error}")))
 }
 
 /// Opens a sealed context, rejecting one that was tampered with or has expired.
@@ -114,11 +120,11 @@ pub fn seal(context: SplitContext, key: &[u8]) -> ExecutorResult<String> {
 /// # Errors
 /// [`ExecutorError::InvalidRequest`] for a bad signature, a wrong audience, or
 /// a context past its expiry.
-pub fn unseal(token: &str, key: &[u8]) -> ExecutorResult<SplitContext> {
+pub fn unseal(token: &str, key: &SigningKey) -> ExecutorResult<SplitContext> {
     let mut validation = Validation::new(Algorithm::HS256);
     validation.set_audience(&[AUDIENCE]);
     validation.set_required_spec_claims(&["exp", "aud"]);
-    decode::<SealedClaims>(token, &DecodingKey::from_secret(key), &validation)
+    decode::<SealedClaims>(token, &DecodingKey::from_secret(key.as_bytes()), &validation)
         .map(|data| data.claims.ctx)
         .map_err(|error| ExecutorError::InvalidRequest(format!("context rejected: {error}")))
 }

--- a/crates/agentic-llm-d/src/handler.rs
+++ b/crates/agentic-llm-d/src/handler.rs
@@ -9,8 +9,8 @@ use axum::extract::{Request, State};
 use axum::http::StatusCode;
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
-use serde::Deserialize;
 use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
 use tracing::warn;
 
@@ -24,7 +24,10 @@ use agentic_core::types::request_response::RequestPayload;
 use crate::BackendState;
 use crate::context::{Hydration, ensure_splittable, seal, unseal};
 
-const MAX_BODY_SIZE: usize = 10 * 1024 * 1024;
+const MAX_HYDRATE_BODY_SIZE: usize = 2 * 1024 * 1024;
+const MAX_PERSIST_BODY_SIZE: usize = 16 * 1024 * 1024;
+const MAX_CONTEXT_SIZE: usize = 6 * 1024 * 1024;
+const MAX_UPSTREAM_BODY_SIZE: usize = 4 * 1024 * 1024;
 /// The calling workload's shared secret.
 pub const WORKLOAD_TOKEN_HEADER: &str = "x-agentic-workload-token";
 /// Readiness means storage answers - llm-d owns the model fleet.
@@ -47,10 +50,12 @@ pub async fn require_token(State(state): State<BackendState>, request: Request, 
         .get(WORKLOAD_TOKEN_HEADER)
         .and_then(|value| value.to_str().ok());
     match presented {
-        Some(token) if token_matches(token, &state.api_token) => next.run(request).await,
-        _ => json(
+        Some(token) if token_matches(token, state.secrets.workload_token()) => next.run(request).await,
+        _ => api_error(
             StatusCode::UNAUTHORIZED,
-            br#"{"error":{"type":"invalid_request_error","message":"missing or invalid bearer token"}}"#.to_vec(),
+            "authentication_error",
+            "invalid_workload_token",
+            "missing or invalid workload token",
         ),
     }
 }
@@ -78,7 +83,7 @@ pub async fn ready(State(state): State<BackendState>) -> StatusCode {
 }
 
 pub async fn hydrate(State(state): State<BackendState>, req: Request) -> Response {
-    let payload: RequestPayload = match read_json(req.into_body()).await {
+    let payload: RequestPayload = match read_json(req.into_body(), MAX_HYDRATE_BODY_SIZE).await {
         Ok(payload) => payload,
         Err(response) => return response,
     };
@@ -101,12 +106,17 @@ async fn build_hydration(
     ensure_splittable(&ctx.enriched_request)?;
     let stream = ctx.original_request.stream;
     let request = RawValue::from_string(upstream_request(&ctx, stream)?).map_err(ExecutorError::JsonError)?;
-    let context = seal(ctx.into(), &state.signing_key)?;
+    let context = seal(ctx.into(), state.secrets.signing_key())?;
+    if context.len() > MAX_CONTEXT_SIZE {
+        return Err(ExecutorError::PayloadTooLarge(
+            "hydrated context exceeds the split-execution size budget".to_owned(),
+        ));
+    }
     Ok(Hydration { request, context })
 }
 
 pub async fn persist(State(state): State<BackendState>, req: Request) -> Response {
-    let PersistRequest { context, response, sse } = match read_json(req.into_body()).await {
+    let PersistRequest { context, response, sse } = match read_json(req.into_body(), MAX_PERSIST_BODY_SIZE).await {
         Ok(request) => request,
         Err(response) => return response,
     };
@@ -119,7 +129,20 @@ pub async fn persist(State(state): State<BackendState>, req: Request) -> Respons
             return error_response(ExecutorError::InvalidRequest(message));
         }
     };
-    let context = match unseal(&context, &state.signing_key) {
+    if context.len() > MAX_CONTEXT_SIZE {
+        return error_response(ExecutorError::PayloadTooLarge(
+            "sealed context exceeds the split-execution size budget".to_owned(),
+        ));
+    }
+    let upstream_size = match upstream {
+        UpstreamBody::Json(body) | UpstreamBody::Sse(body) => body.len(),
+    };
+    if upstream_size > MAX_UPSTREAM_BODY_SIZE {
+        return error_response(ExecutorError::PayloadTooLarge(
+            "upstream response exceeds the split-execution size budget".to_owned(),
+        ));
+    }
+    let context = match unseal(&context, state.secrets.signing_key()) {
         Ok(context) => context,
         Err(error) => return error_response(error),
     };
@@ -142,12 +165,36 @@ fn error_response(error: ExecutorError) -> Response {
 }
 
 #[allow(clippy::result_large_err)] // an axum `Response` is the idiomatic error here
-async fn read_json<T: DeserializeOwned>(body: Body) -> Result<T, Response> {
-    let too_large = br#"{"error":{"type":"invalid_request_error","message":"request body too large"}}"#;
-    let bytes = axum::body::to_bytes(body, MAX_BODY_SIZE)
+async fn read_json<T: DeserializeOwned>(body: Body, limit: usize) -> Result<T, Response> {
+    let bytes = axum::body::to_bytes(body, limit)
         .await
-        .map_err(|_| json(StatusCode::PAYLOAD_TOO_LARGE, too_large.to_vec()))?;
+        .map_err(|_| error_response(ExecutorError::PayloadTooLarge("request body too large".to_owned())))?;
     serde_json::from_slice(&bytes).map_err(|error| error_response(ExecutorError::from(error)))
+}
+
+#[derive(Serialize)]
+struct ApiErrorEnvelope<'a> {
+    error: ApiErrorBody<'a>,
+}
+
+#[derive(Serialize)]
+struct ApiErrorBody<'a> {
+    message: &'a str,
+    #[serde(rename = "type")]
+    error_type: &'a str,
+    code: &'a str,
+}
+
+fn api_error(status: StatusCode, error_type: &str, code: &str, message: &str) -> Response {
+    let body = serde_json::to_vec(&ApiErrorEnvelope {
+        error: ApiErrorBody {
+            message,
+            error_type,
+            code,
+        },
+    })
+    .expect("static API error serializes");
+    json(status, body)
 }
 
 fn json(status: StatusCode, body: Vec<u8>) -> Response {

--- a/crates/agentic-llm-d/src/lib.rs
+++ b/crates/agentic-llm-d/src/lib.rs
@@ -12,14 +12,120 @@ use axum::{Router, middleware};
 
 use agentic_core::executor::ExecutionContext;
 
+const MIN_SECRET_LEN: usize = 32;
+
+/// Invalid backend authentication or signing material.
+#[derive(Debug, thiserror::Error)]
+pub enum SecretError {
+    #[error("{name} must be at least {MIN_SECRET_LEN} bytes of independently generated randomness")]
+    TooShort { name: &'static str },
+    #[error("the signing key and workload token must be generated independently")]
+    Reused,
+}
+
+/// Validated secrets shared by the backend handlers.
+#[derive(Clone)]
+pub struct BackendSecrets {
+    signing_key: SigningKey,
+    workload_token: Arc<str>,
+}
+
+/// Validated key used to sign and verify split-execution contexts.
+#[derive(Clone)]
+pub struct SigningKey(Arc<[u8]>);
+
+impl SigningKey {
+    /// Validates a context-signing key.
+    ///
+    /// # Errors
+    /// Returns [`SecretError`] when the key is shorter than 32 non-whitespace
+    /// bytes.
+    pub fn new(value: Vec<u8>) -> Result<Self, SecretError> {
+        if non_whitespace_ascii_len(&value) < MIN_SECRET_LEN {
+            return Err(SecretError::TooShort { name: "signing key" });
+        }
+        Ok(Self(value.into()))
+    }
+
+    pub(crate) fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl BackendSecrets {
+    /// Validates and constructs the secrets required by the split routes.
+    ///
+    /// # Errors
+    /// Returns [`SecretError`] when either value is too short or both values are
+    /// identical.
+    pub fn new(signing_key: Vec<u8>, workload_token: String) -> Result<Self, SecretError> {
+        let signing_key = SigningKey::new(signing_key)?;
+        if non_whitespace_ascii_len(workload_token.as_bytes()) < MIN_SECRET_LEN {
+            return Err(SecretError::TooShort { name: "workload token" });
+        }
+        if signing_key.as_bytes() == workload_token.as_bytes() {
+            return Err(SecretError::Reused);
+        }
+        Ok(Self {
+            signing_key,
+            workload_token: workload_token.into(),
+        })
+    }
+
+    pub(crate) fn signing_key(&self) -> &SigningKey {
+        &self.signing_key
+    }
+
+    pub(crate) fn workload_token(&self) -> &str {
+        &self.workload_token
+    }
+}
+
+fn non_whitespace_ascii_len(value: &[u8]) -> usize {
+    value.iter().filter(|byte| !byte.is_ascii_whitespace()).count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn signing_keys_and_workload_tokens_must_be_long_and_independent() {
+        assert!(matches!(
+            BackendSecrets::new(Vec::new(), "b".repeat(MIN_SECRET_LEN)),
+            Err(SecretError::TooShort { name: "signing key" })
+        ));
+        assert!(matches!(
+            BackendSecrets::new(vec![b'a'; MIN_SECRET_LEN], String::new()),
+            Err(SecretError::TooShort { name: "workload token" })
+        ));
+        assert!(matches!(
+            BackendSecrets::new(vec![b'a'; MIN_SECRET_LEN], "a".repeat(MIN_SECRET_LEN)),
+            Err(SecretError::Reused)
+        ));
+        let sparse = format!("a{}b", " ".repeat(MIN_SECRET_LEN - 2));
+        assert!(matches!(
+            SigningKey::new(sparse.as_bytes().to_vec()),
+            Err(SecretError::TooShort { name: "signing key" })
+        ));
+        assert!(matches!(
+            BackendSecrets::new(vec![b'a'; MIN_SECRET_LEN], sparse),
+            Err(SecretError::TooShort { name: "workload token" })
+        ));
+        assert!(matches!(
+            SigningKey::new(vec![b'a'; MIN_SECRET_LEN - 1]),
+            Err(SecretError::TooShort { name: "signing key" })
+        ));
+        BackendSecrets::new(vec![b'a'; MIN_SECRET_LEN], "b".repeat(MIN_SECRET_LEN)).expect("independent secrets");
+    }
+}
+
 /// All the endpoints need — far less than the gateway's `AppState`.
 #[derive(Clone)]
 pub struct BackendState {
     pub exec_ctx: Arc<ExecutionContext>,
-    /// Seals the context between hydrate and persist.
-    pub signing_key: Arc<Vec<u8>>,
-    /// Shared secret every split-route caller must present.
-    pub api_token: Arc<String>,
+    /// Validated signing and workload-authentication material.
+    pub secrets: BackendSecrets,
 }
 
 /// The whole surface: two split-execution endpoints and two probes.

--- a/crates/agentic-llm-d/src/main.rs
+++ b/crates/agentic-llm-d/src/main.rs
@@ -31,9 +31,6 @@ struct Cli {
     api_token: String,
 }
 
-/// Long enough that a guessed value is not worth trying.
-const MIN_SECRET_LEN: usize = 32;
-
 #[tokio::main]
 async fn main() -> Result<(), runner::Error> {
     tracing_subscriber::fmt::init();
@@ -51,25 +48,6 @@ async fn main() -> Result<(), runner::Error> {
         sqlite: SqliteConfig::default(),
         tools: ToolRuntimeConfig::default(),
     };
-
-    // Checked before binding: a short secret is worse than none, it looks configured.
-    for (name, value) in [
-        ("AGENTIC_LLM_D_SIGNING_KEY", &cli.signing_key),
-        ("AGENTIC_LLM_D_API_TOKEN", &cli.api_token),
-    ] {
-        if value.trim().len() < MIN_SECRET_LEN {
-            eprintln!("{name} must be at least {MIN_SECRET_LEN} characters of independently generated randomness");
-            std::process::exit(2);
-        }
-    }
-
-    // Independence is the property we can actually check. The token travels in a
-    // header on every request, so reusing it as the signing key would let anyone
-    // who sees one forge the other.
-    if cli.signing_key == cli.api_token {
-        eprintln!("AGENTIC_LLM_D_SIGNING_KEY and AGENTIC_LLM_D_API_TOKEN must be generated independently");
-        std::process::exit(2);
-    }
 
     let shutdown = CancellationToken::new();
     let on_signal = shutdown.clone();

--- a/crates/agentic-llm-d/src/runner.rs
+++ b/crates/agentic-llm-d/src/runner.rs
@@ -1,6 +1,7 @@
 //! Build state, bind, serve, drain.
 
-use std::future::IntoFuture;
+use std::future::{Future, IntoFuture};
+use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -11,7 +12,7 @@ use tracing::{info, warn};
 use agentic_core::config::Config;
 use agentic_core::executor::ExecutionContext;
 
-use crate::{BackendState, build_router};
+use crate::{BackendSecrets, BackendState, SecretError, build_router};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -19,11 +20,28 @@ pub enum Error {
     Context(#[from] agentic_core::error::Error),
     #[error("failed to bind or serve: {0}")]
     Io(#[from] std::io::Error),
+    #[error("invalid backend secrets: {0}")]
+    Secret(#[from] SecretError),
 }
 
 /// Matches the gateway's bound: a drain that never finishes would outlive the
 /// pod's termination grace period and be killed mid-request anyway.
 const DRAIN_TIMEOUT: Duration = Duration::from_secs(8);
+
+async fn drain_backend<F>(server: Pin<&mut F>) -> Result<(), Error>
+where
+    F: Future<Output = Result<(), std::io::Error>>,
+{
+    if let Ok(result) = tokio::time::timeout(DRAIN_TIMEOUT, server).await {
+        result.map_err(Error::Io)
+    } else {
+        warn!(
+            timeout_seconds = DRAIN_TIMEOUT.as_secs(),
+            "drain timed out; closing remaining connections"
+        );
+        Ok(())
+    }
+}
 
 /// Opens storage from `config` and serves the backend router until `shutdown`,
 /// then drains in-flight requests for at most [`DRAIN_TIMEOUT`].
@@ -38,34 +56,60 @@ pub async fn serve(
     port: u16,
     shutdown: CancellationToken,
 ) -> Result<(), Error> {
+    let secrets = BackendSecrets::new(signing_key, api_token)?;
     let exec_ctx = Arc::new(ExecutionContext::from_config(config).await?);
-    let signing_key = Arc::new(signing_key);
-    let api_token = Arc::new(api_token);
     let listener = TcpListener::bind(format!("{host}:{port}")).await?;
-    info!("agentic-llm-d listening on {host}:{port} — no proxy, no inference");
+    info!("agentic-llm-d listening on {host}:{port}, no proxy, no inference");
     let graceful = shutdown.clone();
-    let serving = axum::serve(
-        listener,
-        build_router(BackendState {
-            exec_ctx,
-            signing_key,
-            api_token,
-        }),
-    )
-    .with_graceful_shutdown(async move { graceful.cancelled().await })
-    .into_future();
+    let serving = axum::serve(listener, build_router(BackendState { exec_ctx, secrets }))
+        .with_graceful_shutdown(async move { graceful.cancelled().await })
+        .into_future();
     tokio::pin!(serving);
 
     tokio::select! {
         result = &mut serving => result?,
         () = shutdown.cancelled() => {
-            if tokio::time::timeout(DRAIN_TIMEOUT, serving).await.is_err() {
-                warn!(
-                    timeout_seconds = DRAIN_TIMEOUT.as_secs(),
-                    "drain timed out; closing remaining connections"
-                );
-            }
+            drain_backend(serving.as_mut()).await?;
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use agentic_core::config::{PostgresConfig, SqliteConfig, ToolRuntimeConfig};
+
+    #[tokio::test]
+    async fn backend_drain_preserves_server_errors() {
+        let server = std::future::ready(Err(std::io::Error::other("backend failed")));
+        tokio::pin!(server);
+
+        let error = drain_backend(server.as_mut()).await.unwrap_err();
+
+        assert_eq!(error.to_string(), "failed to bind or serve: backend failed");
+    }
+
+    #[tokio::test]
+    async fn serve_rejects_empty_secrets_before_binding() {
+        let config = Config {
+            llm_api_base: String::new(),
+            openai_api_key: None,
+            llm_ready_timeout_s: 0.0,
+            llm_ready_interval_s: 0.0,
+            skip_llm_ready_check: true,
+            db_url: Some("sqlite://?mode=memory".to_owned()),
+            postgres: PostgresConfig::default(),
+            sqlite: SqliteConfig::default(),
+            tools: ToolRuntimeConfig::default(),
+        };
+        let shutdown = CancellationToken::new();
+        shutdown.cancel();
+
+        let error = serve(&config, Vec::new(), String::new(), "127.0.0.1", 0, shutdown)
+            .await
+            .expect_err("empty secrets must be rejected");
+
+        assert!(error.to_string().contains("at least 32 bytes"), "got: {error}");
+    }
 }

--- a/crates/agentic-llm-d/tests/http_contract.rs
+++ b/crates/agentic-llm-d/tests/http_contract.rs
@@ -1,0 +1,279 @@
+use std::sync::Arc;
+
+use agentic_core::executor::{ConversationHandler, ExecutionContext, ResponseHandler};
+use agentic_core::storage::{ConversationStore, ResponseStore, create_pool_with_schema};
+use agentic_llm_d::{BackendSecrets, BackendState, build_router};
+use axum::Router;
+use axum::body::{Body, to_bytes};
+use axum::http::{Request, StatusCode};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+const API_TOKEN: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const SIGNING_KEY: &[u8] = b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+async fn state() -> BackendState {
+    let pool = create_pool_with_schema(Some("sqlite://?mode=memory"))
+        .await
+        .expect("pool");
+    BackendState {
+        exec_ctx: Arc::new(ExecutionContext::new(
+            ConversationHandler::new(ConversationStore::new(Arc::clone(&pool))),
+            ResponseHandler::new(ResponseStore::new(pool)),
+            Arc::new(reqwest::Client::new()),
+            "http://localhost:8000".to_owned(),
+        )),
+        secrets: BackendSecrets::new(SIGNING_KEY.to_vec(), API_TOKEN.to_owned()).expect("valid secrets"),
+    }
+}
+
+async fn response_json(response: axum::response::Response) -> Value {
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.expect("body");
+    serde_json::from_slice(&bytes).expect("JSON response")
+}
+
+async fn hydrate_context(router: &Router, input: &str) -> String {
+    let response = router
+        .clone()
+        .oneshot(
+            Request::post("/v1alpha/responses/hydrate")
+                .header("content-type", "application/json")
+                .header("x-agentic-workload-token", API_TOKEN)
+                .body(Body::from(
+                    json!({"model": "test-model", "input": input, "store": true}).to_string(),
+                ))
+                .expect("request"),
+        )
+        .await
+        .expect("router response");
+    assert_eq!(response.status(), StatusCode::OK);
+    response_json(response).await["context"]
+        .as_str()
+        .expect("sealed context")
+        .to_owned()
+}
+
+async fn assert_body_too_large(response: axum::response::Response) {
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    assert_eq!(
+        response_json(response).await,
+        json!({
+            "error": {
+                "message": "request body too large",
+                "type": "invalid_request_error",
+                "code": "body_too_large"
+            }
+        })
+    );
+}
+
+#[tokio::test]
+async fn missing_workload_token_has_a_standard_error_envelope() {
+    let response = build_router(state().await)
+        .oneshot(
+            Request::post("/v1alpha/responses/hydrate")
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .expect("request"),
+        )
+        .await
+        .expect("router response");
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(
+        response_json(response).await,
+        json!({
+            "error": {
+                "message": "missing or invalid workload token",
+                "type": "authentication_error",
+                "code": "invalid_workload_token"
+            }
+        })
+    );
+}
+
+#[tokio::test]
+async fn hydrate_rejects_a_body_that_cannot_fit_the_round_trip_budget() {
+    let body = json!({
+        "model": "test-model",
+        "input": "x".repeat(2 * 1024 * 1024),
+        "store": true
+    })
+    .to_string();
+    let response = build_router(state().await)
+        .oneshot(
+            Request::post("/v1alpha/responses/hydrate")
+                .header("content-type", "application/json")
+                .header("x-agentic-workload-token", API_TOKEN)
+                .body(Body::from(body))
+                .expect("request"),
+        )
+        .await
+        .expect("router response");
+
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    assert_eq!(
+        response_json(response).await,
+        json!({
+            "error": {
+                "message": "request body too large",
+                "type": "invalid_request_error",
+                "code": "body_too_large"
+            }
+        })
+    );
+}
+
+#[tokio::test]
+async fn a_near_limit_hydrate_response_can_be_persisted() {
+    let router = build_router(state().await);
+    let body = json!({
+        "model": "test-model",
+        "input": "x".repeat(1_900_000),
+        "store": true
+    })
+    .to_string();
+    let hydrated = router
+        .clone()
+        .oneshot(
+            Request::post("/v1alpha/responses/hydrate")
+                .header("content-type", "application/json")
+                .header("x-agentic-workload-token", API_TOKEN)
+                .body(Body::from(body))
+                .expect("request"),
+        )
+        .await
+        .expect("router response");
+    assert_eq!(hydrated.status(), StatusCode::OK);
+    let context = response_json(hydrated).await["context"]
+        .as_str()
+        .expect("sealed context")
+        .to_owned();
+
+    let persisted = router
+        .oneshot(
+            Request::post("/v1alpha/responses/persist")
+                .header("content-type", "application/json")
+                .header("x-agentic-workload-token", API_TOKEN)
+                .body(Body::from(
+                    json!({
+                        "context": context,
+                        "response": {
+                            "id": "resp_upstream",
+                            "object": "response",
+                            "created_at": 1_700_000_000,
+                            "model": "test-model",
+                            "status": "completed",
+                            "output": []
+                        }
+                    })
+                    .to_string(),
+                ))
+                .expect("request"),
+        )
+        .await
+        .expect("router response");
+
+    assert_eq!(persisted.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn persist_rejects_each_size_budget_with_a_standard_envelope() {
+    let router = build_router(state().await);
+    let response = router
+        .clone()
+        .oneshot(
+            Request::post("/v1alpha/responses/persist")
+                .header("content-type", "application/json")
+                .header("x-agentic-workload-token", API_TOKEN)
+                .body(Body::from("x".repeat(16 * 1024 * 1024 + 1)))
+                .expect("request"),
+        )
+        .await
+        .expect("router response");
+    assert_body_too_large(response).await;
+
+    for body in [
+        json!({
+            "context": "x".repeat(6 * 1024 * 1024 + 1),
+            "response": {"id": "resp_upstream", "status": "completed", "output": []}
+        })
+        .to_string(),
+        json!({
+            "context": "valid-size-but-not-sealed",
+            "sse": "x".repeat(4 * 1024 * 1024 + 1)
+        })
+        .to_string(),
+    ] {
+        let response = router
+            .clone()
+            .oneshot(
+                Request::post("/v1alpha/responses/persist")
+                    .header("content-type", "application/json")
+                    .header("x-agentic-workload-token", API_TOKEN)
+                    .body(Body::from(body))
+                    .expect("request"),
+            )
+            .await
+            .expect("router response");
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        assert_eq!(response_json(response).await["error"]["code"], "body_too_large");
+    }
+}
+
+#[tokio::test]
+async fn duplicate_persist_has_a_standard_conflict_envelope() {
+    let router = build_router(state().await);
+    let context = hydrate_context(&router, "What is 2+2?").await;
+    let body = json!({
+        "context": context,
+        "response": {
+            "id": "resp_upstream",
+            "object": "response",
+            "created_at": 1_700_000_000,
+            "model": "test-model",
+            "status": "completed",
+            "output": []
+        }
+    })
+    .to_string();
+
+    let first = router
+        .clone()
+        .oneshot(
+            Request::post("/v1alpha/responses/persist")
+                .header("content-type", "application/json")
+                .header("x-agentic-workload-token", API_TOKEN)
+                .body(Body::from(body.clone()))
+                .expect("request"),
+        )
+        .await
+        .expect("router response");
+    assert_eq!(first.status(), StatusCode::OK);
+    let response_id = response_json(first).await["id"]
+        .as_str()
+        .expect("stored response id")
+        .to_owned();
+
+    let duplicate = router
+        .oneshot(
+            Request::post("/v1alpha/responses/persist")
+                .header("content-type", "application/json")
+                .header("x-agentic-workload-token", API_TOKEN)
+                .body(Body::from(body))
+                .expect("request"),
+        )
+        .await
+        .expect("router response");
+    assert_eq!(duplicate.status(), StatusCode::CONFLICT);
+    assert_eq!(
+        response_json(duplicate).await,
+        json!({
+            "error": {
+                "message": format!("conflict: a turn is already stored under '{response_id}'"),
+                "type": "conflict_error",
+                "code": "response_already_stored"
+            }
+        })
+    );
+}

--- a/crates/agentic-llm-d/tests/split_execution_integration.rs
+++ b/crates/agentic-llm-d/tests/split_execution_integration.rs
@@ -11,6 +11,7 @@ use agentic_core::executor::{
 };
 use agentic_core::storage::{ConversationStore, ResponseStore, create_pool_with_schema};
 use agentic_core::types::request_response::{RequestPayload, ResponsePayload};
+use agentic_llm_d::SigningKey;
 use agentic_llm_d::context::{Hydration, SplitContext, ensure_splittable, seal, unseal};
 use serde_json::value::RawValue;
 use serde_json::{Value, json};
@@ -51,9 +52,12 @@ fn upstream_json(text: &str) -> String {
 /// The same turn as SSE, the way a streaming caller would have relayed it.
 fn upstream_sse(text: &str) -> String {
     [
+        json!({"type": "response.created", "response": {"id": "resp_upstream", "status": "in_progress"}}),
+        json!({"type": "response.in_progress", "response": {"id": "resp_upstream", "status": "in_progress"}}),
         json!({"type": "response.output_item.added", "output_index": 0,
                "item": {"type": "message", "id": "msg_1", "role": "assistant", "status": "in_progress", "content": []}}),
-        json!({"type": "response.output_text.delta", "output_index": 0, "item_id": "msg_1", "delta": text}),
+        json!({"type": "response.output_text.delta", "output_index": 0, "content_index": 0,
+               "item_id": "msg_1", "delta": text}),
         json!({"type": "response.output_item.done", "output_index": 0, "item": answer(text)[0]}),
         json!({"type": "response.completed", "response": {"id": "resp_upstream", "status": "completed"}}),
     ]
@@ -63,7 +67,9 @@ fn upstream_sse(text: &str) -> String {
     .concat()
 }
 
-const KEY: &[u8] = b"test-signing-key";
+fn signing_key() -> SigningKey {
+    SigningKey::new(b"test-signing-key-32-bytes-minimum!".to_vec()).expect("valid test key")
+}
 
 /// What the hydrate handler composes.
 async fn hydrate(request: RequestPayload, ctx: &ExecutionContext) -> ExecutorResult<Hydration> {
@@ -74,7 +80,7 @@ async fn hydrate(request: RequestPayload, ctx: &ExecutionContext) -> ExecutorRes
     let body = RawValue::from_string(upstream_request(&live, stream)?).map_err(ExecutorError::JsonError)?;
     Ok(Hydration {
         request: body,
-        context: seal(live.into(), KEY)?,
+        context: seal(live.into(), &signing_key())?,
     })
 }
 
@@ -84,7 +90,7 @@ async fn persist(
     upstream: UpstreamBody<'_>,
     ctx: &ExecutionContext,
 ) -> ExecutorResult<ResponsePayload> {
-    let live = RequestContext::from(unseal(&context, KEY)?);
+    let live = RequestContext::from(unseal(&context, &signing_key())?);
     let payload = decode_upstream(&live, upstream)?;
     commit(live, payload, ctx).await
 }
@@ -118,6 +124,55 @@ async fn a_streamed_turn_persists_from_the_relayed_frames() {
     assert_eq!(replayed(&next).0, 3, "the streamed turn is continuable");
 }
 
+#[tokio::test]
+async fn output_item_done_is_authoritative_when_delta_is_missing() {
+    let ctx = exec_ctx().await;
+    let streamed = turn("What is 2+2?", None, &ctx).await;
+    let sse = [
+        json!({"type": "response.created", "response": {"id": "resp_upstream", "status": "in_progress"}}),
+        json!({"type": "response.in_progress", "response": {"id": "resp_upstream", "status": "in_progress"}}),
+        json!({"type": "response.output_item.added", "output_index": 0,
+               "item": {"type": "message", "id": "msg_1", "role": "assistant",
+                        "status": "in_progress", "content": []}}),
+        json!({"type": "response.output_item.done", "output_index": 0, "item": answer("4")[0]}),
+        json!({"type": "response.completed", "response": {"id": "resp_upstream", "status": "completed"}}),
+    ]
+    .iter()
+    .map(|frame| format!("data: {frame}\n\n"))
+    .collect::<Vec<_>>()
+    .concat();
+
+    let stored = persist(streamed.context, UpstreamBody::Sse(&sse), &ctx)
+        .await
+        .expect("persist from authoritative done item");
+    let output = serde_json::to_value(&stored.output).expect("serialize output");
+    assert_eq!(output[0]["content"][0]["text"], "4");
+}
+
+#[tokio::test]
+async fn a_function_call_stream_passes_strict_validation() {
+    let ctx = exec_ctx().await;
+    let streamed = turn("Call lookup", None, &ctx).await;
+    let sse = [
+        r#"data: {"type":"response.created","response":{"id":"resp_upstream","status":"in_progress"}}"#,
+        r#"data: {"type":"response.in_progress","response":{"id":"resp_upstream","status":"in_progress"}}"#,
+        r#"data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"lookup","arguments":"","status":"in_progress"}}"#,
+        r#"data: {"type":"response.function_call_arguments.delta","output_index":0,"item_id":"fc_1","delta":"{\"q\":"}"#,
+        r#"data: {"type":"response.function_call_arguments.done","output_index":0,"item_id":"fc_1","name":"lookup","arguments":"{\"q\":\"rust\"}"}"#,
+        r#"data: {"type":"response.output_item.done","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"lookup","arguments":"{\"q\":\"rust\"}","status":"completed"}}"#,
+        r#"data: {"type":"response.completed","response":{"id":"resp_upstream","status":"completed"}}"#,
+    ]
+    .join("\n\n");
+
+    let stored = persist(streamed.context, UpstreamBody::Sse(&sse), &ctx)
+        .await
+        .expect("persist function-call SSE");
+    assert!(matches!(
+        stored.output.as_slice(),
+        [agentic_core::types::io::OutputItem::FunctionCall(_)]
+    ));
+}
+
 /// Every way a turn is refused, and the status the caller sees.
 #[tokio::test]
 async fn a_turn_that_cannot_be_stored_is_refused() {
@@ -135,29 +190,96 @@ async fn a_turn_that_cannot_be_stored_is_refused() {
         r#"{"id":"resp_upstream"}"#.to_owned(),
         r#"{"id":"resp_upstream","status":"completed"}"#.to_owned(),
         r#"{"id":"resp_upstream","status":"completed","output":[123]}"#.to_owned(),
+        r#"{"id":"resp_upstream","status":"queued","output":[]}"#.to_owned(),
+        r#"{"id":"resp_upstream","status":"potato","output":[]}"#.to_owned(),
     ] {
         let refused = persist(turn("hi", None, &ctx).await.context, UpstreamBody::Json(&body), &ctx).await;
         assert_eq!(status_of(&refused.expect_err("not storable")), 400, "accepted: {body}");
     }
 
     let completed = r#"data: {"type":"response.completed","response":{"id":"resp_upstream","status":"completed"}}"#;
+    let created = r#"data: {"type":"response.created","response":{"id":"resp_upstream","status":"in_progress"}}"#;
+    let in_progress =
+        r#"data: {"type":"response.in_progress","response":{"id":"resp_upstream","status":"in_progress"}}"#;
     for sse in [
         // A relay that died mid-stream: `finish_stream` would call this complete.
         r#"data: {"type":"response.output_text.delta","item_id":"msg_1","delta":"4"}"#.to_owned(),
         // A frame the accumulator could not read must not be skipped past.
         format!("data: not-json\n\n{completed}"),
+        // A terminal event without its required response object must not turn
+        // a truncated stream into an empty completed response.
+        r#"data: {"type":"response.completed"}"#.to_owned(),
+        // A terminal event cannot stand in for the lifecycle that preceded it.
+        completed.to_owned(),
+        // The response can be created only once.
+        [created, created, in_progress, completed].join("\n\n"),
+        // Every lifecycle event must describe the same upstream response.
+        [
+            created,
+            in_progress,
+            r#"data: {"type":"response.completed","response":{"id":"resp_other","status":"completed"}}"#,
+        ]
+        .join("\n\n"),
+        // A valid terminal event must not hide an unmatched content delta.
+        format!(
+            "{created}\n\n{in_progress}\n\ndata: {{\"type\":\"response.output_text.delta\",\"output_index\":0,\"item_id\":\"msg_1\",\"delta\":\"4\"}}\n\n{completed}"
+        ),
+        // A lifecycle-correct frame must still carry its event-specific data.
+        [
+            created,
+            in_progress,
+            r#"data: {"type":"response.output_item.added","output_index":0,"item":{"type":"message","id":"msg_1","role":"assistant","status":"in_progress","content":[]}}"#,
+            r#"data: {"type":"response.output_text.delta","output_index":0,"item_id":"msg_1"}"#,
+            r#"data: {"type":"response.output_item.done","output_index":0,"item":{"type":"message","id":"msg_1","role":"assistant","status":"completed","content":[]}}"#,
+            completed,
+        ]
+        .join("\n\n"),
+        // Known item events must identify the item they mutate.
+        [
+            created,
+            in_progress,
+            r#"data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"lookup","arguments":"","status":"in_progress"}}"#,
+            r#"data: {"type":"response.function_call_arguments.delta","output_index":0,"delta":"{}"}"#,
+        ]
+        .join("\n\n"),
+        // An event cannot mutate an active item of a different type.
+        [
+            created,
+            in_progress,
+            r#"data: {"type":"response.output_item.added","output_index":0,"item":{"type":"message","id":"msg_1","role":"assistant","status":"in_progress","content":[]}}"#,
+            r#"data: {"type":"response.function_call_arguments.delta","output_index":0,"item_id":"msg_1","delta":"{}"}"#,
+        ]
+        .join("\n\n"),
+        // Completed item identifiers and indexes cannot be reused later in the stream.
+        [
+            created,
+            in_progress,
+            r#"data: {"type":"response.output_item.added","output_index":0,"item":{"type":"message","id":"msg_1","role":"assistant","status":"in_progress","content":[]}}"#,
+            r#"data: {"type":"response.output_item.done","output_index":0,"item":{"type":"message","id":"msg_1","role":"assistant","status":"completed","content":[]}}"#,
+            r#"data: {"type":"response.output_item.added","output_index":0,"item":{"type":"message","id":"msg_1","role":"assistant","status":"in_progress","content":[]}}"#,
+        ]
+        .join("\n\n"),
+        // Unsupported output item types must not be coerced into empty messages.
+        [
+            created,
+            in_progress,
+            r#"data: {"type":"response.output_item.added","output_index":0,"item":{"type":"file_search_call","id":"fs_1","status":"in_progress","queries":["rust"]}}"#,
+            r#"data: {"type":"response.output_item.done","output_index":0,"item":{"type":"file_search_call","id":"fs_1","status":"completed","queries":["rust"]}}"#,
+            completed,
+        ]
+        .join("\n\n"),
     ] {
         let refused = persist(turn("hi", None, &ctx).await.context, UpstreamBody::Sse(&sse), &ctx).await;
         assert_eq!(status_of(&refused.expect_err("bad stream")), 400, "accepted: {sse}");
     }
 
-    let opened = unseal(&turn("hi", None, &ctx).await.context, KEY).expect("unseal");
+    let opened = unseal(&turn("hi", None, &ctx).await.context, &signing_key()).expect("unseal");
     let no_id = seal(
         SplitContext {
             response_id: String::new(),
             ..opened
         },
-        KEY,
+        &signing_key(),
     )
     .expect("seal");
     let refused = persist(no_id, UpstreamBody::Json(&upstream_json("4")), &ctx).await;
@@ -173,7 +295,7 @@ async fn a_turn_that_is_not_written_still_returns() {
     failed["status"] = json!("failed");
     failed["output"] = json!([]);
     let attempt = turn("hi", None, &ctx).await;
-    let id = unseal(&attempt.context, KEY).expect("unseal").response_id;
+    let id = unseal(&attempt.context, &signing_key()).expect("unseal").response_id;
     let payload = persist(attempt.context, UpstreamBody::Json(&failed.to_string()), &ctx)
         .await
         .expect("a failed turn is not a boundary error");
@@ -202,13 +324,35 @@ async fn reusing_a_reserved_id_is_refused() {
     assert!(text.contains('4') && !text.contains('5'));
 }
 
+/// Concurrent delivery must have the same externally visible retry contract as
+/// a sequential retry: one write wins and the duplicate is a 409 conflict.
+#[tokio::test]
+async fn concurrent_reuse_of_a_reserved_id_is_a_conflict() {
+    let ctx = exec_ctx().await;
+    let hydrated = turn("What is 2+2?", None, &ctx).await;
+    let first_context = hydrated.context.clone();
+    let second_context = hydrated.context;
+    let first_body = upstream_json("4");
+    let second_body = first_body.clone();
+
+    let (first, second) = tokio::join!(
+        persist(first_context, UpstreamBody::Json(&first_body), &ctx),
+        persist(second_context, UpstreamBody::Json(&second_body), &ctx),
+    );
+
+    let statuses = [first, second].map(|result| result.map_or_else(|error| status_of(&error), |_| 200));
+    assert_eq!(statuses.iter().filter(|status| **status == 200).count(), 1);
+    assert_eq!(statuses.iter().filter(|status| **status == 409).count(), 1);
+}
+
 /// A gateway-owned tool reaches a split turn only by inheritance: the gateway
 /// stored it, and a continuation sending no `tools` picks it up during
 /// rehydration — after the request itself has already passed the check.
 #[tokio::test]
 async fn an_inherited_gateway_tool_is_refused() {
     let ctx = exec_ctx().await;
-    let mut gateway_turn = RequestContext::from(unseal(&turn("hi", None, &ctx).await.context, KEY).expect("unseal"));
+    let mut gateway_turn =
+        RequestContext::from(unseal(&turn("hi", None, &ctx).await.context, &signing_key()).expect("unseal"));
     gateway_turn.enriched_request.tools = Some(vec![
         serde_json::from_value(json!({"type": "web_search_preview"})).expect("gateway tool"),
     ]);
@@ -285,7 +429,11 @@ async fn a_context_this_service_did_not_seal_is_rejected() {
     let sealed = turn("hi", None, &ctx).await.context;
 
     for forged in [
-        seal(unseal(&sealed, KEY).expect("unseal"), b"a-different-key").expect("seal"),
+        seal(
+            unseal(&sealed, &signing_key()).expect("unseal"),
+            &SigningKey::new(b"a-different-signing-key-32-bytes!".to_vec()).expect("alternate test key"),
+        )
+        .expect("seal"),
         format!("{sealed}tampered"),
     ] {
         let refused = persist(forged, UpstreamBody::Json(&upstream_json("4")), &ctx).await;

--- a/crates/agentic-llm-d/tests/split_execution_integration.rs
+++ b/crates/agentic-llm-d/tests/split_execution_integration.rs
@@ -56,10 +56,17 @@ fn upstream_sse(text: &str) -> String {
         json!({"type": "response.in_progress", "response": {"id": "resp_upstream", "status": "in_progress"}}),
         json!({"type": "response.output_item.added", "output_index": 0,
                "item": {"type": "message", "id": "msg_1", "role": "assistant", "status": "in_progress", "content": []}}),
+        json!({"type": "response.content_part.added", "output_index": 0, "content_index": 0,
+               "item_id": "msg_1", "part": {"type": "output_text", "text": "", "annotations": []}}),
         json!({"type": "response.output_text.delta", "output_index": 0, "content_index": 0,
                "item_id": "msg_1", "delta": text}),
+        json!({"type": "response.output_text.done", "output_index": 0, "content_index": 0,
+               "item_id": "msg_1", "text": text}),
+        json!({"type": "response.content_part.done", "output_index": 0, "content_index": 0,
+               "item_id": "msg_1", "part": answer(text)[0]["content"][0]}),
         json!({"type": "response.output_item.done", "output_index": 0, "item": answer(text)[0]}),
-        json!({"type": "response.completed", "response": {"id": "resp_upstream", "status": "completed"}}),
+        json!({"type": "response.completed",
+               "response": {"id": "resp_upstream", "status": "completed", "output": answer(text)}}),
     ]
     .iter()
     .map(|frame| format!("data: {frame}\n\n"))
@@ -135,7 +142,8 @@ async fn output_item_done_is_authoritative_when_delta_is_missing() {
                "item": {"type": "message", "id": "msg_1", "role": "assistant",
                         "status": "in_progress", "content": []}}),
         json!({"type": "response.output_item.done", "output_index": 0, "item": answer("4")[0]}),
-        json!({"type": "response.completed", "response": {"id": "resp_upstream", "status": "completed"}}),
+        json!({"type": "response.completed",
+               "response": {"id": "resp_upstream", "status": "completed", "output": answer("4")}}),
     ]
     .iter()
     .map(|frame| format!("data: {frame}\n\n"))
@@ -160,7 +168,7 @@ async fn a_function_call_stream_passes_strict_validation() {
         r#"data: {"type":"response.function_call_arguments.delta","output_index":0,"item_id":"fc_1","delta":"{\"q\":"}"#,
         r#"data: {"type":"response.function_call_arguments.done","output_index":0,"item_id":"fc_1","name":"lookup","arguments":"{\"q\":\"rust\"}"}"#,
         r#"data: {"type":"response.output_item.done","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"lookup","arguments":"{\"q\":\"rust\"}","status":"completed"}}"#,
-        r#"data: {"type":"response.completed","response":{"id":"resp_upstream","status":"completed"}}"#,
+        r#"data: {"type":"response.completed","response":{"id":"resp_upstream","status":"completed","output":[{"type":"function_call","id":"fc_1","call_id":"call_1","name":"lookup","arguments":"{\"q\":\"rust\"}","status":"completed"}]}}"#,
     ]
     .join("\n\n");
 
@@ -181,8 +189,8 @@ async fn a_turn_that_cannot_be_stored_is_refused() {
     let unknown = hydrate(request("hi", Some("resp_missing")), &ctx).await;
     assert_eq!(status_of(&unknown.expect_err("unknown id")), 404);
 
-    // A caller-supplied body gets none of the in-process parser's defaults. An
-    // unrecognized item *type* is still fine — `OutputItem` keeps a catch-all.
+    // A caller-supplied body gets none of the in-process parser's defaults,
+    // including the catch-all used for compatibility on trusted internal paths.
     let mut in_progress: Value = serde_json::from_str(&upstream_json("partial")).expect("json");
     in_progress["status"] = json!("in_progress");
     for body in [
@@ -192,6 +200,9 @@ async fn a_turn_that_cannot_be_stored_is_refused() {
         r#"{"id":"resp_upstream","status":"completed","output":[123]}"#.to_owned(),
         r#"{"id":"resp_upstream","status":"queued","output":[]}"#.to_owned(),
         r#"{"id":"resp_upstream","status":"potato","output":[]}"#.to_owned(),
+        r#"{"id":"resp_upstream","status":"completed","output":[{"type":"future_item","id":"future_1"}]}"#.to_owned(),
+        r#"{"id":"resp_upstream","status":"completed","output":[{"type":"function_call","call_id":"call_1","name":"lookup","arguments":"{}","status":"completed"}]}"#.to_owned(),
+        r#"{"id":"resp_upstream","status":"completed","output":[{"type":"message","id":"msg_1","role":"assistant","status":"completed","content":[]},{"type":"message","id":"msg_1","role":"assistant","status":"completed","content":[]}]}"#.to_owned(),
     ] {
         let refused = persist(turn("hi", None, &ctx).await.context, UpstreamBody::Json(&body), &ctx).await;
         assert_eq!(status_of(&refused.expect_err("not storable")), 400, "accepted: {body}");
@@ -223,6 +234,11 @@ async fn a_turn_that_cannot_be_stored_is_refused() {
         // A valid terminal event must not hide an unmatched content delta.
         format!(
             "{created}\n\n{in_progress}\n\ndata: {{\"type\":\"response.output_text.delta\",\"output_index\":0,\"item_id\":\"msg_1\",\"delta\":\"4\"}}\n\n{completed}"
+        ),
+        // Terminal output cannot contain an item that was omitted from the relayed item events.
+        format!(
+            "{created}\n\n{in_progress}\n\ndata: {{\"type\":\"response.completed\",\"response\":{{\"id\":\"resp_upstream\",\"status\":\"completed\",\"output\":{}}}}}",
+            answer("4")
         ),
         // A lifecycle-correct frame must still carry its event-specific data.
         [

--- a/crates/agentic-server-core/src/events/mod.rs
+++ b/crates/agentic-server-core/src/events/mod.rs
@@ -2,4 +2,5 @@ pub mod normalize;
 pub mod types;
 
 pub use normalize::normalize_sse_line;
+pub(crate) use normalize::normalize_sse_value;
 pub use types::{EventFrame, EventPayload, SSEEventType, SSEItemType, WireEvent};

--- a/crates/agentic-server-core/src/events/normalize.rs
+++ b/crates/agentic-server-core/src/events/normalize.rs
@@ -16,6 +16,11 @@ pub fn normalize_sse_line(line: &str) -> Option<EventFrame> {
     }
 
     let json: Value = deserialize_from_str_opt(data_str)?;
+    normalize_sse_value(json)
+}
+
+/// Normalizes an already parsed SSE payload.
+pub(crate) fn normalize_sse_value(json: Value) -> Option<EventFrame> {
     let event_type = json
         .get("type")
         .and_then(Value::as_str)

--- a/crates/agentic-server-core/src/executor/accumulator.rs
+++ b/crates/agentic-server-core/src/executor/accumulator.rs
@@ -266,9 +266,13 @@ impl ResponseAccumulator {
 
     pub(crate) fn process_sse_line(&mut self, line: &str) -> Option<EventFrame> {
         let frame = normalize_sse_line(line)?;
-        self.capture_terminal_details_if_needed(&frame);
-        self.process_event(&frame);
+        self.process_normalized_event(&frame);
         Some(frame)
+    }
+
+    pub(crate) fn process_normalized_event(&mut self, frame: &EventFrame) {
+        self.capture_terminal_details_if_needed(frame);
+        self.process_event(frame);
     }
 
     pub(super) fn process_sse_line_with_translator(
@@ -543,6 +547,10 @@ impl ResponseAccumulator {
         };
         if let Some(entry) = in_flight_key.as_deref().and_then(|key| self.in_flight.get_mut(key)) {
             match (&mut entry.item, done_item) {
+                (InFlight::Message { item, text }, Some(OutputItem::Message(done_message))) => {
+                    *item = done_message;
+                    text.clear();
+                }
                 (InFlight::Reasoning { item }, _) => item.apply_done(payload, &mut String::new()),
                 (InFlight::FunctionCall { item, arguments }, _) => item.apply_done(payload, arguments),
                 (InFlight::CustomToolCall { item, input }, _) => item.apply_done(payload, input),
@@ -657,7 +665,8 @@ impl ResponseAccumulator {
 fn in_flight_matches_call_type(item: &InFlight, item_type: SSEItemType) -> bool {
     matches!(
         (item, item_type),
-        (InFlight::FunctionCall { .. }, SSEItemType::FunctionCall)
+        (InFlight::Message { .. }, SSEItemType::Message)
+            | (InFlight::FunctionCall { .. }, SSEItemType::FunctionCall)
             | (InFlight::CustomToolCall { .. }, SSEItemType::CustomToolCall)
             | (InFlight::WebSearchCall { .. }, SSEItemType::WebSearchCall)
             | (InFlight::McpCall { .. }, SSEItemType::McpCall)

--- a/crates/agentic-server-core/src/executor/error.rs
+++ b/crates/agentic-server-core/src/executor/error.rs
@@ -81,6 +81,10 @@ pub enum ExecutorError {
     #[error("invalid request: {0}")]
     InvalidRequest(String),
 
+    /// The request exceeds a documented transport or component size budget.
+    #[error("{0}")]
+    PayloadTooLarge(String),
+
     /// The request conflicts with state already stored.
     #[error("conflict: {0}")]
     Conflict(String),
@@ -119,6 +123,7 @@ impl ExecutorError {
             | Self::InvalidRequest(_)
             | Self::JsonError(_) => StatusCode::BAD_REQUEST,
             Self::Conflict(_) => StatusCode::CONFLICT,
+            Self::PayloadTooLarge(_) => StatusCode::PAYLOAD_TOO_LARGE,
             Self::Tool(ToolError::Execution(_)) | Self::CompactionFailed { .. } => StatusCode::BAD_GATEWAY,
             Self::ParseError(_) => StatusCode::UNPROCESSABLE_ENTITY,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
@@ -133,8 +138,10 @@ impl ExecutorError {
             | Self::Tool(ToolError::Config(_) | ToolError::MissingOutput { .. })
             | Self::InvalidRequest(_)
             | Self::ParseError(_)
-            | Self::JsonError(_) => "invalid_request_error",
+            | Self::JsonError(_)
+            | Self::PayloadTooLarge(_) => "invalid_request_error",
             Self::Storage(e) if e.is_not_found() => "not_found",
+            Self::Conflict(_) => "conflict_error",
             Self::LLMRequest { .. } | Self::LLMTransport { .. } | Self::CompactionFailed { .. } => "upstream_error",
             Self::Tool(ToolError::Execution(_)) => "tool_error",
             _ => "server_error",
@@ -146,6 +153,8 @@ impl ExecutorError {
     pub fn error_code(&self) -> &'static str {
         match self.client_visible_error() {
             Self::ConversationLocked { .. } => "conversation_locked",
+            Self::Conflict(_) => "response_already_stored",
+            Self::PayloadTooLarge(_) => "body_too_large",
             other => other.error_type(),
         }
     }
@@ -285,6 +294,24 @@ mod tests {
         let value: serde_json::Value = serde_json::from_slice(&body).expect("valid error response JSON");
 
         assert!(!value["error"].as_object().expect("error object").contains_key("param"));
+    }
+
+    #[test]
+    fn response_id_conflict_has_a_machine_readable_conflict_envelope() {
+        let error = ExecutorError::Conflict("a turn is already stored under 'resp_1'".to_owned());
+
+        assert_eq!(error.http_status(), StatusCode::CONFLICT);
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(&error.into_response_body())
+                .expect("valid error response JSON"),
+            serde_json::json!({
+                "error": {
+                    "message": "conflict: a turn is already stored under 'resp_1'",
+                    "type": "conflict_error",
+                    "code": "response_already_stored"
+                }
+            })
+        );
     }
 
     #[test]

--- a/crates/agentic-server-core/src/executor/modes/response.rs
+++ b/crates/agentic-server-core/src/executor/modes/response.rs
@@ -1,6 +1,6 @@
 //! Response storage handler — owns all response store operations.
 
-use crate::storage::{InOutItem, ResponseData, ResponseMetadata, ResponseStore, StorageError};
+use crate::storage::{InOutItem, ResponseData, ResponseMetadata, ResponseStore};
 use crate::types::io::OutputItem;
 
 use crate::executor::error::{ExecutorError, ExecutorResult};
@@ -32,20 +32,6 @@ impl ResponseHandler {
             .as_deref()
             .ok_or_else(|| ExecutorError::InvalidRequest("previous_response_id is required for get".into()))?;
         self.store.get(prev_id).await.map_err(ExecutorError::Storage)
-    }
-
-    /// Whether a response is already stored under `response_id`. Split execution
-    /// reserves the id before inference, so a retried persist may carry one that
-    /// is already written.
-    ///
-    /// # Errors
-    /// Returns `ExecutorError` if the store is disabled or the query fails.
-    pub async fn stored(&self, response_id: &str) -> ExecutorResult<bool> {
-        match self.store.get(response_id).await {
-            Ok(_) => Ok(true),
-            Err(StorageError::NotFound { .. }) => Ok(false),
-            Err(error) => Err(ExecutorError::Storage(error)),
-        }
     }
 
     /// Validates that the response for `previous_response_id` exists.
@@ -95,7 +81,8 @@ impl ResponseHandler {
         new_items.extend(ctx.new_input_items.into_iter().map(InOutItem::Input));
         new_items.extend(output_items.into_iter().map(InOutItem::Output));
 
-        self.store
+        let result = self
+            .store
             .persist_with_conversation_id(
                 &ctx.response_id,
                 ctx.conversation_id.as_deref(),
@@ -103,8 +90,15 @@ impl ResponseHandler {
                 new_items,
                 &metadata,
             )
-            .await
-            .map_err(ExecutorError::Storage)
+            .await;
+        match result {
+            Err(error) if error.is_unique_violation() => Err(ExecutorError::Conflict(format!(
+                "a turn is already stored under '{}'",
+                ctx.response_id
+            ))),
+            Err(error) => Err(ExecutorError::Storage(error)),
+            Ok(()) => Ok(()),
+        }
     }
 }
 

--- a/crates/agentic-server-core/src/executor/persist.rs
+++ b/crates/agentic-server-core/src/executor/persist.rs
@@ -25,12 +25,14 @@ pub(crate) async fn persist_if_needed(
     resp_handler: ResponseHandler,
 ) -> ExecutorResult<()> {
     if should_persist(&ctx) {
-        persist_response(payload, ctx, conv_handler, resp_handler)
-            .await
-            .map_err(|source| {
+        match persist_response(payload, ctx, conv_handler, resp_handler).await {
+            Err(error @ ExecutorError::Conflict(_)) => Err(error),
+            Err(source) => {
                 error!(error = ?source, "failed to persist response");
-                ExecutorError::Persistence(Box::new(source))
-            })
+                Err(ExecutorError::Persistence(Box::new(source)))
+            }
+            Ok(()) => Ok(()),
+        }
     } else {
         Ok(())
     }
@@ -101,15 +103,6 @@ pub async fn commit(
         return Err(ExecutorError::InvalidRequest(format!(
             "upstream response status '{}' is not terminal",
             payload.status
-        )));
-    }
-
-    // A retry carries the same reserved id. Returning the caller's payload would
-    // report content storage does not hold, so refuse instead.
-    if exec_ctx.resp_handler.stored(&payload.id).await? {
-        return Err(ExecutorError::Conflict(format!(
-            "a turn is already stored under '{}'",
-            payload.id
         )));
     }
 

--- a/crates/agentic-server-core/src/executor/upstream.rs
+++ b/crates/agentic-server-core/src/executor/upstream.rs
@@ -95,6 +95,7 @@ enum ResponseLifecycle {
 #[derive(Default)]
 struct RelayedStreamValidator {
     active_items: HashMap<u32, ActiveItem>,
+    completed_items: HashMap<u32, ActiveItem>,
     seen_item_ids: HashSet<String>,
     seen_output_indexes: HashSet<u32>,
     lifecycle: ResponseLifecycle,
@@ -135,7 +136,7 @@ impl RelayedStreamValidator {
                 let item = event.get("item").ok_or_else(|| missing_field(&event_name, "item"))?;
                 let item_id = required_str(item, "id", "output item")?;
                 let item_type = required_str(item, "type", "output item")?;
-                ensure_supported_stream_item_type(item_type)?;
+                ensure_supported_output_item_type(item_type)?;
                 if self.seen_output_indexes.contains(&output_index) || self.seen_item_ids.contains(item_id) {
                     return Err(ExecutorError::InvalidRequest(format!(
                         "upstream stream repeats output item '{item_id}'"
@@ -157,7 +158,7 @@ impl RelayedStreamValidator {
                 let item = event.get("item").ok_or_else(|| missing_field(&event_name, "item"))?;
                 let item_id = required_str(item, "id", "output item")?;
                 let item_type = required_str(item, "type", "output item")?;
-                ensure_supported_stream_item_type(item_type)?;
+                ensure_supported_output_item_type(item_type)?;
                 OutputItem::deserialize(item).map_err(|error| {
                     ExecutorError::InvalidRequest(format!("upstream stream output item is invalid: {error}"))
                 })?;
@@ -226,6 +227,7 @@ impl RelayedStreamValidator {
                         "upstream stream ended with unfinished output items".to_owned(),
                     ));
                 }
+                self.validate_terminal_output(response)?;
                 self.lifecycle = ResponseLifecycle::Terminal;
             }
             _ => {
@@ -265,12 +267,48 @@ impl RelayedStreamValidator {
         event_name: &str,
     ) -> ExecutorResult<()> {
         self.require_active_item(output_index, item_id, item_type, event_name)?;
-        self.active_items.remove(&output_index);
+        let item = self.active_items.remove(&output_index).ok_or_else(|| {
+            ExecutorError::InvalidRequest(format!(
+                "upstream stream event '{event_name}' has no active output item"
+            ))
+        })?;
+        self.completed_items.insert(output_index, item);
+        Ok(())
+    }
+
+    fn validate_terminal_output(&self, response: &Value) -> ExecutorResult<()> {
+        let output = response
+            .get("output")
+            .and_then(Value::as_array)
+            .ok_or_else(|| missing_field("terminal upstream response", "output"))?;
+        if output.len() != self.completed_items.len() {
+            return Err(ExecutorError::InvalidRequest(
+                "terminal upstream response output does not match completed item events".to_owned(),
+            ));
+        }
+        for (index, item) in output.iter().enumerate() {
+            let output_index = u32::try_from(index).map_err(|_| {
+                ExecutorError::InvalidRequest("terminal upstream response has too many output items".to_owned())
+            })?;
+            let item_id = required_str(item, "id", "terminal output item")?;
+            let item_type = required_str(item, "type", "terminal output item")?;
+            ensure_supported_output_item_type(item_type)?;
+            let Some(completed) = self.completed_items.get(&output_index) else {
+                return Err(ExecutorError::InvalidRequest(
+                    "terminal upstream response output does not match completed item events".to_owned(),
+                ));
+            };
+            if item_id != completed.id || item_type != completed.item_type {
+                return Err(ExecutorError::InvalidRequest(
+                    "terminal upstream response output does not match completed item events".to_owned(),
+                ));
+            }
+        }
         Ok(())
     }
 }
 
-fn ensure_supported_stream_item_type(item_type: &str) -> ExecutorResult<()> {
+fn ensure_supported_output_item_type(item_type: &str) -> ExecutorResult<()> {
     if matches!(
         item_type,
         "message"
@@ -285,7 +323,7 @@ fn ensure_supported_stream_item_type(item_type: &str) -> ExecutorResult<()> {
         return Ok(());
     }
     Err(ExecutorError::InvalidRequest(format!(
-        "upstream stream output item type '{item_type}' is unsupported"
+        "upstream output item type '{item_type}' is unsupported"
     )))
 }
 
@@ -362,7 +400,10 @@ fn validate_event_fields(event: &Value, event_type: SSEEventType, event_name: &s
         SSEEventType::ContentPartAdded
         | SSEEventType::ContentPartDone
         | SSEEventType::ReasoningPartAdded
-        | SSEEventType::ReasoningPartDone => Some("part"),
+        | SSEEventType::ReasoningPartDone => {
+            let _ = required_object(event, "part", event_name)?;
+            None
+        }
         SSEEventType::ResponseCreated
         | SSEEventType::ResponseInProgress
         | SSEEventType::ResponseCompleted
@@ -404,6 +445,17 @@ fn required_string<'a>(value: &'a Value, field: &str, owner: &str) -> ExecutorRe
         .ok_or_else(|| missing_field(owner, field))
 }
 
+fn required_object<'a>(
+    value: &'a Value,
+    field: &str,
+    owner: &str,
+) -> ExecutorResult<&'a serde_json::Map<String, Value>> {
+    value
+        .get(field)
+        .and_then(Value::as_object)
+        .ok_or_else(|| missing_field(owner, field))
+}
+
 fn required_u32(value: &Value, field: &str, owner: &str) -> ExecutorResult<u32> {
     value
         .get(field)
@@ -439,10 +491,20 @@ pub fn ensure_strict_response(body: &str) -> ExecutorResult<()> {
             "upstream response has no 'output' array".to_owned(),
         ));
     };
+    let mut item_ids = HashSet::with_capacity(items.len());
     for (index, item) in items.iter().enumerate() {
-        if let Err(error) = OutputItem::deserialize(item) {
-            return Err(ExecutorError::InvalidRequest(format!(
+        let owner = format!("upstream response output[{index}]");
+        let item_id = required_str(item, "id", &owner)?;
+        let item_type = required_str(item, "type", &owner)?;
+        ensure_supported_output_item_type(item_type)?;
+        OutputItem::deserialize(item).map_err(|error| {
+            ExecutorError::InvalidRequest(format!(
                 "upstream response output[{index}] is not a valid item: {error}"
+            ))
+        })?;
+        if !item_ids.insert(item_id) {
+            return Err(ExecutorError::InvalidRequest(format!(
+                "upstream response repeats output item '{item_id}'"
             )));
         }
     }

--- a/crates/agentic-server-core/src/executor/upstream.rs
+++ b/crates/agentic-server-core/src/executor/upstream.rs
@@ -1,10 +1,11 @@
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use futures::StreamExt;
 use serde::Deserialize;
 use serde_json::Value;
 
-use crate::events::{EventFrame, SSEEventType, WireEvent};
+use crate::events::{EventFrame, SSEEventType, WireEvent, normalize_sse_value};
 use crate::executor::accumulator::ResponseAccumulator;
 use crate::executor::error::{ExecutorError, ExecutorResult};
 use crate::executor::function_sse::FunctionSseTranslator;
@@ -82,6 +83,339 @@ fn is_data_frame(line: &str) -> bool {
         .is_some_and(|payload| !payload.is_empty() && payload != "[DONE]")
 }
 
+#[derive(Default)]
+enum ResponseLifecycle {
+    #[default]
+    AwaitingCreated,
+    Created(String),
+    InProgress(String),
+    Terminal,
+}
+
+#[derive(Default)]
+struct RelayedStreamValidator {
+    active_items: HashMap<u32, ActiveItem>,
+    seen_item_ids: HashSet<String>,
+    seen_output_indexes: HashSet<u32>,
+    lifecycle: ResponseLifecycle,
+}
+
+struct ActiveItem {
+    id: String,
+    item_type: String,
+}
+
+impl RelayedStreamValidator {
+    fn validate_line(&mut self, line: &str) -> ExecutorResult<Option<EventFrame>> {
+        let Some(payload) = line.strip_prefix("data:").map(str::trim) else {
+            return Ok(None);
+        };
+        if payload.is_empty() || payload == "[DONE]" {
+            return Ok(None);
+        }
+
+        let event: Value = deserialize_from_str(payload).map_err(ExecutorError::JsonError)?;
+        let event_name = required_str(&event, "type", "streaming event")?.to_owned();
+        if matches!(self.lifecycle, ResponseLifecycle::Terminal) {
+            return Err(ExecutorError::InvalidRequest(
+                "upstream stream contains an event after its terminal event".to_owned(),
+            ));
+        }
+
+        let event_type = SSEEventType::from(event_name.as_str());
+        match event_type {
+            SSEEventType::ResponseCreated
+            | SSEEventType::ResponseInProgress
+            | SSEEventType::ResponseCompleted
+            | SSEEventType::ResponseFailed
+            | SSEEventType::ResponseIncomplete => self.validate_response_event(&event, event_type, &event_name)?,
+            SSEEventType::OutputItemAdded => {
+                self.require_in_progress(&event_name)?;
+                let output_index = required_u32(&event, "output_index", &event_name)?;
+                let item = event.get("item").ok_or_else(|| missing_field(&event_name, "item"))?;
+                let item_id = required_str(item, "id", "output item")?;
+                let item_type = required_str(item, "type", "output item")?;
+                ensure_supported_stream_item_type(item_type)?;
+                if self.seen_output_indexes.contains(&output_index) || self.seen_item_ids.contains(item_id) {
+                    return Err(ExecutorError::InvalidRequest(format!(
+                        "upstream stream repeats output item '{item_id}'"
+                    )));
+                }
+                self.seen_output_indexes.insert(output_index);
+                self.seen_item_ids.insert(item_id.to_owned());
+                self.active_items.insert(
+                    output_index,
+                    ActiveItem {
+                        id: item_id.to_owned(),
+                        item_type: item_type.to_owned(),
+                    },
+                );
+            }
+            SSEEventType::OutputItemDone => {
+                self.require_in_progress(&event_name)?;
+                let output_index = required_u32(&event, "output_index", &event_name)?;
+                let item = event.get("item").ok_or_else(|| missing_field(&event_name, "item"))?;
+                let item_id = required_str(item, "id", "output item")?;
+                let item_type = required_str(item, "type", "output item")?;
+                ensure_supported_stream_item_type(item_type)?;
+                OutputItem::deserialize(item).map_err(|error| {
+                    ExecutorError::InvalidRequest(format!("upstream stream output item is invalid: {error}"))
+                })?;
+                self.finish_item(output_index, item_id, item_type, &event_name)?;
+            }
+            SSEEventType::Other => self.require_in_progress(&event_name)?,
+            event_type => {
+                self.require_in_progress(&event_name)?;
+                let output_index = required_u32(&event, "output_index", &event_name)?;
+                let item_id = required_str(&event, "item_id", &event_name)?;
+                self.require_active_item(output_index, item_id, expected_item_type(event_type), &event_name)?;
+                validate_event_fields(&event, event_type, &event_name)?;
+            }
+        }
+        normalize_sse_value(event).map(Some).ok_or_else(|| {
+            ExecutorError::InvalidRequest(format!("upstream stream event '{event_name}' could not be normalized"))
+        })
+    }
+
+    fn require_in_progress(&self, event_name: &str) -> ExecutorResult<()> {
+        if matches!(self.lifecycle, ResponseLifecycle::InProgress(_)) {
+            return Ok(());
+        }
+        Err(ExecutorError::InvalidRequest(format!(
+            "upstream stream event '{event_name}' is out of lifecycle order"
+        )))
+    }
+
+    fn validate_response_event(
+        &mut self,
+        event: &Value,
+        event_type: SSEEventType,
+        event_name: &str,
+    ) -> ExecutorResult<()> {
+        let response = event
+            .get("response")
+            .ok_or_else(|| missing_field(event_name, "response"))?;
+        let response_id = required_str(response, "id", "upstream response")?;
+        let status = required_str(response, "status", "upstream response")?;
+        let expected_status = match event_type {
+            SSEEventType::ResponseCreated | SSEEventType::ResponseInProgress => "in_progress",
+            SSEEventType::ResponseCompleted => "completed",
+            SSEEventType::ResponseFailed => "failed",
+            SSEEventType::ResponseIncomplete => "incomplete",
+            _ => return Ok(()),
+        };
+        if status != expected_status {
+            return Err(ExecutorError::InvalidRequest(format!(
+                "upstream stream event '{event_name}' has status '{status}', expected '{expected_status}'"
+            )));
+        }
+
+        match (&self.lifecycle, event_type) {
+            (ResponseLifecycle::AwaitingCreated, SSEEventType::ResponseCreated) => {
+                self.lifecycle = ResponseLifecycle::Created(response_id.to_owned());
+            }
+            (ResponseLifecycle::Created(created_id), SSEEventType::ResponseInProgress) if created_id == response_id => {
+                self.lifecycle = ResponseLifecycle::InProgress(response_id.to_owned());
+            }
+            (
+                ResponseLifecycle::InProgress(in_progress_id),
+                SSEEventType::ResponseCompleted | SSEEventType::ResponseFailed | SSEEventType::ResponseIncomplete,
+            ) if in_progress_id == response_id => {
+                if !self.active_items.is_empty() {
+                    return Err(ExecutorError::InvalidRequest(
+                        "upstream stream ended with unfinished output items".to_owned(),
+                    ));
+                }
+                self.lifecycle = ResponseLifecycle::Terminal;
+            }
+            _ => {
+                return Err(ExecutorError::InvalidRequest(format!(
+                    "upstream stream event '{event_name}' is out of lifecycle order or changes the response id"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn require_active_item(
+        &self,
+        output_index: u32,
+        item_id: &str,
+        expected_type: &str,
+        event_name: &str,
+    ) -> ExecutorResult<()> {
+        let Some(active) = self.active_items.get(&output_index) else {
+            return Err(ExecutorError::InvalidRequest(format!(
+                "upstream stream event '{event_name}' has no active output item"
+            )));
+        };
+        if item_id != active.id || expected_type != active.item_type {
+            return Err(ExecutorError::InvalidRequest(format!(
+                "upstream stream event '{event_name}' does not match its active output item"
+            )));
+        }
+        Ok(())
+    }
+
+    fn finish_item(
+        &mut self,
+        output_index: u32,
+        item_id: &str,
+        item_type: &str,
+        event_name: &str,
+    ) -> ExecutorResult<()> {
+        self.require_active_item(output_index, item_id, item_type, event_name)?;
+        self.active_items.remove(&output_index);
+        Ok(())
+    }
+}
+
+fn ensure_supported_stream_item_type(item_type: &str) -> ExecutorResult<()> {
+    if matches!(
+        item_type,
+        "message"
+            | "function_call"
+            | "custom_tool_call"
+            | "web_search_call"
+            | "mcp_call"
+            | "mcp_list_tools"
+            | "reasoning"
+            | "compaction"
+    ) {
+        return Ok(());
+    }
+    Err(ExecutorError::InvalidRequest(format!(
+        "upstream stream output item type '{item_type}' is unsupported"
+    )))
+}
+
+fn expected_item_type(event_type: SSEEventType) -> &'static str {
+    match event_type {
+        SSEEventType::OutputTextDelta
+        | SSEEventType::OutputTextDone
+        | SSEEventType::ContentPartAdded
+        | SSEEventType::ContentPartDone => "message",
+        SSEEventType::FunctionCallArgumentsDelta | SSEEventType::FunctionCallArgumentsDone => "function_call",
+        SSEEventType::CustomToolCallInputDelta | SSEEventType::CustomToolCallInputDone => "custom_tool_call",
+        SSEEventType::ReasoningTextDelta
+        | SSEEventType::ReasoningTextDone
+        | SSEEventType::ReasoningPartAdded
+        | SSEEventType::ReasoningPartDone
+        | SSEEventType::ReasoningSummaryTextDelta
+        | SSEEventType::ReasoningSummaryTextDone => "reasoning",
+        SSEEventType::FileSearchCallSearching | SSEEventType::FileSearchCallCompleted => "file_search_call",
+        SSEEventType::WebSearchCallInProgress
+        | SSEEventType::WebSearchCallSearching
+        | SSEEventType::WebSearchCallCompleted => "web_search_call",
+        SSEEventType::McpCallInProgress
+        | SSEEventType::McpCallArgumentsDelta
+        | SSEEventType::McpCallArgumentsDone
+        | SSEEventType::McpCallCompleted
+        | SSEEventType::McpCallFailed => "mcp_call",
+        SSEEventType::McpListToolsInProgress
+        | SSEEventType::McpListToolsCompleted
+        | SSEEventType::McpListToolsFailed => "mcp_list_tools",
+        SSEEventType::ResponseCreated
+        | SSEEventType::ResponseInProgress
+        | SSEEventType::ResponseCompleted
+        | SSEEventType::ResponseFailed
+        | SSEEventType::ResponseIncomplete
+        | SSEEventType::OutputItemAdded
+        | SSEEventType::OutputItemDone
+        | SSEEventType::Other => unreachable!("only item events are classified"),
+    }
+}
+
+fn validate_event_fields(event: &Value, event_type: SSEEventType, event_name: &str) -> ExecutorResult<()> {
+    match event_type {
+        SSEEventType::OutputTextDelta
+        | SSEEventType::OutputTextDone
+        | SSEEventType::ContentPartAdded
+        | SSEEventType::ContentPartDone
+        | SSEEventType::ReasoningTextDelta
+        | SSEEventType::ReasoningTextDone
+        | SSEEventType::ReasoningPartAdded
+        | SSEEventType::ReasoningPartDone => {
+            let _ = required_u32(event, "content_index", event_name)?;
+        }
+        SSEEventType::ReasoningSummaryTextDelta | SSEEventType::ReasoningSummaryTextDone => {
+            let _ = required_u32(event, "summary_index", event_name)?;
+        }
+        _ => {}
+    }
+    let required = match event_type {
+        SSEEventType::OutputTextDelta
+        | SSEEventType::FunctionCallArgumentsDelta
+        | SSEEventType::CustomToolCallInputDelta
+        | SSEEventType::ReasoningTextDelta
+        | SSEEventType::ReasoningSummaryTextDelta
+        | SSEEventType::McpCallArgumentsDelta => Some("delta"),
+        SSEEventType::OutputTextDone | SSEEventType::ReasoningTextDone | SSEEventType::ReasoningSummaryTextDone => {
+            Some("text")
+        }
+        SSEEventType::FunctionCallArgumentsDone => {
+            let _ = required_str(event, "name", event_name)?;
+            Some("arguments")
+        }
+        SSEEventType::McpCallArgumentsDone => Some("arguments"),
+        SSEEventType::CustomToolCallInputDone => Some("input"),
+        SSEEventType::ContentPartAdded
+        | SSEEventType::ContentPartDone
+        | SSEEventType::ReasoningPartAdded
+        | SSEEventType::ReasoningPartDone => Some("part"),
+        SSEEventType::ResponseCreated
+        | SSEEventType::ResponseInProgress
+        | SSEEventType::ResponseCompleted
+        | SSEEventType::ResponseFailed
+        | SSEEventType::ResponseIncomplete
+        | SSEEventType::OutputItemAdded
+        | SSEEventType::OutputItemDone
+        | SSEEventType::FileSearchCallSearching
+        | SSEEventType::FileSearchCallCompleted
+        | SSEEventType::WebSearchCallInProgress
+        | SSEEventType::WebSearchCallSearching
+        | SSEEventType::WebSearchCallCompleted
+        | SSEEventType::McpCallInProgress
+        | SSEEventType::McpCallCompleted
+        | SSEEventType::McpCallFailed
+        | SSEEventType::McpListToolsInProgress
+        | SSEEventType::McpListToolsCompleted
+        | SSEEventType::McpListToolsFailed
+        | SSEEventType::Other => None,
+    };
+    if let Some(field) = required {
+        let _ = required_string(event, field, event_name)?;
+    }
+    Ok(())
+}
+
+fn required_str<'a>(value: &'a Value, field: &str, owner: &str) -> ExecutorResult<&'a str> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| missing_field(owner, field))
+}
+
+fn required_string<'a>(value: &'a Value, field: &str, owner: &str) -> ExecutorResult<&'a str> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .ok_or_else(|| missing_field(owner, field))
+}
+
+fn required_u32(value: &Value, field: &str, owner: &str) -> ExecutorResult<u32> {
+    value
+        .get(field)
+        .and_then(Value::as_u64)
+        .and_then(|value| u32::try_from(value).ok())
+        .ok_or_else(|| missing_field(owner, field))
+}
+
+fn missing_field(owner: &str, field: &str) -> ExecutorError {
+    ExecutorError::InvalidRequest(format!("{owner} has no valid '{field}'"))
+}
+
 /// Rejects a body [`ResponseAccumulator::from_json`] would accept too generously:
 /// it defaults a missing `status` to `completed` and drops unreadable items, which
 /// is safe for our own fetch but not for a body an outside caller supplied.
@@ -90,10 +424,15 @@ fn is_data_frame(line: &str) -> bool {
 /// [`ExecutorError::InvalidRequest`] naming the field that is missing or invalid.
 pub fn ensure_strict_response(body: &str) -> ExecutorResult<()> {
     let json: Value = deserialize_from_str(body).map_err(ExecutorError::JsonError)?;
-    if !json["status"].is_string() {
+    let Some(status) = json["status"].as_str() else {
         return Err(ExecutorError::InvalidRequest(
             "upstream response has no 'status'".to_owned(),
         ));
+    };
+    if !matches!(status, "completed" | "failed" | "incomplete") {
+        return Err(ExecutorError::InvalidRequest(format!(
+            "upstream response status '{status}' is not terminal"
+        )));
     }
     let Some(items) = json["output"].as_array() else {
         return Err(ExecutorError::InvalidRequest(
@@ -129,11 +468,11 @@ pub(super) fn payload_from_upstream(
         UpstreamBody::Json(body) => ResponseAccumulator::from_json(body, ctx.conversation_id.as_deref())?,
         UpstreamBody::Sse(sse) => {
             let mut acc = ResponseAccumulator::new(ctx.response_id.clone(), ctx.conversation_id.clone());
+            let mut validator = RelayedStreamValidator::default();
             for line in sse.lines() {
-                if !absorb_line(&mut acc, ctx, line) {
-                    return Err(ExecutorError::InvalidRequest(
-                        "upstream stream contains a malformed data frame".to_owned(),
-                    ));
+                if let Some(frame) = validator.validate_line(line)? {
+                    acc.process_normalized_event(&frame);
+                    log_upstream_failure(&frame, &ctx.response_id);
                 }
             }
             if !acc.saw_terminal_frame() {

--- a/crates/agentic-server-core/src/storage/types/errors.rs
+++ b/crates/agentic-server-core/src/storage/types/errors.rs
@@ -69,6 +69,15 @@ impl StorageError {
         matches!(self, Self::ConversationConflict { .. })
     }
 
+    /// Returns `true` when the database rejected a duplicate unique key.
+    #[must_use]
+    pub fn is_unique_violation(&self) -> bool {
+        matches!(
+            self,
+            Self::Database(sqlx::Error::Database(error)) if error.is_unique_violation()
+        )
+    }
+
     /// Extracts the resource type and ID if this is a "not found" error.
     #[must_use]
     pub fn not_found_details(&self) -> Option<(String, String)> {

--- a/docs/design/agentic-llm-d.md
+++ b/docs/design/agentic-llm-d.md
@@ -30,8 +30,8 @@ caller-authored context. Callers treat it as opaque.
 
 Neither step reimplements the storage flow. `hydrate` calls `rehydrate_conversation` and `upstream_request`; `persist` calls
 `decode_upstream` and `commit`. All four are core operations the in-process executor already uses or shares, so a change
-to how a turn is rehydrated or stored reaches both paths at once. This crate contains no parsing, no storage access and
-no request building of its own.
+to how a turn is rehydrated or stored reaches both paths at once. The llm-d crate contains no storage access or
+request-building logic of its own.
 
 What it does contain is the boundary itself: the check for what cannot be split, strict validation for the relayed
 JSON or streaming events, the conversion between the live and wire context forms, and the sealing.

--- a/docs/design/agentic-llm-d.md
+++ b/docs/design/agentic-llm-d.md
@@ -16,8 +16,8 @@ serve it. Cache-aware scoring can still prefer the engine that handled the previ
 upstream request body with the history inlined and every continuation and storage field removed, and a sealed context
 describing the turn. The caller forwards the body to a model unchanged and echoes the context back.
 
-`persist` takes that context together with the response the model produced — either a complete JSON body, or the SSE
-frames a streaming caller has already relayed to its own client — assembles the turn, stores it, and returns the
+`persist` takes that context together with the response the model produced, either a complete JSON body or the SSE
+frames a streaming caller has already relayed to its own client, assembles the turn, stores it, and returns the
 response envelope carrying the reserved `resp_` identifier. Nothing is re-emitted for a streamed turn, since the caller
 has already sent the frames on.
 
@@ -28,18 +28,18 @@ caller-authored context. Callers treat it as opaque.
 
 ## Composition
 
-Neither step reimplements the flow. `hydrate` calls `rehydrate_conversation` and `upstream_request`; `persist` calls
+Neither step reimplements the storage flow. `hydrate` calls `rehydrate_conversation` and `upstream_request`; `persist` calls
 `decode_upstream` and `commit`. All four are core operations the in-process executor already uses or shares, so a change
 to how a turn is rehydrated or stored reaches both paths at once. This crate contains no parsing, no storage access and
 no request building of its own.
 
-What it does contain is the boundary itself: the check for what cannot be split, the conversion between the live and
-wire context forms, and the sealing.
+What it does contain is the boundary itself: the check for what cannot be split, strict validation for the relayed
+JSON or streaming events, the conversion between the live and wire context forms, and the sealing.
 
 Core keeps what is not specific to one consumer. `decode_upstream` is the OpenAI JSON/SSE adapter; it validates a
 caller-supplied body more strictly than the in-process parser, which defaults a missing status and drops items it
 cannot read. `commit` takes a normalized `ResponsePayload` and owns the rest of the shared behaviour:
-reserved-identifier and terminal-status validation, the conflict check on an identifier already stored, and conditional
+reserved-identifier and terminal-status validation, atomic duplicate detection during insertion, and conditional
 persistence. A response still in progress is something an external caller can return but the in-process flow never
 produces; storing it would hand back an identifier that could never be continued, so `commit` rejects it.
 
@@ -49,7 +49,7 @@ limits, so sharing one predicate stops them drifting apart as features are added
 
 ## Boundary
 
-`ensure_splittable` names the feature that prevents a request being split: `conversation_id`, gateway-owned tools,
+`ensure_splittable` names the feature that prevents a request being split: `conversation_id`, gateway-executed built-in tools,
 compaction input, or `context_management`. Each needs state that the in-process executor keeps between steps.
 
 ## The crate
@@ -60,12 +60,29 @@ passthrough proxy, `/v1`, the WebSocket transport, upstream readiness probing an
 absent, so these endpoints cannot be exposed on a listener that also serves `/v1`. Readiness reports whether storage
 answers, since the coordinator owns the model fleet.
 
-## Discussion points
+## Calling and deployment contract
 
-The endpoints authenticate the calling workload with a shared token. That identifies a workload and not a tenant, so
-per-response authorization still needs an owner the schema does not record
-([#107](https://github.com/vllm-project/agentic-api/issues/107)); network policy remains defence in depth. A retried
-`persist` returns `409` rather than the turn it already stored, and the check that detects the reuse is a read before
-the write, so concurrent retries can still race. The sealed context carries the original request and base64 expands it,
-so hydrate's body limit admits turns whose persist body exceeds the same limit. Request fields that `RequestPayload`
-does not model are dropped rather than forwarded, which narrows what reaches vLLM compared with plain passthrough.
+Every hydrate or persist request must send the shared workload credential in
+`x-agentic-workload-token`. Configure the token with `AGENTIC_LLM_D_API_TOKEN` and configure the independent context
+signing key with `AGENTIC_LLM_D_SIGNING_KEY`. Each secret must contain at least 32 non-whitespace bytes. The binary
+rejects missing, short, or reused values before opening storage or binding its listener.
+
+The request budgets are deliberately asymmetric. A hydrate body is limited to 2 MiB. A returned sealed context is
+limited to 6 MiB. Persist accepts a body up to 16 MiB, with at most 6 MiB of context and 4 MiB of decoded upstream
+JSON or SSE. These component budgets leave room for the persist JSON envelope and ensure a context returned by
+hydrate can be echoed back. A larger response is rejected with `413` and code `body_too_large`.
+
+The workload token authenticates only the coordinator, not the end user or tenant. Deploy this listener only on an
+encrypted, policy-restricted service network where every token holder is trusted with all stored response history.
+Network policy is defense in depth, not tenant authorization. Per-response ownership remains tracked in
+[#107](https://github.com/vllm-project/agentic-api/issues/107), and the endpoint must not be exposed across tenant
+trust boundaries until that work lands.
+
+A repeated persist for an already stored response ID returns `409` with code `response_already_stored`. Duplicate
+detection happens atomically at insertion, so concurrent delivery has the same result. The service does not yet prove
+that an identical retry matches the stored payload, so it does not return a prior success response.
+
+## Remaining compatibility point
+
+Request fields that `RequestPayload` does not model are dropped rather than forwarded, which narrows what reaches
+vLLM compared with plain pass-through.

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -107,6 +107,7 @@ nav:
     - ADR-03: adr/ADR-03_gateway_integration.md
     - Claude Code Integration: design/claude-code-integration.md
     - Codex Integration: design/codex-integration.md
+    - llm-d Backend Mode: design/agentic-llm-d.md
     - Core Public API: design/core-public-api.md
     - MCP Gateway Integration: design/mcp-gateway-integration.md
     - Messages Gateway Tool Classification: design/messages-gateway-tool-classification.md


### PR DESCRIPTION
## Summary

- harden the split execution endpoints added in #216 with validated secret types, separate hydrate, context, response, and persist size budgets, stable 401, 409, and 413 error envelopes, and propagated shutdown errors
- make duplicate persistence atomic by mapping the database uniqueness violation to a stable `409 response_already_stored` response
- strictly validate caller-relayed JSON and SSE response lifecycles, required fields, item identity and type, terminal status, and permanent output ID/index uniqueness before persistence
- treat `response.output_item.done` as authoritative so missing deltas cannot silently truncate stored message content, and reject stream item types that cannot be represented safely
- document the workload-token contract, deployment trust boundary, limits, and retry behavior

The workload token authenticates a trusted coordinator, not a tenant. Per-response tenant ownership remains tracked in #107, so these endpoints should stay on an encrypted, policy-restricted service network.

## Test Plan

- `cargo fmt --all -- --check`
- `CARGO_INCREMENTAL=0 RUSTFLAGS='-C debuginfo=0' cargo clippy -j 2 --workspace --all-targets -- -D warnings`
- `CARGO_INCREMENTAL=0 RUSTFLAGS='-C debuginfo=0' cargo test --workspace -j 2`
- `uv run --with-requirements docs/requirements.txt mkdocs build --strict`

The standard PostgreSQL tests that require `TEST_POSTGRES_URL` remained ignored.
