### PR TITLE
fix: reject unusable relayed call IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to Agentic API are documented here.
 
 ### Fixed
 
+- Rejected split-execution responses with missing or duplicate tool call IDs before persistence, keeping the reserved
+  response ID available for a corrected retry.
 - Hardened split execution with atomic duplicate persistence, strict relayed-response validation, independent secret
   validation, bounded hydrate and persist payloads, stable error envelopes, and graceful shutdown error propagation.
 - Forwarded Responses `text` generation settings through typed execution paths while preserving provider-specific

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ All notable changes to Agentic API are documented here.
 
 ### Fixed
 
-- Rejected split-execution responses with missing or duplicate tool call IDs before persistence, keeping the reserved
-  response ID available for a corrected retry.
+- Rejected split-execution responses with missing, reused, or unstable tool call IDs before persistence, keeping the
+  reserved response ID available for a corrected retry.
 - Hardened split execution with atomic duplicate persistence, strict relayed-response validation, independent secret
   validation, bounded hydrate and persist payloads, stable error envelopes, and graceful shutdown error propagation.
 - Forwarded Responses `text` generation settings through typed execution paths while preserving provider-specific

--- a/crates/agentic-llm-d/tests/split_execution_integration.rs
+++ b/crates/agentic-llm-d/tests/split_execution_integration.rs
@@ -117,6 +117,19 @@ fn status_of(error: &ExecutorError) -> u16 {
     error.http_status().as_u16()
 }
 
+fn assert_call_id_error(error: &ExecutorError, case: &str, untrusted_marker: Option<&str>) {
+    assert_eq!(status_of(error), 400, "{case}: {error}");
+    let message = error.to_string();
+    assert!(message.contains("call_id"), "{case}: {error}");
+    if let Some(marker) = untrusted_marker {
+        assert!(!message.contains(marker), "untrusted call_id leaked: {message}");
+        assert!(
+            message.contains("output[0]") && message.contains("output[1]"),
+            "{case}: {message}"
+        );
+    }
+}
+
 #[tokio::test]
 async fn a_streamed_turn_persists_from_the_relayed_frames() {
     let ctx = exec_ctx().await;
@@ -179,6 +192,121 @@ async fn a_function_call_stream_passes_strict_validation() {
         stored.output.as_slice(),
         [agentic_core::types::io::OutputItem::FunctionCall(_)]
     ));
+}
+
+#[tokio::test]
+async fn relayed_json_tool_call_ids_are_validated_before_persistence() {
+    assert_relayed_tool_call_ids_are_validated(false).await;
+}
+
+#[tokio::test]
+async fn relayed_sse_tool_call_ids_are_validated_before_persistence() {
+    assert_relayed_tool_call_ids_are_validated(true).await;
+}
+
+async fn assert_relayed_tool_call_ids_are_validated(stream: bool) {
+    let ctx = exec_ctx().await;
+    let mut accepted = Vec::new();
+    let duplicate_id = "call_duplicate\r\nforged-log-entry";
+    let malformed_outputs = [
+        (
+            "function call without call_id",
+            "completed",
+            json!([{
+                "type": "function_call", "id": "fc_1", "name": "lookup",
+                "arguments": "{}", "status": "completed"
+            }]),
+            None,
+        ),
+        (
+            "custom tool call with empty call_id",
+            "incomplete",
+            json!([{
+                "type": "custom_tool_call", "id": "ctc_1", "call_id": "",
+                "name": "raw_echo", "input": "hello", "status": "completed"
+            }]),
+            None,
+        ),
+        (
+            "function and custom calls with the same call_id",
+            "completed",
+            json!([
+                {
+                    "type": "function_call", "id": "fc_1", "call_id": duplicate_id,
+                    "name": "lookup", "arguments": "{}", "status": "completed"
+                },
+                {
+                    "type": "custom_tool_call", "id": "ctc_2", "call_id": duplicate_id,
+                    "name": "raw_echo", "input": "hello", "status": "completed"
+                }
+            ]),
+            Some("forged-log-entry"),
+        ),
+    ];
+
+    for (case, status, output, untrusted_marker) in malformed_outputs {
+        let attempt = turn("Call a tool", None, &ctx).await;
+        let context = attempt.context.clone();
+        let response_id = unseal(&context, &signing_key()).expect("unseal").response_id;
+        let body = json!({
+            "id": "resp_upstream", "object": "response", "created_at": 1_700_000_000,
+            "model": "test-model", "status": status, "output": output
+        });
+        let relayed = if stream {
+            let mut frames = vec![
+                json!({"type": "response.created", "response": {"id": "resp_upstream", "status": "in_progress"}}),
+                json!({"type": "response.in_progress", "response": {"id": "resp_upstream", "status": "in_progress"}}),
+            ];
+            for (output_index, item) in output.as_array().expect("output items").iter().enumerate() {
+                frames.push(json!({
+                    "type": "response.output_item.added", "output_index": output_index, "item": item
+                }));
+                frames.push(json!({
+                    "type": "response.output_item.done", "output_index": output_index, "item": item
+                }));
+            }
+            frames.push(json!({
+                "type": format!("response.{status}"),
+                "response": {"id": "resp_upstream", "status": status, "output": output}
+            }));
+            frames
+                .iter()
+                .map(|frame| format!("data: {frame}\n\n"))
+                .collect::<Vec<_>>()
+                .concat()
+        } else {
+            body.to_string()
+        };
+        let upstream = if stream {
+            UpstreamBody::Sse(&relayed)
+        } else {
+            UpstreamBody::Json(&relayed)
+        };
+
+        let Err(error) = persist(attempt.context, upstream, &ctx).await else {
+            let poisoned = hydrate(request("continue", Some(&response_id)), &ctx)
+                .await
+                .expect_err("accepted invalid response remained continuable");
+            accepted.push(format!("{case}: {poisoned}"));
+            continue;
+        };
+        assert_call_id_error(&error, case, untrusted_marker);
+
+        // Validation must happen before insertion so the caller can retry
+        // the reserved response ID with a usable upstream response.
+        let valid = json!({
+            "id": "resp_retry", "status": "completed", "output": [{
+                "type": "custom_tool_call", "id": "ctc_retry", "call_id": "call_retry",
+                "name": "raw_echo", "input": "retry succeeded", "status": "completed"
+            }]
+        })
+        .to_string();
+        let stored = persist(context, UpstreamBody::Json(&valid), &ctx)
+            .await
+            .unwrap_or_else(|error| panic!("{case} consumed {response_id}: {error}"));
+        assert_eq!(stored.id, response_id);
+    }
+    assert!(accepted.is_empty(), "accepted invalid calls: {}", accepted.join("; "));
 }
 
 /// Every way a turn is refused, and the status the caller sees.
@@ -309,13 +437,20 @@ async fn a_turn_that_is_not_written_still_returns() {
 
     let mut failed: Value = serde_json::from_str(&upstream_json("")).expect("json");
     failed["status"] = json!("failed");
-    failed["output"] = json!([]);
+    failed["output"] = json!([{
+        "type": "function_call", "id": "fc_partial", "name": "lookup",
+        "arguments": "", "status": "in_progress"
+    }]);
     let attempt = turn("hi", None, &ctx).await;
     let id = unseal(&attempt.context, &signing_key()).expect("unseal").response_id;
     let payload = persist(attempt.context, UpstreamBody::Json(&failed.to_string()), &ctx)
         .await
         .expect("a failed turn is not a boundary error");
     assert_eq!(payload.status, "error", "`failed` normalizes to the error status");
+    assert!(matches!(
+        payload.output.as_slice(),
+        [agentic_core::types::io::OutputItem::FunctionCall(call)] if call.call_id.is_empty()
+    ));
     let orphan = hydrate(request("and then?", Some(&id)), &ctx).await;
     assert_eq!(status_of(&orphan.expect_err("never stored")), 404);
 }

--- a/crates/agentic-llm-d/tests/split_execution_integration.rs
+++ b/crates/agentic-llm-d/tests/split_execution_integration.rs
@@ -30,6 +30,10 @@ async fn exec_ctx() -> ExecutionContext {
 
 /// Built the way a request actually arrives — through deserialization.
 fn request(input: &str, previous: Option<&str>) -> RequestPayload {
+    request_value(&json!(input), previous)
+}
+
+fn request_value(input: &Value, previous: Option<&str>) -> RequestPayload {
     let mut body = json!({"model": "test-model", "input": input, "store": true});
     if let Some(previous) = previous {
         body["previous_response_id"] = json!(previous);
@@ -72,6 +76,57 @@ fn upstream_sse(text: &str) -> String {
     .map(|frame| format!("data: {frame}\n\n"))
     .collect::<Vec<_>>()
     .concat()
+}
+
+fn upstream_call_json(output: &Value, status: &str) -> String {
+    json!({
+        "id": "resp_upstream",
+        "object": "response",
+        "created_at": 1_700_000_000,
+        "model": "test-model",
+        "status": status,
+        "output": [output],
+    })
+    .to_string()
+}
+
+fn upstream_call_sse(added: &Value, done: &Value, terminal: &Value, status: &str) -> String {
+    [
+        json!({"type": "response.created", "response": {"id": "resp_upstream", "status": "in_progress"}}),
+        json!({"type": "response.in_progress", "response": {"id": "resp_upstream", "status": "in_progress"}}),
+        json!({"type": "response.output_item.added", "output_index": 0, "item": added}),
+        json!({"type": "response.output_item.done", "output_index": 0, "item": done}),
+        json!({
+            "type": format!("response.{status}"),
+            "response": {"id": "resp_upstream", "status": status, "output": [terminal]},
+        }),
+    ]
+    .iter()
+    .map(|frame| format!("data: {frame}\n\n"))
+    .collect::<Vec<_>>()
+    .concat()
+}
+
+fn function_call(id: &str, call_id: &str, status: &str) -> Value {
+    json!({
+        "type": "function_call",
+        "id": id,
+        "call_id": call_id,
+        "name": "lookup",
+        "arguments": "{}",
+        "status": status,
+    })
+}
+
+fn custom_tool_call(id: &str, call_id: &str, status: &str) -> Value {
+    json!({
+        "type": "custom_tool_call",
+        "id": id,
+        "call_id": call_id,
+        "name": "raw_echo",
+        "input": "hello",
+        "status": status,
+    })
 }
 
 fn signing_key() -> SigningKey {
@@ -128,6 +183,42 @@ fn assert_call_id_error(error: &ExecutorError, case: &str, untrusted_marker: Opt
             "{case}: {message}"
         );
     }
+}
+
+async fn assert_relayed_call_id_rejected(
+    ctx: &ExecutionContext,
+    attempt: Hydration,
+    relayed: &str,
+    stream: bool,
+    case: &str,
+    marker: &str,
+    expected_detail: &str,
+) {
+    let retry_context = attempt.context.clone();
+    let response_id = unseal(&retry_context, &signing_key()).expect("unseal").response_id;
+    let upstream = if stream {
+        UpstreamBody::Sse(relayed)
+    } else {
+        UpstreamBody::Json(relayed)
+    };
+    let error = persist(attempt.context, upstream, ctx).await.expect_err(case);
+    assert_eq!(status_of(&error), 400, "{case}: {error}");
+    let message = error.to_string();
+    assert!(
+        message.contains("call_id") && message.contains("output[0]") && message.contains(expected_detail),
+        "{case}: {message}"
+    );
+    assert!(!message.contains(marker), "{case}: leaked call_id: {message}");
+
+    let retry = function_call("fc_retry", "call_retry", "completed");
+    let corrected = persist(
+        retry_context,
+        UpstreamBody::Json(&upstream_call_json(&retry, "completed")),
+        ctx,
+    )
+    .await
+    .unwrap_or_else(|error| panic!("{case} consumed {response_id}: {error}"));
+    assert_eq!(corrected.id, response_id);
 }
 
 #[tokio::test]
@@ -309,6 +400,209 @@ async fn assert_relayed_tool_call_ids_are_validated(stream: bool) {
     assert!(accepted.is_empty(), "accepted invalid calls: {}", accepted.join("; "));
 }
 
+#[tokio::test]
+async fn relayed_json_call_id_cannot_reuse_continued_history() {
+    assert_relayed_call_id_cannot_reuse_continued_history(false).await;
+}
+
+#[tokio::test]
+async fn relayed_sse_call_id_cannot_reuse_continued_history() {
+    assert_relayed_call_id_cannot_reuse_continued_history(true).await;
+}
+
+async fn assert_relayed_call_id_cannot_reuse_continued_history(stream: bool) {
+    let ctx = exec_ctx().await;
+    let reused_call_id = "call_prior\r\nforged-history-log-entry";
+    let first_call = function_call("fc_prior", reused_call_id, "completed");
+    let first = turn("Call lookup", None, &ctx).await;
+    let stored = persist(
+        first.context,
+        UpstreamBody::Json(&upstream_call_json(&first_call, "completed")),
+        &ctx,
+    )
+    .await
+    .expect("store the prior call");
+
+    let resolution = json!([{
+        "type": "function_call_output",
+        "call_id": reused_call_id,
+        "output": "prior result",
+    }]);
+    let continued = hydrate(request_value(&resolution, Some(&stored.id)), &ctx)
+        .await
+        .expect("resolve the prior call");
+    let repeated = custom_tool_call("ctc_repeated", reused_call_id, "completed");
+    let relayed = if stream {
+        upstream_call_sse(&repeated, &repeated, &repeated, "completed")
+    } else {
+        upstream_call_json(&repeated, "completed")
+    };
+    assert_relayed_call_id_rejected(
+        &ctx,
+        continued,
+        &relayed,
+        stream,
+        "a continued call_id must remain unique",
+        "forged-history-log-entry",
+        "history",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn relayed_call_id_cannot_reuse_a_call_replayed_in_the_current_input() {
+    let ctx = exec_ctx().await;
+    let reused_call_id = "call_input\r\nforged-input-log-entry";
+    let input = json!([
+        {
+            "type": "function_call",
+            "id": "fc_input",
+            "call_id": reused_call_id,
+            "name": "lookup",
+            "arguments": "{}",
+            "status": "completed",
+        },
+        {"type": "function_call_output", "call_id": reused_call_id, "output": "input result"},
+    ]);
+    let attempt = hydrate(request_value(&input, None), &ctx)
+        .await
+        .expect("the replayed call/output pair is valid input");
+    let repeated = function_call("fc_repeated", reused_call_id, "completed");
+    assert_relayed_call_id_rejected(
+        &ctx,
+        attempt,
+        &upstream_call_json(&repeated, "completed"),
+        false,
+        "an upstream call_id must remain unique across manually replayed input",
+        "forged-input-log-entry",
+        "request input[0]",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn relayed_sse_call_id_is_stable_across_item_representations() {
+    let ctx = exec_ctx().await;
+    let changed_call_id = "call_changed\r\nforged-stream-log-entry";
+    let cases = [
+        (
+            "function call changes in output_item.done",
+            function_call("fc_1", "call_original", "in_progress"),
+            function_call("fc_1", changed_call_id, "completed"),
+            function_call("fc_1", changed_call_id, "completed"),
+            "completed",
+        ),
+        (
+            "function call changes in terminal output",
+            function_call("fc_1", "call_original", "in_progress"),
+            function_call("fc_1", "call_original", "completed"),
+            function_call("fc_1", changed_call_id, "completed"),
+            "completed",
+        ),
+        (
+            "incomplete function call changes in output_item.done",
+            function_call("fc_1", "call_original", "in_progress"),
+            function_call("fc_1", changed_call_id, "completed"),
+            function_call("fc_1", changed_call_id, "completed"),
+            "incomplete",
+        ),
+        (
+            "custom call changes in output_item.done",
+            custom_tool_call("ctc_1", "call_original", "in_progress"),
+            custom_tool_call("ctc_1", changed_call_id, "completed"),
+            custom_tool_call("ctc_1", changed_call_id, "completed"),
+            "completed",
+        ),
+        (
+            "custom call changes in terminal output",
+            custom_tool_call("ctc_1", "call_original", "in_progress"),
+            custom_tool_call("ctc_1", "call_original", "completed"),
+            custom_tool_call("ctc_1", changed_call_id, "completed"),
+            "completed",
+        ),
+    ];
+
+    for (case, added, done, terminal, status) in cases {
+        let sse = upstream_call_sse(&added, &done, &terminal, status);
+        assert_relayed_call_id_rejected(
+            &ctx,
+            turn("Call a tool", None, &ctx).await,
+            &sse,
+            true,
+            case,
+            "forged-stream-log-entry",
+            "changes",
+        )
+        .await;
+    }
+}
+
+#[tokio::test]
+async fn relayed_sse_function_argument_event_cannot_change_call_id() {
+    let ctx = exec_ctx().await;
+    let changed_call_id = "call_changed\r\nforged-argument-log-entry";
+    let added = function_call("fc_1", "call_original", "in_progress");
+    let done_without_id = function_call("fc_1", "", "completed");
+    let terminal = function_call("fc_1", "call_original", "completed");
+    let sse = [
+        json!({"type": "response.created", "response": {"id": "resp_upstream", "status": "in_progress"}}),
+        json!({"type": "response.in_progress", "response": {"id": "resp_upstream", "status": "in_progress"}}),
+        json!({"type": "response.output_item.added", "output_index": 0, "item": added}),
+        json!({
+            "type": "response.function_call_arguments.done",
+            "output_index": 0,
+            "item_id": "fc_1",
+            "call_id": changed_call_id,
+            "name": "lookup",
+            "arguments": "{}",
+        }),
+        json!({"type": "response.output_item.done", "output_index": 0, "item": done_without_id}),
+        json!({
+            "type": "response.completed",
+            "response": {"id": "resp_upstream", "status": "completed", "output": [terminal]},
+        }),
+    ]
+    .iter()
+    .map(|frame| format!("data: {frame}\n\n"))
+    .collect::<Vec<_>>()
+    .concat();
+
+    assert_relayed_call_id_rejected(
+        &ctx,
+        turn("Call a tool", None, &ctx).await,
+        &sse,
+        true,
+        "an arguments event cannot replace an announced call_id",
+        "forged-argument-log-entry",
+        "changes",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn relayed_sse_call_id_can_first_appear_in_output_item_done() {
+    let ctx = exec_ctx().await;
+    for (added, done) in [
+        (
+            function_call("fc_1", "", "in_progress"),
+            function_call("fc_1", "call_function", "completed"),
+        ),
+        (
+            custom_tool_call("ctc_1", "", "in_progress"),
+            custom_tool_call("ctc_1", "call_custom", "completed"),
+        ),
+    ] {
+        let sse = upstream_call_sse(&added, &done, &done, "completed");
+        persist(
+            turn("Call a tool", None, &ctx).await.context,
+            UpstreamBody::Sse(&sse),
+            &ctx,
+        )
+        .await
+        .expect("a later first non-empty call_id is valid");
+    }
+}
+
 /// Every way a turn is refused, and the status the caller sees.
 #[tokio::test]
 async fn a_turn_that_cannot_be_stored_is_refused() {
@@ -453,6 +747,22 @@ async fn a_turn_that_is_not_written_still_returns() {
     ));
     let orphan = hydrate(request("and then?", Some(&id)), &ctx).await;
     assert_eq!(status_of(&orphan.expect_err("never stored")), 404);
+
+    // A failed response remains returned-but-unstored even when its partial
+    // item representations disagree; no unusable continuation can be created.
+    let added = function_call("fc_failed", "call_original", "in_progress");
+    let done = function_call("fc_failed", "call_changed", "completed");
+    let failed_sse = upstream_call_sse(&added, &done, &done, "failed");
+    let failed_attempt = turn("hi", None, &ctx).await;
+    let failed_id = unseal(&failed_attempt.context, &signing_key())
+        .expect("unseal")
+        .response_id;
+    let payload = persist(failed_attempt.context, UpstreamBody::Sse(&failed_sse), &ctx)
+        .await
+        .expect("failed partial output is not a persistence error");
+    assert_eq!(payload.status, "error");
+    let orphan = hydrate(request("and then?", Some(&failed_id)), &ctx).await;
+    assert_eq!(status_of(&orphan.expect_err("failed SSE was never stored")), 404);
 }
 
 /// Until an identical retry can be proven identical, a reused id is refused.

--- a/crates/agentic-server-core/src/executor/persist.rs
+++ b/crates/agentic-server-core/src/executor/persist.rs
@@ -3,6 +3,8 @@
 //! Writes the completed response and output items to storage, routing to the
 //! appropriate handler based on whether the turn belongs to a conversation.
 
+use std::collections::HashMap;
+
 use crate::executor::error::{ExecutorError, ExecutorResult};
 use crate::executor::modes::{ConversationHandler, ResponseHandler};
 use crate::executor::request::{ExecutionContext, RequestContext};
@@ -85,7 +87,7 @@ pub async fn persist_turn(
 /// returned unstored, as the in-process flow does.
 ///
 /// # Errors
-/// [`ExecutorError::InvalidRequest`] for an unusable id or unfinished response,
+/// [`ExecutorError::InvalidRequest`] for unusable IDs or an unfinished response,
 /// [`ExecutorError::Conflict`] for an id already stored, or a storage error.
 pub async fn commit(
     ctx: RequestContext,
@@ -98,12 +100,16 @@ pub async fn commit(
         ));
     }
 
+    let status = payload.status.parse::<ResponseStatus>().unwrap_or_default();
     // Storing an unfinished turn would return an id that can never be continued.
-    if payload.status.parse::<ResponseStatus>().unwrap_or_default() == ResponseStatus::InProgress {
+    if status == ResponseStatus::InProgress {
         return Err(ExecutorError::InvalidRequest(format!(
             "upstream response status '{}' is not terminal",
             payload.status
         )));
+    }
+    if matches!(status, ResponseStatus::Completed | ResponseStatus::Incomplete) {
+        validate_output_call_ids(&payload.output)?;
     }
 
     persist_if_needed(
@@ -114,4 +120,26 @@ pub async fn commit(
     )
     .await?;
     Ok(payload)
+}
+
+fn validate_output_call_ids(output_items: &[OutputItem]) -> ExecutorResult<()> {
+    let mut call_ids = HashMap::new();
+    for (index, item) in output_items.iter().enumerate() {
+        let (item_type, call_id) = match item {
+            OutputItem::FunctionCall(call) => ("function_call", call.call_id.as_str()),
+            OutputItem::CustomToolCall(call) => ("custom_tool_call", call.call_id.as_str()),
+            _ => continue,
+        };
+        if call_id.is_empty() {
+            return Err(ExecutorError::InvalidRequest(format!(
+                "upstream response output[{index}] {item_type} has no valid 'call_id'"
+            )));
+        }
+        if let Some(first_index) = call_ids.insert(call_id, index) {
+            return Err(ExecutorError::InvalidRequest(format!(
+                "upstream response output[{index}] repeats 'call_id' from output[{first_index}]"
+            )));
+        }
+    }
+    Ok(())
 }

--- a/crates/agentic-server-core/src/executor/persist.rs
+++ b/crates/agentic-server-core/src/executor/persist.rs
@@ -8,8 +8,9 @@ use std::collections::HashMap;
 use crate::executor::error::{ExecutorError, ExecutorResult};
 use crate::executor::modes::{ConversationHandler, ResponseHandler};
 use crate::executor::request::{ExecutionContext, RequestContext};
+use crate::storage::InOutItem;
 use crate::types::event::ResponseStatus;
-use crate::types::io::OutputItem;
+use crate::types::io::{InputItem, OutputItem};
 use crate::types::request_response::ResponsePayload;
 use tracing::error;
 
@@ -109,7 +110,7 @@ pub async fn commit(
         )));
     }
     if matches!(status, ResponseStatus::Completed | ResponseStatus::Incomplete) {
-        validate_output_call_ids(&payload.output)?;
+        validate_output_call_ids(&ctx, &payload.output, &exec_ctx.resp_handler).await?;
     }
 
     persist_if_needed(
@@ -122,7 +123,11 @@ pub async fn commit(
     Ok(payload)
 }
 
-fn validate_output_call_ids(output_items: &[OutputItem]) -> ExecutorResult<()> {
+async fn validate_output_call_ids(
+    ctx: &RequestContext,
+    output_items: &[OutputItem],
+    resp_handler: &ResponseHandler,
+) -> ExecutorResult<()> {
     let mut call_ids = HashMap::new();
     for (index, item) in output_items.iter().enumerate() {
         let (item_type, call_id) = match item {
@@ -135,11 +140,46 @@ fn validate_output_call_ids(output_items: &[OutputItem]) -> ExecutorResult<()> {
                 "upstream response output[{index}] {item_type} has no valid 'call_id'"
             )));
         }
-        if let Some(first_index) = call_ids.insert(call_id, index) {
+        if let Some((first_index, _)) = call_ids.insert(call_id, (index, item_type)) {
             return Err(ExecutorError::InvalidRequest(format!(
-                "upstream response output[{index}] repeats 'call_id' from output[{first_index}]"
+                "upstream response output[{index}] {item_type} repeats 'call_id' from output[{first_index}]"
+            )));
+        }
+    }
+    if call_ids.is_empty() {
+        return Ok(());
+    }
+
+    for (history_index, item) in resp_handler.rehydrate(ctx).await?.iter().enumerate() {
+        if let Some((output_index, item_type)) = stored_call_id(item).and_then(|call_id| call_ids.get(call_id)) {
+            return Err(ExecutorError::InvalidRequest(format!(
+                "upstream response output[{output_index}] {item_type} repeats 'call_id' from continued history item[{history_index}]"
+            )));
+        }
+    }
+    for (input_index, item) in ctx.new_input_items.iter().enumerate() {
+        if let Some((output_index, item_type)) = input_call_id(item).and_then(|call_id| call_ids.get(call_id)) {
+            return Err(ExecutorError::InvalidRequest(format!(
+                "upstream response output[{output_index}] {item_type} repeats 'call_id' from request input[{input_index}]"
             )));
         }
     }
     Ok(())
+}
+
+fn stored_call_id(item: &InOutItem) -> Option<&str> {
+    match item {
+        InOutItem::Input(item) => input_call_id(item),
+        InOutItem::Output(OutputItem::FunctionCall(call)) => Some(&call.call_id),
+        InOutItem::Output(OutputItem::CustomToolCall(call)) => Some(&call.call_id),
+        InOutItem::Output(_) => None,
+    }
+}
+
+fn input_call_id(item: &InputItem) -> Option<&str> {
+    match item {
+        InputItem::FunctionCall(call) => Some(&call.call_id),
+        InputItem::CustomToolCall(call) => Some(&call.call_id),
+        _ => None,
+    }
 }

--- a/crates/agentic-server-core/src/executor/upstream.rs
+++ b/crates/agentic-server-core/src/executor/upstream.rs
@@ -104,6 +104,8 @@ struct RelayedStreamValidator {
 struct ActiveItem {
     id: String,
     item_type: String,
+    call_id: Option<String>,
+    call_id_changed: bool,
 }
 
 impl RelayedStreamValidator {
@@ -149,6 +151,8 @@ impl RelayedStreamValidator {
                     ActiveItem {
                         id: item_id.to_owned(),
                         item_type: item_type.to_owned(),
+                        call_id: item_call_id(item, item_type).map(str::to_owned),
+                        call_id_changed: false,
                     },
                 );
             }
@@ -162,6 +166,13 @@ impl RelayedStreamValidator {
                 OutputItem::deserialize(item).map_err(|error| {
                     ExecutorError::InvalidRequest(format!("upstream stream output item is invalid: {error}"))
                 })?;
+                self.observe_active_call_id(
+                    output_index,
+                    item_id,
+                    item_type,
+                    item_call_id(item, item_type),
+                    &event_name,
+                )?;
                 self.finish_item(output_index, item_id, item_type, &event_name)?;
             }
             SSEEventType::Other => self.require_in_progress(&event_name)?,
@@ -169,8 +180,21 @@ impl RelayedStreamValidator {
                 self.require_in_progress(&event_name)?;
                 let output_index = required_u32(&event, "output_index", &event_name)?;
                 let item_id = required_str(&event, "item_id", &event_name)?;
-                self.require_active_item(output_index, item_id, expected_item_type(event_type), &event_name)?;
+                let item_type = expected_item_type(event_type);
+                self.require_active_item(output_index, item_id, item_type, &event_name)?;
                 validate_event_fields(&event, event_type, &event_name)?;
+                if matches!(
+                    event_type,
+                    SSEEventType::FunctionCallArgumentsDelta | SSEEventType::FunctionCallArgumentsDone
+                ) {
+                    self.observe_active_call_id(
+                        output_index,
+                        item_id,
+                        item_type,
+                        item_call_id(&event, item_type),
+                        &event_name,
+                    )?;
+                }
             }
         }
         normalize_sse_value(event).map(Some).ok_or_else(|| {
@@ -227,7 +251,7 @@ impl RelayedStreamValidator {
                         "upstream stream ended with unfinished output items".to_owned(),
                     ));
                 }
-                self.validate_terminal_output(response)?;
+                self.validate_terminal_output(response, event_type != SSEEventType::ResponseFailed)?;
                 self.lifecycle = ResponseLifecycle::Terminal;
             }
             _ => {
@@ -276,7 +300,31 @@ impl RelayedStreamValidator {
         Ok(())
     }
 
-    fn validate_terminal_output(&self, response: &Value) -> ExecutorResult<()> {
+    fn observe_active_call_id(
+        &mut self,
+        output_index: u32,
+        item_id: &str,
+        item_type: &str,
+        call_id: Option<&str>,
+        event_name: &str,
+    ) -> ExecutorResult<()> {
+        let Some(active) = self.active_items.get_mut(&output_index) else {
+            return Err(ExecutorError::InvalidRequest(format!(
+                "upstream stream event '{event_name}' has no active output item"
+            )));
+        };
+        if item_id != active.id || item_type != active.item_type {
+            return Err(ExecutorError::InvalidRequest(format!(
+                "upstream stream event '{event_name}' does not match its active output item"
+            )));
+        }
+        if let Some(call_id) = call_id {
+            active.observe_call_id(call_id);
+        }
+        Ok(())
+    }
+
+    fn validate_terminal_output(&mut self, response: &Value, enforce_call_id_stability: bool) -> ExecutorResult<()> {
         let output = response
             .get("output")
             .and_then(Value::as_array)
@@ -293,7 +341,7 @@ impl RelayedStreamValidator {
             let item_id = required_str(item, "id", "terminal output item")?;
             let item_type = required_str(item, "type", "terminal output item")?;
             ensure_supported_output_item_type(item_type)?;
-            let Some(completed) = self.completed_items.get(&output_index) else {
+            let Some(completed) = self.completed_items.get_mut(&output_index) else {
                 return Err(ExecutorError::InvalidRequest(
                     "terminal upstream response output does not match completed item events".to_owned(),
                 ));
@@ -303,9 +351,34 @@ impl RelayedStreamValidator {
                     "terminal upstream response output does not match completed item events".to_owned(),
                 ));
             }
+            if let Some(call_id) = item_call_id(item, item_type) {
+                completed.observe_call_id(call_id);
+            }
+            if enforce_call_id_stability && completed.call_id_changed {
+                return Err(ExecutorError::InvalidRequest(format!(
+                    "upstream stream changes 'call_id' for output[{output_index}]"
+                )));
+            }
         }
         Ok(())
     }
+}
+
+impl ActiveItem {
+    fn observe_call_id(&mut self, call_id: &str) {
+        match self.call_id.as_deref() {
+            Some(first) if first != call_id => self.call_id_changed = true,
+            None => self.call_id = Some(call_id.to_owned()),
+            Some(_) => {}
+        }
+    }
+}
+
+fn item_call_id<'a>(item: &'a Value, item_type: &str) -> Option<&'a str> {
+    if !matches!(item_type, "function_call" | "custom_tool_call") {
+        return None;
+    }
+    item.get("call_id")?.as_str().filter(|call_id| !call_id.is_empty())
 }
 
 fn ensure_supported_output_item_type(item_type: &str) -> ExecutorResult<()> {


### PR DESCRIPTION
## Summary

- Reject completed or incomplete split-execution responses whose `function_call` or `custom_tool_call` output has a missing/empty `call_id`, repeats one within the response, or reuses one from the rehydrated response chain or the current replayed input.
- In caller-relayed SSE, bind each tool call's first non-empty `call_id` across `response.output_item.added`, function-argument events, `response.output_item.done`, and terminal output, rejecting later changes before persistence.
- Validate before the first write so a rejected payload does not consume the reserved response ID and can be corrected and retried. Failed partial responses retain their existing returned-but-unstored behavior.

## Problem and contract

The split `commit` path deserialized an omitted `call_id` as an empty string and persisted the terminal response. It also checked neither resolved IDs from the continued history nor changes between SSE representations. The resulting response ID was accepted but could fail on the next continuation, or a client could answer the originally announced ID while a different ID was persisted.

The repository's continuation state treats call IDs as opaque, globally unique identifiers within the rehydrated sequence. The upstream types also require these IDs:

- OpenAI response function calls: https://github.com/openai/openai-python/blob/main/src/openai/types/responses/response_function_tool_call.py
- OpenAI custom tool calls: https://github.com/openai/openai-python/blob/main/src/openai/types/responses/response_custom_tool_call.py
- vLLM call-ID construction: https://github.com/vllm-project/vllm/blob/31e9c13685b484d4ba67dc4e73019b23402609c7/vllm/entrypoints/openai/responses/utils.py#L93-L108

A scan of the recorded corpus found no missing, empty, or repeated finalized call ID. Across 62 recorded SSE call lifecycles, added/done/intermediate representations never changed `call_id`. Older cassettes with terminal representation differences already violate the split validator's item-identity contract and are not newly rejected by this patch.

## Red/green reproduction

Against unmodified reviewed head `60aa5dc`, test-only controls failed because all of these payloads were accepted and persisted:

- JSON and SSE responses reusing a resolved historical function-call ID in a later custom call
- an SSE call announcing ID A in `response.output_item.added` and persisting ID B from `response.output_item.done`

A fresh counterexample against the first implementation also failed: `response.function_call_arguments.done` could replace the announced ID even when done/terminal item representations later returned to the original ID. The final implementation observes that mutation as well.

The final regressions cover JSON/SSE, function/custom cross-kind reuse, manually replayed current input, added/done/terminal and argument-event mutation, completed/incomplete/failed terminal states, initially empty IDs filled later, malicious CRLF markers, corrected retry, and unchanged failed-response persistence behavior. All rejection diagnostics use bounded indices and never echo the upstream ID.

## Compatibility and scope

- The additional history read occurs only for a completed/incomplete payload containing a new function or custom call.
- Failed responses remain returnable and unstored even if partial SSE representations disagree.
- The normal in-process upstream accumulator is unchanged; stability enforcement is limited to caller-supplied split SSE.
- No API, wire-format, or persistence schema changes are introduced.
- PR #236 changes the strict SSE validator's architecture and does not currently enforce this invariant, so merge order may require retaining this regression while resolving that file mechanically.

## Test Plan

Exact final commit `7f9bf9964209de75acebe72a0fe2fb854a12d975` was tested from a clean detached worktree:

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p agentic-llm-d --test split_execution_integration` (19 passed)
- `cargo test --workspace --all-features -- --test-threads=4` (all runnable tests passed; 5 PostgreSQL tests require `TEST_POSTGRES_URL`, and 1 doctest is repository-ignored)
- Python suite (111 passed, 3 package-install scenarios skipped by the suite)
- cassette validator (108/108 cassettes, 238 turns)
- source-install CLI end-to-end test
- strict MkDocs build
- all-file pre-commit hooks; Apple Git deadlocked in `check-added-large-files --all-files`, so that hook was rerun successfully on the complete four-file diff while every other hook passed over all files
