### PR TITLE
feat: multiplex response streams over WebSocket

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -159,11 +159,22 @@ building `ExecuteRequest`, preserving strict validation for in-process execution
 
 `GET /v1/responses` upgrades to a WebSocket. Structurally this is not a one-shot
 handler like the HTTP routes — `responses_ws_loop` is a long-lived session loop that
-reads `response.create` messages off the socket, queues any that arrive while a
-response is streaming, and drives the *same* `ExecuteRequest::run()` executor call the
-HTTP handler uses. WebSocket sessions always force `stream: true, store: true`. Because
-axum's built-in graceful shutdown doesn't wait for upgraded connections, `AppState`
-carries a separate `WebSocketTracker` so shutdown can drain in-flight sessions.
+reads `response.create` messages off the socket and drives the *same*
+`ExecuteRequest::run()` executor call the HTTP handler uses. Requests with distinct
+`stream_id` values run concurrently, while requests in the same lane remain FIFO;
+requests without a `stream_id` share a default FIFO lane. The session admits at most
+64 active or queued requests and 12 MiB of aggregate request data. WebSocket sessions
+always force `stream: true, store: true`. Because axum's built-in graceful shutdown
+doesn't wait for upgraded connections, `AppState` carries a separate
+`WebSocketTracker` so shutdown can drain in-flight sessions.
+
+Executor streams propagate downstream backpressure through a bounded event channel.
+Upstream SSE lines are capped at 256 KiB, while normalized events are capped at 1 MiB.
+Each request also shares a 1 MiB response budget across MCP discovery, upstream rounds,
+and normalized gateway tool output, so a slow consumer cannot turn a fixed event-count
+buffer into unbounded retained memory. MCP discovery participates in the same 16-permit
+materialization window as gateway calls and is capped at 64 server declarations and
+128 discovered tools per request.
 Errors are modeled by a dedicated `WsError` enum (`handler/websocket/error.rs`) rather
 than reusing the HTTP JSON-error path, since some failure modes (a dead socket) must
 not attempt to write a response.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -175,6 +175,10 @@ and normalized gateway tool output, so a slow consumer cannot turn a fixed event
 buffer into unbounded retained memory. MCP discovery participates in the same 16-permit
 materialization window as gateway calls and is capped at 64 server declarations and
 128 discovered tools per request.
+The WebSocket transport queues only serialized, size-checked events, capped at
+1 MiB each including routing metadata, in its 64-entry outbound queue. Local
+completion validates both lifecycle events before persistence. Authentication is
+rechecked at request dispatch so queued work cannot start after identity expiry.
 Errors are modeled by a dedicated `WsError` enum (`handler/websocket/error.rs`) rather
 than reusing the HTTP JSON-error path, since some failure modes (a dead socket) must
 not attempt to write a response.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to Agentic API are documented here.
 
 ### Fixed
 
+- Bounded WebSocket queues, generated response data, gateway tool results, and MCP discovery and HTTP/SSE payloads so
+  concurrent response streams cannot grow memory without limit.
 - Hardened split execution with atomic duplicate persistence, strict relayed-response validation, independent secret
   validation, bounded hydrate and persist payloads, stable error envelopes, and graceful shutdown error propagation.
 - Forwarded Responses `text` generation settings through typed execution paths while preserving provider-specific
@@ -28,6 +30,8 @@ All notable changes to Agentic API are documented here.
 
 ### Added
 
+- Added concurrent Responses WebSocket multiplexing with per-request `stream_id` routing, preserving FIFO ordering
+  within each stream while allowing independent streams to interleave on one connection.
 - Documented running Agentic API in front of NVIDIA Dynamo and recorded Dynamo cassettes for stateful and
   function-call flows.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,7 @@ dependencies = [
  "serde_yaml",
  "serde_yml",
  "sqlx",
+ "sse-stream",
  "thiserror",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ rmcp = { version = "1.8", default-features = false }
 serde = { version = "1", features = ["derive"] }
 # Structured Outputs emit object keys in JSON Schema declaration order.
 serde_json = { version = "1", features = ["preserve_order", "raw_value"] }
+sse-stream = "0.2.3"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"

--- a/crates/agentic-server-core/Cargo.toml
+++ b/crates/agentic-server-core/Cargo.toml
@@ -33,6 +33,7 @@ rmcp = { workspace = true, features = [
 ] }
 serde.workspace = true
 serde_json.workspace = true
+sse-stream.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["time"] }
 tracing.workspace = true

--- a/crates/agentic-server-core/src/executor/compaction.rs
+++ b/crates/agentic-server-core/src/executor/compaction.rs
@@ -205,7 +205,7 @@ pub(crate) async fn compact_items(
         conversation_id: None,
         conversation_version: None,
     };
-    let response = fetch_blocking_payload(&ctx, exec_ctx, auth).await?;
+    let response = fetch_blocking_payload(&ctx, exec_ctx, auth, None).await?;
     let summary = completed_summary_text(&response)?;
 
     Ok((

--- a/crates/agentic-server-core/src/executor/engine.rs
+++ b/crates/agentic-server-core/src/executor/engine.rs
@@ -175,7 +175,7 @@ async fn build_tool_registry(
                 tools,
                 &mut executors,
                 |bytes| response_budget.consume(bytes),
-                move || policy.clone().acquire_materialization_permit(),
+                move || policy.acquire_materialization_permit(),
             )
             .await?
         }
@@ -929,13 +929,7 @@ mod tests {
         });
         let mut held_permits = Vec::new();
         for _ in 0..crate::executor::gateway::MAX_CONCURRENT_MATERIALIZATIONS {
-            held_permits.push(
-                exec_ctx
-                    .gateway_scheduler_policy
-                    .clone()
-                    .acquire_materialization_permit()
-                    .await,
-            );
+            held_permits.push(exec_ctx.gateway_scheduler_policy.acquire_materialization_permit().await);
         }
 
         let plain_budget = ExecutorResponseBudget::new();

--- a/crates/agentic-server-core/src/executor/engine.rs
+++ b/crates/agentic-server-core/src/executor/engine.rs
@@ -19,13 +19,16 @@ use super::gateway::{
     emit_gateway_start_events, emit_response_start_events, execute_and_emit_output_calls, has_client_owned_calls,
     public_output_items,
 };
-use super::gateway_accumulator::{GatewayStreamAccumulator, StreamEvent, error_sse_chunk};
+use super::gateway_accumulator::{GatewayStreamAccumulator, STREAM_EVENT_BUFFER, StreamEvent, error_sse_chunk};
 use crate::events::EventFrame;
 use crate::executor::error::ExecutorResult;
 use crate::executor::inference::DONE_MARKER;
 use crate::executor::persist::persist_if_needed;
 use crate::executor::rehydrate::{prepare_reasoning_for_vllm, rehydrate_conversation, validate_reasoning_for_vllm};
 use crate::executor::request::{ExecutionContext, RequestContext};
+use crate::executor::response_budget::ExecutorResponseBudget;
+#[cfg(test)]
+use crate::executor::response_budget::MAX_EXECUTOR_RESPONSE_BYTES;
 use crate::executor::upstream::{emit_deferred_stream_events, fetch_blocking_payload, fetch_stream_payload};
 use crate::tool::{ToolRegistry, mcp};
 use crate::types::io::{InputItem, OutputItem, ResponseUsage, ResponsesInput, ToolChoice};
@@ -143,15 +146,15 @@ async fn run_until_gateway_tools_complete(
     exec_ctx: &ExecutionContext,
     auth: Option<&str>,
     stream_upstream: bool,
-    mut stream: Option<(&mut GatewayStreamAccumulator, &mpsc::UnboundedSender<StreamEvent>)>,
+    mut stream: Option<(&mut GatewayStreamAccumulator, &mpsc::Sender<StreamEvent>)>,
 ) -> ExecutorResult<(ResponsePayload, RequestContext)> {
     if ctx.enriched_request.input.has_compaction_trigger() {
         let (payload, ctx) = run_compaction_trigger(ctx, exec_ctx, auth).await?;
         if let Some((stream_accumulator, stream_sender)) = stream.as_mut() {
-            emit_response_start_events(&payload, stream_accumulator, stream_sender)?;
+            emit_response_start_events(&payload, stream_accumulator, stream_sender).await?;
             let event_plans = compaction_event_plans(&payload.output, 0);
-            emit_gateway_start_events(&event_plans, stream_accumulator, stream_sender)?;
-            emit_gateway_completed_events(&payload.output, &event_plans, stream_accumulator, stream_sender)?;
+            emit_gateway_start_events(&event_plans, stream_accumulator, stream_sender).await?;
+            emit_gateway_completed_events(&payload.output, &event_plans, stream_accumulator, stream_sender).await?;
         }
         return Ok((payload, ctx));
     }
@@ -159,10 +162,23 @@ async fn run_until_gateway_tools_complete(
     run_gateway_tool_loop(ctx, exec_ctx, auth, stream_upstream, stream).await
 }
 
-async fn build_tool_registry(ctx: &mut RequestContext, exec_ctx: &ExecutionContext) -> ExecutorResult<ToolRegistry> {
+async fn build_tool_registry(
+    ctx: &mut RequestContext,
+    exec_ctx: &ExecutionContext,
+    response_budget: &ExecutorResponseBudget,
+) -> ExecutorResult<ToolRegistry> {
     let mut executors = exec_ctx.gateway_executors.request_scoped();
     let mut registry: ToolRegistry = match ctx.enriched_request.tools.as_mut() {
-        Some(tools) => ToolRegistry::build_with_handlers(tools, &mut executors).await?,
+        Some(tools) => {
+            let policy = exec_ctx.gateway_scheduler_policy.clone();
+            ToolRegistry::build_with_handlers_guarded(
+                tools,
+                &mut executors,
+                |bytes| response_budget.consume(bytes),
+                move || policy.clone().acquire_materialization_permit(),
+            )
+            .await?
+        }
         None => ToolRegistry::default(),
     };
     registry.cache_listed_mcp_tools(&ctx.enriched_request.input);
@@ -176,14 +192,29 @@ fn prepare_initial_reasoning_for_vllm(input: &mut ResponsesInput, round: usize, 
     Ok(())
 }
 
+fn log_custom_tool_calls(output: &[OutputItem], response_id: &str) {
+    for item in output {
+        if let OutputItem::CustomToolCall(call) = item {
+            debug!(
+                %response_id,
+                call_id = %call.call_id,
+                name = %call.name,
+                input_bytes = call.input.len(),
+                "custom tool call requires client execution"
+            );
+        }
+    }
+}
+
 async fn run_gateway_tool_loop(
     mut ctx: RequestContext,
     exec_ctx: &ExecutionContext,
     auth: Option<&str>,
     stream_upstream: bool,
-    mut stream: Option<(&mut GatewayStreamAccumulator, &mpsc::UnboundedSender<StreamEvent>)>,
+    mut stream: Option<(&mut GatewayStreamAccumulator, &mpsc::Sender<StreamEvent>)>,
 ) -> ExecutorResult<(ResponsePayload, RequestContext)> {
-    let mut registry = build_tool_registry(&mut ctx, exec_ctx).await?;
+    let response_budget = ExecutorResponseBudget::new();
+    let mut registry = build_tool_registry(&mut ctx, exec_ctx, &response_budget).await?;
     let mut combined_output: Vec<OutputItem> = registry
         .mcp_list_tool_items()
         .map(mcp::handler::list_tools_output_item)
@@ -205,6 +236,7 @@ async fn run_gateway_tool_loop(
                     .as_mut()
                     .map(|(accumulator, sender)| (&mut **accumulator, *sender)),
                 output_offset,
+                &response_budget,
             )
             .await?;
             if round == 0 {
@@ -212,22 +244,15 @@ async fn run_gateway_tool_loop(
             }
             (stream_payload.payload, stream_payload.deferred_events)
         } else {
-            (fetch_blocking_payload(&ctx, exec_ctx, auth).await?, Vec::new())
+            (
+                fetch_blocking_payload(&ctx, exec_ctx, auth, Some(&response_budget)).await?,
+                Vec::new(),
+            )
         };
         registry.restore_final_payload_output(&mut payload.output);
         accumulate_usage(&mut combined_usage, payload.usage.take());
         let current_output = std::mem::take(&mut payload.output);
-        for item in &current_output {
-            if let OutputItem::CustomToolCall(call) = item {
-                debug!(
-                    response_id = %ctx.response_id,
-                    call_id = %call.call_id,
-                    name = %call.name,
-                    input_bytes = call.input.len(),
-                    "custom tool call requires client execution"
-                );
-            }
-        }
+        log_custom_tool_calls(&current_output, &ctx.response_id);
         let has_client_owned = has_client_owned_calls(&current_output, &registry);
         let gateway_results = execute_and_emit_round_output_calls(
             &current_output,
@@ -235,7 +260,10 @@ async fn run_gateway_tool_loop(
             output_offset,
             deferred_stream_events,
             &ctx,
-            exec_ctx.gateway_scheduler_policy,
+            GatewayExecutionResources {
+                policy: exec_ctx.gateway_scheduler_policy.clone(),
+                response_budget: &response_budget,
+            },
             stream
                 .as_mut()
                 .map(|(accumulator, sender)| (&mut **accumulator, *sender)),
@@ -330,17 +358,33 @@ async fn run_compaction_trigger(
     Ok((payload, ctx))
 }
 
+#[derive(Clone)]
+struct GatewayExecutionResources<'a> {
+    policy: GatewaySchedulerPolicy,
+    response_budget: &'a ExecutorResponseBudget,
+}
+
 async fn execute_and_emit_round_output_calls(
     output_items: &[OutputItem],
     registry: &ToolRegistry,
     output_offset: usize,
     deferred_events: Vec<EventFrame>,
     ctx: &RequestContext,
-    policy: GatewaySchedulerPolicy,
-    stream: Option<(&mut GatewayStreamAccumulator, &mpsc::UnboundedSender<StreamEvent>)>,
+    resources: GatewayExecutionResources<'_>,
+    stream: Option<(&mut GatewayStreamAccumulator, &mpsc::Sender<StreamEvent>)>,
 ) -> ExecutorResult<Vec<GatewayCallResult>> {
     match (deferred_events.is_empty(), stream) {
-        (true, stream) => execute_and_emit_output_calls(output_items, registry, output_offset, policy, stream).await,
+        (true, stream) => {
+            execute_and_emit_output_calls(
+                output_items,
+                registry,
+                output_offset,
+                resources.policy.clone(),
+                resources.response_budget,
+                stream,
+            )
+            .await
+        }
         (false, Some((stream_accumulator, stream_sender))) => {
             execute_and_emit_ordered_output_calls(
                 output_items,
@@ -348,12 +392,22 @@ async fn execute_and_emit_round_output_calls(
                 output_offset,
                 deferred_events,
                 ctx,
-                policy,
+                resources,
                 (stream_accumulator, stream_sender),
             )
             .await
         }
-        (false, None) => execute_and_emit_output_calls(output_items, registry, output_offset, policy, None).await,
+        (false, None) => {
+            execute_and_emit_output_calls(
+                output_items,
+                registry,
+                output_offset,
+                resources.policy.clone(),
+                resources.response_budget,
+                None,
+            )
+            .await
+        }
     }
 }
 
@@ -363,8 +417,8 @@ async fn execute_and_emit_ordered_output_calls(
     output_offset: usize,
     deferred_events: Vec<EventFrame>,
     ctx: &RequestContext,
-    policy: GatewaySchedulerPolicy,
-    stream: (&mut GatewayStreamAccumulator, &mpsc::UnboundedSender<StreamEvent>),
+    resources: GatewayExecutionResources<'_>,
+    stream: (&mut GatewayStreamAccumulator, &mpsc::Sender<StreamEvent>),
 ) -> ExecutorResult<Vec<GatewayCallResult>> {
     let (stream_accumulator, stream_sender) = stream;
     let mut events_by_output = Vec::with_capacity(output_items.len());
@@ -383,15 +437,16 @@ async fn execute_and_emit_ordered_output_calls(
         events_by_output[output_index].push(frame);
     }
 
-    let mut scheduler = GatewayScheduler::plan(output_items, registry, output_offset, policy);
+    let mut scheduler = GatewayScheduler::plan(output_items, registry, output_offset, resources.policy.clone());
     let initial_event_run_len = scheduler.initial_event_run_len(output_items, registry);
     emit_gateway_start_events(
         scheduler.event_plans().take(initial_event_run_len),
         stream_accumulator,
         stream_sender,
-    )?;
+    )
+    .await?;
 
-    let gateway_results = scheduler.execute().await?;
+    let gateway_results = scheduler.execute_with_budget(resources.response_budget).await?;
     for (index, output_events) in events_by_output.iter_mut().enumerate() {
         if let Some(call_index) = scheduler.call_index_for_item(index) {
             let plan = scheduler
@@ -399,9 +454,9 @@ async fn execute_and_emit_ordered_output_calls(
                 .expect("scheduled call index always has an event plan");
             let result = std::slice::from_ref(&gateway_results[call_index]);
             if call_index >= initial_event_run_len {
-                emit_gateway_start_events(std::iter::once(plan), stream_accumulator, stream_sender)?;
+                emit_gateway_start_events(std::iter::once(plan), stream_accumulator, stream_sender).await?;
             }
-            emit_gateway_completed_events(result, std::iter::once(plan), stream_accumulator, stream_sender)?;
+            emit_gateway_completed_events(result, std::iter::once(plan), stream_accumulator, stream_sender).await?;
             emit_deferred_stream_events(
                 std::mem::take(output_events),
                 ctx,
@@ -409,7 +464,8 @@ async fn execute_and_emit_ordered_output_calls(
                 stream_accumulator,
                 stream_sender,
                 output_offset,
-            )?;
+            )
+            .await?;
         } else {
             emit_deferred_stream_events(
                 std::mem::take(output_events),
@@ -418,7 +474,8 @@ async fn execute_and_emit_ordered_output_calls(
                 stream_accumulator,
                 stream_sender,
                 output_offset,
-            )?;
+            )
+            .await?;
         }
     }
     emit_deferred_stream_events(
@@ -428,7 +485,8 @@ async fn execute_and_emit_ordered_output_calls(
         stream_accumulator,
         stream_sender,
         output_offset,
-    )?;
+    )
+    .await?;
     Ok(gateway_results)
 }
 
@@ -462,7 +520,7 @@ async fn run_blocking(
 
 fn run_stream(ctx: RequestContext, exec_ctx: Arc<ExecutionContext>, auth: Option<String>) -> BoxStream {
     Box::pin(stream! {
-        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let (event_tx, mut event_rx) = mpsc::channel(STREAM_EVENT_BUFFER);
         let exec_ctx_for_run = Arc::clone(&exec_ctx);
         let event_tx_for_run = event_tx.clone();
         let stream_accumulator = GatewayStreamAccumulator::new();
@@ -492,14 +550,14 @@ fn run_stream(ctx: RequestContext, exec_ctx: Arc<ExecutionContext>, auth: Option
                                 yield chunk;
                             }
                         }
-                        Ok((Err(e), mut stream_accumulator)) => {
+                        Ok((Err(e), _stream_accumulator)) => {
                             while let Ok(event) = event_rx.try_recv() {
                                 yield consume_stream_event(event, &mut next_sequence_number);
                             }
-                            yield stream_accumulator.executor_error_chunk(&e);
+                            yield GatewayStreamAccumulator::executor_error_chunk_at(&e, next_sequence_number);
                             yield DONE_MARKER.to_string();
                         }
-                        Ok((Ok((payload, ctx)), mut stream_accumulator)) => {
+                        Ok((Ok((payload, ctx)), stream_accumulator)) => {
                             while let Ok(event) = event_rx.try_recv() {
                                 yield consume_stream_event(event, &mut next_sequence_number);
                             }
@@ -511,12 +569,19 @@ fn run_stream(ctx: RequestContext, exec_ctx: Arc<ExecutionContext>, auth: Option
                             let rh = exec_ctx.resp_handler.clone();
                             let mut terminal_accumulator = stream_accumulator.clone();
                             let terminal_chunk = terminal_accumulator.terminal_response_chunk(&payload);
-                            match persist_if_needed(payload, ctx, ch, rh).await {
-                                Ok(()) => match terminal_chunk {
-                                    Ok(chunk) => yield chunk,
-                                    Err(e) => yield stream_accumulator.executor_error_chunk(&e),
-                                },
-                                Err(e) => yield stream_accumulator.executor_error_chunk(&e),
+                            match terminal_chunk {
+                                Err(e) => {
+                                    yield GatewayStreamAccumulator::executor_error_chunk_at(&e, next_sequence_number);
+                                }
+                                Ok(chunk) => match persist_if_needed(payload, ctx, ch, rh).await {
+                                    Ok(()) => yield chunk,
+                                    Err(e) => {
+                                        yield GatewayStreamAccumulator::executor_error_chunk_at(
+                                            &e,
+                                            next_sequence_number,
+                                        );
+                                    }
+                                }
                             }
                             yield DONE_MARKER.to_string();
                         }
@@ -539,7 +604,7 @@ fn stream_task_failure_chunk(error: &tokio::task::JoinError, sequence_number: u6
 
 fn panicked_stream_chunks(
     error: &tokio::task::JoinError,
-    event_rx: &mut mpsc::UnboundedReceiver<StreamEvent>,
+    event_rx: &mut mpsc::Receiver<StreamEvent>,
     next_sequence_number: &mut u64,
 ) -> Vec<String> {
     let mut chunks = Vec::new();
@@ -617,7 +682,7 @@ impl ExecuteRequest {
             Ok(Either::Right(run_stream(ctx, self.exec_ctx, self.client_auth)))
         } else {
             Ok(Either::Left(
-                run_blocking(ctx, &self.exec_ctx, self.client_auth.as_deref()).await?,
+                Box::pin(run_blocking(ctx, &self.exec_ctx, self.client_auth.as_deref())).await?,
             ))
         }
     }
@@ -732,6 +797,163 @@ mod tests {
             format!("http://{address}"),
         );
         (exec_ctx, server)
+    }
+
+    #[tokio::test]
+    async fn mcp_discovery_uses_the_request_wide_response_budget() {
+        let payload: RequestPayload = serde_json::from_value(serde_json::json!({
+            "model": "test-model",
+            "store": false,
+            "input": "test input",
+            "tools": [{"type": "mcp", "server_label": "large-server"}]
+        }))
+        .expect("valid request");
+        let mut request = RequestContext {
+            original_request: payload.clone(),
+            enriched_request: payload,
+            new_input_items: Vec::new(),
+            response_id: "resp_test".to_owned(),
+            conversation_id: None,
+            conversation_version: None,
+        };
+        let mut exec_ctx = ExecutionContext::new(
+            ConversationHandler::new(ConversationStore::disabled()),
+            ResponseHandler::new(ResponseStore::disabled()),
+            Arc::new(reqwest::Client::new()),
+            "http://127.0.0.1:1".to_owned(),
+        );
+        exec_ctx.gateway_executors.insert(GatewayExecutorRegistration::Mcp {
+            server_label: "large-server".to_owned(),
+            handlers: vec![McpDiscoveredHandler {
+                param: McpDiscoveredToolParam {
+                    server_label: "large-server".to_owned(),
+                    tool_name: "large-tool".to_owned(),
+                    internal_name: "mcp__large_server__large_tool".to_owned(),
+                    tool: serde_json::from_value(serde_json::json!({
+                        "name": "large-tool",
+                        "description": "x".repeat(1_024),
+                        "inputSchema": {"type": "object"}
+                    }))
+                    .expect("valid MCP tool"),
+                },
+                handler: Arc::new(McpHandler::discovered_tool_spec_only()),
+            }],
+        });
+        let response_budget = ExecutorResponseBudget::new();
+        response_budget
+            .consume(MAX_EXECUTOR_RESPONSE_BYTES - 512)
+            .expect("reserve most of the response budget");
+
+        let error = build_tool_registry(&mut request, &exec_ctx, &response_budget)
+            .await
+            .expect_err("MCP discovery must share the request-wide response budget");
+
+        assert!(matches!(
+            error,
+            crate::executor::error::ExecutorError::StreamError(message)
+                if message.contains("response budget exceeded")
+        ));
+    }
+
+    #[tokio::test]
+    async fn each_mcp_discovery_acquires_and_releases_one_shared_materialization_permit() {
+        let mcp_payload: RequestPayload = serde_json::from_value(serde_json::json!({
+            "model": "test-model",
+            "store": false,
+            "input": "test input",
+            "tools": [
+                {"type": "mcp", "server_label": "counter"},
+                {"type": "mcp", "server_label": "search"}
+            ]
+        }))
+        .expect("valid MCP request");
+        let mut mcp_request = RequestContext {
+            original_request: mcp_payload.clone(),
+            enriched_request: mcp_payload,
+            new_input_items: Vec::new(),
+            response_id: "resp_mcp".to_owned(),
+            conversation_id: None,
+            conversation_version: None,
+        };
+        let plain_payload: RequestPayload = serde_json::from_value(serde_json::json!({
+            "model": "test-model",
+            "store": false,
+            "input": "test input"
+        }))
+        .expect("valid request without tools");
+        let mut plain_request = RequestContext {
+            original_request: plain_payload.clone(),
+            enriched_request: plain_payload,
+            new_input_items: Vec::new(),
+            response_id: "resp_plain".to_owned(),
+            conversation_id: None,
+            conversation_version: None,
+        };
+        let mut exec_ctx = ExecutionContext::new(
+            ConversationHandler::new(ConversationStore::disabled()),
+            ResponseHandler::new(ResponseStore::disabled()),
+            Arc::new(reqwest::Client::new()),
+            "http://127.0.0.1:1".to_owned(),
+        );
+        exec_ctx.gateway_executors.insert(GatewayExecutorRegistration::Mcp {
+            server_label: "counter".to_owned(),
+            handlers: vec![McpDiscoveredHandler {
+                param: McpDiscoveredToolParam {
+                    server_label: "counter".to_owned(),
+                    tool_name: "read".to_owned(),
+                    internal_name: "mcp__counter__read".to_owned(),
+                    tool: serde_json::from_value(serde_json::json!({
+                        "name": "read",
+                        "inputSchema": {"type": "object"}
+                    }))
+                    .expect("valid MCP tool"),
+                },
+                handler: Arc::new(McpHandler::discovered_tool_spec_only()),
+            }],
+        });
+        exec_ctx.gateway_executors.insert(GatewayExecutorRegistration::Mcp {
+            server_label: "search".to_owned(),
+            handlers: vec![McpDiscoveredHandler {
+                param: McpDiscoveredToolParam {
+                    server_label: "search".to_owned(),
+                    tool_name: "query".to_owned(),
+                    internal_name: "mcp__search__query".to_owned(),
+                    tool: serde_json::from_value(serde_json::json!({
+                        "name": "query",
+                        "inputSchema": {"type": "object"}
+                    }))
+                    .expect("valid MCP tool"),
+                },
+                handler: Arc::new(McpHandler::discovered_tool_spec_only()),
+            }],
+        });
+        let mut held_permits = Vec::new();
+        for _ in 0..crate::executor::gateway::MAX_CONCURRENT_MATERIALIZATIONS {
+            held_permits.push(
+                exec_ctx
+                    .gateway_scheduler_policy
+                    .clone()
+                    .acquire_materialization_permit()
+                    .await,
+            );
+        }
+
+        let plain_budget = ExecutorResponseBudget::new();
+        let mut plain_build = Box::pin(build_tool_registry(&mut plain_request, &exec_ctx, &plain_budget));
+        assert!(matches!(
+            futures::poll!(plain_build.as_mut()),
+            std::task::Poll::Ready(Ok(_))
+        ));
+        drop(plain_build);
+
+        let mcp_budget = ExecutorResponseBudget::new();
+        let mut mcp_build = Box::pin(build_tool_registry(&mut mcp_request, &exec_ctx, &mcp_budget));
+        assert!(futures::poll!(mcp_build.as_mut()).is_pending());
+
+        drop(held_permits.pop());
+        mcp_build
+            .await
+            .expect("sequential MCP discoveries should reuse the released shared permit");
     }
 
     #[tokio::test]
@@ -853,6 +1075,66 @@ mod tests {
                 (response, events)
             }
         }
+    }
+
+    #[tokio::test]
+    async fn oversized_terminal_response_is_not_persisted() {
+        let (mut exec_ctx, server) = streaming_execution_context().await;
+        let pool = create_pool_with_schema(Some("sqlite::memory:"))
+            .await
+            .expect("create response store");
+        let response_store = ResponseStore::new(pool);
+        exec_ctx.resp_handler = ResponseHandler::new(response_store.clone());
+
+        let payload: RequestPayload = serde_json::from_value(serde_json::json!({
+            "model": "test-model",
+            "stream": true,
+            "store": true,
+            "input": "short input",
+            "instructions": "x".repeat(MAX_EXECUTOR_RESPONSE_BYTES),
+        }))
+        .expect("valid oversized request");
+        let Either::Right(stream) = ExecuteRequest::new(payload, Arc::new(exec_ctx))
+            .run()
+            .await
+            .expect("request setup succeeds")
+        else {
+            panic!("streaming request must return a stream");
+        };
+
+        let events = stream
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .flat_map(|chunk| {
+                chunk
+                    .lines()
+                    .filter_map(|line| line.strip_prefix("data: "))
+                    .filter_map(|data| serde_json::from_str::<serde_json::Value>(data).ok())
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        let response_id = events
+            .iter()
+            .find(|event| event["type"] == "response.created")
+            .and_then(|event| event["response"]["id"].as_str())
+            .expect("created event has response ID");
+
+        assert!(events.iter().all(|event| event["type"] != "response.completed"));
+        assert!(events.iter().any(|event| {
+            event["type"] == "error"
+                && event["error"]["message"]
+                    .as_str()
+                    .is_some_and(|message| message.contains("stream event exceeded"))
+        }));
+        assert!(
+            response_store
+                .get(response_id)
+                .await
+                .expect_err("oversized terminal response must not be persisted")
+                .is_not_found()
+        );
+        server.abort();
     }
 
     fn mcp_list_tools_lifecycle_event_count(events: &[serde_json::Value]) -> usize {
@@ -1016,14 +1298,14 @@ mod tests {
     #[tokio::test]
     async fn stream_task_panic_after_event_uses_next_sequence_number_for_error() {
         let accumulator = GatewayStreamAccumulator::new();
-        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let (event_tx, mut event_rx) = mpsc::channel(STREAM_EVENT_BUFFER);
         let task = tokio::spawn(async move {
             let mut accumulator = accumulator;
             let event = accumulator
                 .process_sse_line(r#"data: {"type":"response.created"}"#, 0)
                 .expect("event should be emitted");
             event_tx
-                .send(StreamEvent {
+                .try_send(StreamEvent {
                     content: "event".to_owned(),
                     sequence_number: event.sequence_number().expect("event should be numbered"),
                 })

--- a/crates/agentic-server-core/src/executor/gateway.rs
+++ b/crates/agentic-server-core/src/executor/gateway.rs
@@ -1,33 +1,54 @@
 use std::num::NonZeroUsize;
+use std::sync::Arc;
 use std::time::Duration;
 
 use futures::future::join_all;
-use tokio::sync::Semaphore;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 use crate::config::DEFAULT_MAX_CONCURRENT_GATEWAY_CALLS;
 use crate::events::SSEEventType;
 use crate::executor::error::{ExecutorError, ExecutorResult};
 use crate::executor::gateway_accumulator::{GatewayStreamAccumulator, StreamEvent, emit_sse_frame, synthetic_event};
 use crate::executor::request::RequestContext;
+use crate::executor::response_budget::ExecutorResponseBudget;
+use crate::tool::handler::MAX_GATEWAY_TOOL_OUTPUT_BYTES;
 use crate::tool::{GatewayBinding, ToolError, ToolOutput, ToolOwnership, ToolRegistry};
 use crate::types::io::output::{FunctionToolCall, GatewayCallStatus, McpCallStatus};
 use crate::types::io::{InputItem, OutputItem, ResponsesInput};
 use crate::types::request_response::ResponsePayload;
 use crate::utils::common::{serialize_to_string, serialize_to_value};
 
+pub(super) const MAX_CONCURRENT_MATERIALIZATIONS: usize = 16;
+
 /// Request-independent execution policy owned by one [`ExecutionContext`].
 ///
-/// The nonzero type makes `.buffered(0)` unrepresentable. Distinct execution
-/// contexts retain their own limits instead of sharing process-global state.
-#[derive(Debug, Clone, Copy)]
+/// The nonzero type prevents a zero-capacity per-request semaphore. Distinct
+/// execution contexts retain their own limits instead of sharing process-global state.
+#[derive(Debug, Clone)]
 pub(crate) struct GatewaySchedulerPolicy {
     max_concurrent_calls: NonZeroUsize,
+    materialization_permits: Arc<Semaphore>,
 }
 
 impl GatewaySchedulerPolicy {
     #[must_use]
-    pub(crate) const fn new(max_concurrent_calls: NonZeroUsize) -> Self {
-        Self { max_concurrent_calls }
+    pub(crate) fn new(max_concurrent_calls: NonZeroUsize) -> Self {
+        // Each permit protects one handler whose output is capped at
+        // MAX_GATEWAY_TOOL_OUTPUT_BYTES. The policy is cloned with an
+        // ExecutionContext, so this bound is shared by concurrent requests
+        // (including WebSocket lanes) instead of being recreated per turn.
+        Self {
+            max_concurrent_calls,
+            materialization_permits: Arc::new(Semaphore::new(MAX_CONCURRENT_MATERIALIZATIONS)),
+        }
+    }
+
+    /// Acquires one process-wide materialization slot shared by cloned execution contexts.
+    pub(crate) async fn acquire_materialization_permit(self) -> OwnedSemaphorePermit {
+        self.materialization_permits
+            .acquire_owned()
+            .await
+            .expect("materialization semaphore is never closed")
     }
 }
 
@@ -212,13 +233,21 @@ impl GatewayScheduler {
 
     /// Executes planned calls under the bounded-concurrency policy and records
     /// each tool's completed public lifecycle on the same slot.
+    #[cfg(test)]
     pub(super) async fn execute(&mut self) -> ExecutorResult<Vec<GatewayCallResult>> {
+        self.execute_with_budget(&ExecutorResponseBudget::new()).await
+    }
+
+    pub(super) async fn execute_with_budget(
+        &mut self,
+        response_budget: &ExecutorResponseBudget,
+    ) -> ExecutorResult<Vec<GatewayCallResult>> {
         let execution_slots = Semaphore::new(self.policy.max_concurrent_calls.get());
         let results = join_all(
             self.calls
                 .iter()
                 .cloned()
-                .map(|call| self.run_one(call, &execution_slots)),
+                .map(|call| self.run_one(call, &execution_slots, response_budget)),
         )
         .await
         .into_iter()
@@ -232,7 +261,12 @@ impl GatewayScheduler {
         Ok(results)
     }
 
-    async fn run_one(&self, plan: GatewayCallPlan, execution_slots: &Semaphore) -> ExecutorResult<GatewayCallResult> {
+    async fn run_one(
+        &self,
+        plan: GatewayCallPlan,
+        execution_slots: &Semaphore,
+        response_budget: &ExecutorResponseBudget,
+    ) -> ExecutorResult<GatewayCallResult> {
         let GatewayCallPlan {
             item_index,
             call,
@@ -244,6 +278,7 @@ impl GatewayScheduler {
                 &call,
                 &format!("gateway tool '{}' has no registered handler", call.name),
             )?;
+            response_budget.consume(output.output.len())?;
             return Ok(GatewayCallResult {
                 item_index,
                 input_item: InputItem::FunctionCallOutput(output.into()),
@@ -256,6 +291,7 @@ impl GatewayScheduler {
             None => None,
         };
         let _execution_slot = execution_slots.acquire().await.expect("semaphore is never closed");
+        let _materialization_permit = self.policy.clone().acquire_materialization_permit().await;
 
         let dispatched = if self.timeout.is_zero() {
             binding.execute(&call.call_id, &call.name, &call.arguments).await
@@ -273,6 +309,13 @@ impl GatewayScheduler {
                 ))),
             }
         };
+        match &dispatched {
+            Ok(output) => enforce_gateway_tool_output_size(output.output.len())?,
+            Err(ToolError::Execution(message) | ToolError::Config(message)) => {
+                enforce_gateway_tool_output_size(message.len())?;
+            }
+            Err(ToolError::MissingOutput { .. }) => {}
+        }
         let (output, status) = match dispatched {
             Ok(output) => (output, GatewayCallStatus::Completed),
             Err(ToolError::Execution(message) | ToolError::Config(message)) => {
@@ -280,6 +323,7 @@ impl GatewayScheduler {
             }
             Err(error @ ToolError::MissingOutput { .. }) => return Err(ExecutorError::from(error)),
         };
+        response_budget.consume(output.output.len())?;
         let public_output = binding.public_output(&call, &output, status);
         Ok(GatewayCallResult {
             item_index,
@@ -287,6 +331,15 @@ impl GatewayScheduler {
             public_output,
         })
     }
+}
+
+fn enforce_gateway_tool_output_size(bytes: usize) -> ExecutorResult<()> {
+    if bytes > MAX_GATEWAY_TOOL_OUTPUT_BYTES {
+        return Err(ExecutorError::StreamError(format!(
+            "gateway tool output exceeded {MAX_GATEWAY_TOOL_OUTPUT_BYTES} bytes"
+        )));
+    }
+    Ok(())
 }
 
 pub(super) fn has_client_owned_calls(output_items: &[OutputItem], registry: &ToolRegistry) -> bool {
@@ -365,10 +418,10 @@ fn output_item_value(item: &OutputItem) -> ExecutorResult<serde_json::Value> {
     serde_json::to_value(item).map_err(ExecutorError::JsonError)
 }
 
-pub(super) fn emit_response_start_events(
+pub(super) async fn emit_response_start_events(
     payload: &ResponsePayload,
     stream_accumulator: &mut GatewayStreamAccumulator,
-    stream_sender: &tokio::sync::mpsc::UnboundedSender<StreamEvent>,
+    stream_sender: &tokio::sync::mpsc::Sender<StreamEvent>,
 ) -> ExecutorResult<()> {
     let mut response = payload.clone();
     "in_progress".clone_into(&mut response.status);
@@ -377,7 +430,7 @@ pub(super) fn emit_response_start_events(
     let response = serialize_to_value(&response).map_err(ExecutorError::JsonError)?;
     for event_type in [SSEEventType::ResponseCreated, SSEEventType::ResponseInProgress] {
         let mut event = synthetic_event(event_type, [("response".to_owned(), response.clone())])?;
-        emit_gateway_event(&mut event, stream_accumulator, stream_sender)?;
+        emit_gateway_event(&mut event, stream_accumulator, stream_sender).await?;
     }
     Ok(())
 }
@@ -389,10 +442,10 @@ fn complete_gateway_event_plans<T: GatewayPublicOutputSource>(plans: &mut [Gatew
     }
 }
 
-pub(super) fn emit_gateway_start_events<'a>(
+pub(super) async fn emit_gateway_start_events<'a>(
     plans: impl IntoIterator<Item = &'a GatewayEventPlan>,
     stream_accumulator: &mut GatewayStreamAccumulator,
-    stream_sender: &tokio::sync::mpsc::UnboundedSender<StreamEvent>,
+    stream_sender: &tokio::sync::mpsc::Sender<StreamEvent>,
 ) -> ExecutorResult<()> {
     for plan in plans {
         let Some(output_item) = &plan.started_output else {
@@ -406,7 +459,7 @@ pub(super) fn emit_gateway_start_events<'a>(
                 ("item".to_owned(), item),
             ],
         )?;
-        emit_gateway_event(&mut added_event, stream_accumulator, stream_sender)?;
+        emit_gateway_event(&mut added_event, stream_accumulator, stream_sender).await?;
         match output_item {
             OutputItem::WebSearchCall(web_search_call) => {
                 let mut in_progress_event = synthetic_event(
@@ -416,7 +469,7 @@ pub(super) fn emit_gateway_start_events<'a>(
                         ("output_index".to_owned(), serde_json::json!(plan.output_index)),
                     ],
                 )?;
-                emit_gateway_event(&mut in_progress_event, stream_accumulator, stream_sender)?;
+                emit_gateway_event(&mut in_progress_event, stream_accumulator, stream_sender).await?;
                 let mut searching_event = synthetic_event(
                     SSEEventType::WebSearchCallSearching,
                     [
@@ -424,7 +477,7 @@ pub(super) fn emit_gateway_start_events<'a>(
                         ("output_index".to_owned(), serde_json::json!(plan.output_index)),
                     ],
                 )?;
-                emit_gateway_event(&mut searching_event, stream_accumulator, stream_sender)?;
+                emit_gateway_event(&mut searching_event, stream_accumulator, stream_sender).await?;
             }
             OutputItem::McpCall(mcp_call) => {
                 let mut in_progress_event = synthetic_event(
@@ -434,7 +487,7 @@ pub(super) fn emit_gateway_start_events<'a>(
                         ("output_index".to_owned(), serde_json::json!(plan.output_index)),
                     ],
                 )?;
-                emit_gateway_event(&mut in_progress_event, stream_accumulator, stream_sender)?;
+                emit_gateway_event(&mut in_progress_event, stream_accumulator, stream_sender).await?;
                 let arguments = plan.arguments.as_deref().unwrap_or_default();
                 let mut arguments_delta_event = synthetic_event(
                     SSEEventType::McpCallArgumentsDelta,
@@ -444,7 +497,7 @@ pub(super) fn emit_gateway_start_events<'a>(
                         ("output_index".to_owned(), serde_json::json!(plan.output_index)),
                     ],
                 )?;
-                emit_gateway_event(&mut arguments_delta_event, stream_accumulator, stream_sender)?;
+                emit_gateway_event(&mut arguments_delta_event, stream_accumulator, stream_sender).await?;
                 let mut arguments_done_event = synthetic_event(
                     SSEEventType::McpCallArgumentsDone,
                     [
@@ -453,7 +506,7 @@ pub(super) fn emit_gateway_start_events<'a>(
                         ("output_index".to_owned(), serde_json::json!(plan.output_index)),
                     ],
                 )?;
-                emit_gateway_event(&mut arguments_done_event, stream_accumulator, stream_sender)?;
+                emit_gateway_event(&mut arguments_done_event, stream_accumulator, stream_sender).await?;
             }
             OutputItem::McpListTools(list_tools) => {
                 let mut in_progress_event = synthetic_event(
@@ -463,7 +516,7 @@ pub(super) fn emit_gateway_start_events<'a>(
                         ("output_index".to_owned(), serde_json::json!(plan.output_index)),
                     ],
                 )?;
-                emit_gateway_event(&mut in_progress_event, stream_accumulator, stream_sender)?;
+                emit_gateway_event(&mut in_progress_event, stream_accumulator, stream_sender).await?;
             }
             OutputItem::Message(_)
             | OutputItem::FunctionCall(_)
@@ -476,11 +529,11 @@ pub(super) fn emit_gateway_start_events<'a>(
     Ok(())
 }
 
-pub(super) fn emit_gateway_completed_events<'a, T: GatewayPublicOutputSource>(
+pub(super) async fn emit_gateway_completed_events<'a, T: GatewayPublicOutputSource>(
     results: &[T],
     plans: impl IntoIterator<Item = &'a GatewayEventPlan>,
     stream_accumulator: &mut GatewayStreamAccumulator,
-    stream_sender: &tokio::sync::mpsc::UnboundedSender<StreamEvent>,
+    stream_sender: &tokio::sync::mpsc::Sender<StreamEvent>,
 ) -> ExecutorResult<()> {
     for (index, plan) in plans.into_iter().enumerate() {
         let Some(public_output) = plan
@@ -528,7 +581,7 @@ pub(super) fn emit_gateway_completed_events<'a, T: GatewayPublicOutputSource>(
                 completed_fields.insert("item".to_owned(), item.clone());
             }
             let mut completed_event = synthetic_event(event_type, completed_fields)?;
-            emit_gateway_event(&mut completed_event, stream_accumulator, stream_sender)?;
+            emit_gateway_event(&mut completed_event, stream_accumulator, stream_sender).await?;
         }
         let mut done_event = synthetic_event(
             SSEEventType::OutputItemDone,
@@ -537,7 +590,7 @@ pub(super) fn emit_gateway_completed_events<'a, T: GatewayPublicOutputSource>(
                 ("item".to_owned(), item),
             ],
         )?;
-        emit_gateway_event(&mut done_event, stream_accumulator, stream_sender)?;
+        emit_gateway_event(&mut done_event, stream_accumulator, stream_sender).await?;
     }
     Ok(())
 }
@@ -547,34 +600,33 @@ pub(super) async fn execute_and_emit_output_calls(
     registry: &ToolRegistry,
     output_offset: usize,
     policy: GatewaySchedulerPolicy,
-    mut stream: Option<(
-        &mut GatewayStreamAccumulator,
-        &tokio::sync::mpsc::UnboundedSender<StreamEvent>,
-    )>,
+    response_budget: &ExecutorResponseBudget,
+    mut stream: Option<(&mut GatewayStreamAccumulator, &tokio::sync::mpsc::Sender<StreamEvent>)>,
 ) -> ExecutorResult<Vec<GatewayCallResult>> {
     let mut scheduler = GatewayScheduler::plan(output_items, registry, output_offset, policy);
     if let Some((stream_accumulator, stream_sender)) = stream.as_mut() {
-        emit_gateway_start_events(scheduler.event_plans(), stream_accumulator, stream_sender)?;
+        emit_gateway_start_events(scheduler.event_plans(), stream_accumulator, stream_sender).await?;
     }
-    let gateway_results = scheduler.execute().await?;
+    let gateway_results = scheduler.execute_with_budget(response_budget).await?;
     if let Some((stream_accumulator, stream_sender)) = stream.as_mut() {
         emit_gateway_completed_events(
             &gateway_results,
             scheduler.event_plans(),
             stream_accumulator,
             stream_sender,
-        )?;
+        )
+        .await?;
     }
     Ok(gateway_results)
 }
 
-fn emit_gateway_event(
+async fn emit_gateway_event(
     frame: &mut crate::events::EventFrame,
     stream_accumulator: &mut GatewayStreamAccumulator,
-    stream_sender: &tokio::sync::mpsc::UnboundedSender<StreamEvent>,
+    stream_sender: &tokio::sync::mpsc::Sender<StreamEvent>,
 ) -> ExecutorResult<()> {
     if stream_accumulator.process_event(frame, 0) {
-        emit_sse_frame(stream_sender, frame)?;
+        emit_sse_frame(stream_sender, frame).await?;
     }
     Ok(())
 }
@@ -625,7 +677,7 @@ mod tests {
     use crate::executor::accumulator::ResponseAccumulator;
     use crate::types::io::output::{FunctionToolCall, McpListTool, McpListTools};
     use crate::types::io::{CompactionItem, InputItem, McpCallStatus};
-    use tokio::sync::{Notify, mpsc};
+    use tokio::sync::{Notify, Semaphore, mpsc};
 
     fn parse_named_sse_event(content: &str) -> Value {
         let body = content.strip_suffix("\n\n").expect("SSE event terminator");
@@ -640,10 +692,15 @@ mod tests {
     use std::num::NonZeroUsize;
     use std::pin::Pin;
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     use serde_json::Value;
 
-    use super::{GatewayCallPlan, GatewayEventPlan, GatewayExecutionPlan, GatewayScheduler, GatewaySchedulerPolicy};
+    use super::{
+        GatewayCallPlan, GatewayEventPlan, GatewayExecutionPlan, GatewayScheduler, GatewaySchedulerPolicy,
+        MAX_CONCURRENT_MATERIALIZATIONS,
+    };
+    use crate::executor::response_budget::ExecutorResponseBudget;
     use crate::tool::{
         GatewayBinding, GatewayExecutor, GatewayExecutors, GatewayToolEventPlan, ToolError, ToolHandler, ToolOutput,
         ToolRegistry, ToolType,
@@ -707,6 +764,173 @@ mod tests {
             _params: &WebSearchToolParam,
         ) -> Option<OutputItem> {
             crate::tool::web_search::output_item(call, output, status)
+        }
+    }
+
+    struct SizedOutputExecutor {
+        bytes: usize,
+    }
+
+    impl ToolHandler for SizedOutputExecutor {
+        type ToolParams = WebSearchToolParam;
+
+        fn tool_type(&self) -> ToolType {
+            ToolType::WebSearch
+        }
+
+        fn validate(&self, _params: &WebSearchToolParam) -> Result<(), ToolError> {
+            Ok(())
+        }
+
+        fn normalize(&self, _params: &WebSearchToolParam) -> Vec<FunctionTool> {
+            Vec::new()
+        }
+    }
+
+    impl GatewayExecutor for SizedOutputExecutor {
+        type ExecutionParams = WebSearchToolParam;
+
+        fn execute(
+            &self,
+            call_id: &str,
+            _tool_name: &str,
+            _arguments: &str,
+            _params: &WebSearchToolParam,
+        ) -> Pin<Box<dyn Future<Output = Result<ToolOutput, ToolError>> + Send + '_>> {
+            let call_id = call_id.to_owned();
+            let bytes = self.bytes;
+            Box::pin(async move {
+                Ok(ToolOutput {
+                    call_id,
+                    output: "x".repeat(bytes),
+                })
+            })
+        }
+
+        fn supports_parallel_execution(&self) -> bool {
+            true
+        }
+
+        fn public_output(
+            &self,
+            call: &FunctionToolCall,
+            output: &ToolOutput,
+            status: GatewayCallStatus,
+            _params: &WebSearchToolParam,
+        ) -> Option<OutputItem> {
+            crate::tool::web_search::output_item(call, output, status)
+        }
+    }
+
+    struct DrainTrackingExecutor {
+        slow_call_finished: Arc<AtomicBool>,
+    }
+
+    impl ToolHandler for DrainTrackingExecutor {
+        type ToolParams = WebSearchToolParam;
+
+        fn tool_type(&self) -> ToolType {
+            ToolType::WebSearch
+        }
+
+        fn validate(&self, _params: &WebSearchToolParam) -> Result<(), ToolError> {
+            Ok(())
+        }
+
+        fn normalize(&self, _params: &WebSearchToolParam) -> Vec<FunctionTool> {
+            Vec::new()
+        }
+    }
+
+    impl GatewayExecutor for DrainTrackingExecutor {
+        type ExecutionParams = WebSearchToolParam;
+
+        fn execute(
+            &self,
+            call_id: &str,
+            _tool_name: &str,
+            _arguments: &str,
+            _params: &WebSearchToolParam,
+        ) -> Pin<Box<dyn Future<Output = Result<ToolOutput, ToolError>> + Send + '_>> {
+            let call_id = call_id.to_owned();
+            let slow_call_finished = Arc::clone(&self.slow_call_finished);
+            Box::pin(async move {
+                let output = if call_id == "call_fail" {
+                    "x".repeat(crate::tool::handler::MAX_GATEWAY_TOOL_OUTPUT_BYTES + 1)
+                } else {
+                    tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+                    slow_call_finished.store(true, Ordering::SeqCst);
+                    "ok".to_owned()
+                };
+                Ok(ToolOutput { call_id, output })
+            })
+        }
+
+        fn supports_parallel_execution(&self) -> bool {
+            true
+        }
+    }
+
+    struct MaterializationProbeExecutor {
+        active: Arc<AtomicUsize>,
+        peak: Arc<AtomicUsize>,
+        entered: mpsc::Sender<()>,
+        release: Arc<Semaphore>,
+    }
+
+    impl ToolHandler for MaterializationProbeExecutor {
+        type ToolParams = WebSearchToolParam;
+
+        fn tool_type(&self) -> ToolType {
+            ToolType::WebSearch
+        }
+
+        fn validate(&self, _params: &WebSearchToolParam) -> Result<(), ToolError> {
+            Ok(())
+        }
+
+        fn normalize(&self, _params: &WebSearchToolParam) -> Vec<FunctionTool> {
+            Vec::new()
+        }
+    }
+
+    impl GatewayExecutor for MaterializationProbeExecutor {
+        type ExecutionParams = WebSearchToolParam;
+
+        fn execute(
+            &self,
+            call_id: &str,
+            _tool_name: &str,
+            _arguments: &str,
+            _params: &WebSearchToolParam,
+        ) -> Pin<Box<dyn Future<Output = Result<ToolOutput, ToolError>> + Send + '_>> {
+            let call_id = call_id.to_owned();
+            let active = Arc::clone(&self.active);
+            let peak = Arc::clone(&self.peak);
+            let entered = self.entered.clone();
+            let release = Arc::clone(&self.release);
+            Box::pin(async move {
+                let active_now = active.fetch_add(1, Ordering::SeqCst) + 1;
+                peak.fetch_max(active_now, Ordering::SeqCst);
+                entered
+                    .send(())
+                    .await
+                    .map_err(|error| ToolError::Execution(format!("materialization probe receiver closed: {error}")))?;
+                let permit = release
+                    .acquire()
+                    .await
+                    .map_err(|error| ToolError::Execution(format!("materialization probe closed: {error}")))?;
+                permit.forget();
+                active.fetch_sub(1, Ordering::SeqCst);
+                Ok(ToolOutput {
+                    call_id,
+                    output: "ok".to_owned(),
+                })
+            })
+        }
+
+        fn supports_parallel_execution(&self) -> bool {
+            true
         }
     }
 
@@ -794,6 +1018,125 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn gateway_results_share_one_aggregate_response_budget() {
+        let web_search: ResponsesTool =
+            serde_json::from_value(serde_json::json!({"type": "web_search_preview"})).expect("web_search tool param");
+        let mut executors = GatewayExecutors::default();
+        executors.insert(Arc::new(SizedOutputExecutor {
+            bytes: crate::executor::response_budget::MAX_EXECUTOR_RESPONSE_BYTES / 2 + 1,
+        }));
+        let mut tools = [web_search];
+        let registry = ToolRegistry::build_with_handlers(&mut tools, &mut executors)
+            .await
+            .expect("registry builds");
+        let output_items = [
+            OutputItem::FunctionCall(web_search_call("call_a")),
+            OutputItem::FunctionCall(web_search_call("call_b")),
+        ];
+        let mut scheduler = GatewayScheduler::plan(&output_items, &registry, 0, GatewaySchedulerPolicy::default());
+        let response_budget = ExecutorResponseBudget::new();
+
+        let error = scheduler
+            .execute_with_budget(&response_budget)
+            .await
+            .err()
+            .expect("aggregate gateway output must be bounded");
+        assert!(error.to_string().contains("executor response budget exceeded"));
+    }
+
+    #[tokio::test]
+    async fn gateway_scheduler_drains_started_calls_before_returning_an_error() {
+        let slow_call_finished = Arc::new(AtomicBool::new(false));
+        let web_search: ResponsesTool =
+            serde_json::from_value(serde_json::json!({"type": "web_search_preview"})).expect("web_search tool param");
+        let mut executors = GatewayExecutors::default();
+        executors.insert(Arc::new(DrainTrackingExecutor {
+            slow_call_finished: Arc::clone(&slow_call_finished),
+        }));
+        let mut tools = [web_search];
+        let registry = ToolRegistry::build_with_handlers(&mut tools, &mut executors)
+            .await
+            .expect("registry builds");
+        let output_items = [
+            OutputItem::FunctionCall(web_search_call("call_fail")),
+            OutputItem::FunctionCall(web_search_call("call_slow")),
+        ];
+        let mut scheduler = GatewayScheduler::plan(&output_items, &registry, 0, GatewaySchedulerPolicy::default());
+
+        let error = scheduler.execute().await.err().expect("oversized output must fail");
+
+        assert!(error.to_string().contains("gateway tool output exceeded"));
+        assert!(
+            slow_call_finished.load(Ordering::SeqCst),
+            "a peer call started in the same batch must be drained before the scheduler returns"
+        );
+    }
+
+    #[tokio::test]
+    async fn cloned_gateway_policies_share_the_materialization_limit() {
+        const CALLS_PER_SCHEDULER: usize = MAX_CONCURRENT_MATERIALIZATIONS / 2 + 1;
+        const TOTAL_CALLS: usize = CALLS_PER_SCHEDULER * 2;
+
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let release = Arc::new(Semaphore::new(0));
+        let (entered_tx, mut entered_rx) = mpsc::channel(TOTAL_CALLS);
+        let web_search: ResponsesTool =
+            serde_json::from_value(serde_json::json!({"type": "web_search_preview"})).expect("web_search tool param");
+        let mut executors = GatewayExecutors::default();
+        executors.insert(Arc::new(MaterializationProbeExecutor {
+            active: Arc::clone(&active),
+            peak: Arc::clone(&peak),
+            entered: entered_tx,
+            release: Arc::clone(&release),
+        }));
+        let mut tools = [web_search];
+        let registry = ToolRegistry::build_with_handlers(&mut tools, &mut executors)
+            .await
+            .expect("registry builds");
+        let first_items = (0..CALLS_PER_SCHEDULER)
+            .map(|index| OutputItem::FunctionCall(web_search_call(&format!("first_{index}"))))
+            .collect::<Vec<_>>();
+        let second_items = (0..CALLS_PER_SCHEDULER)
+            .map(|index| OutputItem::FunctionCall(web_search_call(&format!("second_{index}"))))
+            .collect::<Vec<_>>();
+        let policy = GatewaySchedulerPolicy::new(NonZeroUsize::new(TOTAL_CALLS).expect("nonzero call count"));
+        let mut first = GatewayScheduler::plan(&first_items, &registry, 0, policy.clone());
+        let mut second = GatewayScheduler::plan(&second_items, &registry, 0, policy);
+
+        let first_task = tokio::spawn(async move { first.execute().await });
+        let second_task = tokio::spawn(async move { second.execute().await });
+
+        for _ in 0..MAX_CONCURRENT_MATERIALIZATIONS {
+            tokio::time::timeout(std::time::Duration::from_secs(1), entered_rx.recv())
+                .await
+                .expect("the shared materialization window should fill")
+                .expect("probe sender should remain open");
+        }
+        assert_eq!(peak.load(Ordering::SeqCst), MAX_CONCURRENT_MATERIALIZATIONS);
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(50), entered_rx.recv())
+                .await
+                .is_err(),
+            "materialization started beyond the shared limit of {MAX_CONCURRENT_MATERIALIZATIONS}"
+        );
+
+        release.add_permits(TOTAL_CALLS);
+        let first_results = first_task
+            .await
+            .expect("first scheduler should not panic")
+            .expect("first scheduler");
+        let second_results = second_task
+            .await
+            .expect("second scheduler should not panic")
+            .expect("second scheduler");
+
+        assert_eq!(first_results.len() + second_results.len(), TOTAL_CALLS);
+        assert_eq!(peak.load(Ordering::SeqCst), MAX_CONCURRENT_MATERIALIZATIONS);
+        assert_eq!(active.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
     async fn scheduler_retains_event_slot_for_gateway_tool_without_handler() {
         let file_search: ResponsesTool = serde_json::from_value(serde_json::json!({
             "type": "file_search",
@@ -834,11 +1177,13 @@ mod tests {
         assert_eq!(results[1].item_index, 1);
         assert!(matches!(results[1].public_output, Some(OutputItem::WebSearchCall(_))));
 
-        let (sender, mut receiver) = mpsc::unbounded_channel();
+        let (sender, mut receiver) = mpsc::channel(32);
         let mut stream_accumulator = crate::executor::gateway_accumulator::GatewayStreamAccumulator::new();
         super::emit_gateway_start_events(scheduler.event_plans(), &mut stream_accumulator, &sender)
+            .await
             .expect("start events");
         super::emit_gateway_completed_events(&results, scheduler.event_plans(), &mut stream_accumulator, &sender)
+            .await
             .expect("completed events");
 
         let events = std::iter::from_fn(|| receiver.try_recv().ok())
@@ -1156,8 +1501,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn mcp_list_tools_uses_shared_gateway_event_lifecycle() {
+    #[tokio::test]
+    async fn mcp_list_tools_uses_shared_gateway_event_lifecycle() {
         let list_tools = McpListTools::new(
             "mcpl_1",
             "counter",
@@ -1171,7 +1516,7 @@ mod tests {
         let discovered_output = crate::tool::mcp::handler::list_tools_output_item(&list_tools);
         let public_output = super::public_output_items(&[discovered_output], &ToolRegistry::default(), &[]);
         let plans = super::mcp_list_tools_event_plans(&public_output, 0);
-        let (sender, mut receiver) = mpsc::unbounded_channel();
+        let (sender, mut receiver) = mpsc::channel(32);
         let mut stream_accumulator = crate::executor::gateway_accumulator::GatewayStreamAccumulator::new();
         stream_accumulator
             .process_sse_line(r#"data: {"type":"response.created"}"#, 0)
@@ -1180,8 +1525,11 @@ mod tests {
             .process_sse_line(r#"data: {"type":"response.in_progress"}"#, 0)
             .expect("response.in_progress");
 
-        super::emit_gateway_start_events(&plans, &mut stream_accumulator, &sender).expect("start events");
+        super::emit_gateway_start_events(&plans, &mut stream_accumulator, &sender)
+            .await
+            .expect("start events");
         super::emit_gateway_completed_events(&public_output, &plans, &mut stream_accumulator, &sender)
+            .await
             .expect("completed events");
 
         let events = std::iter::from_fn(|| receiver.try_recv().ok())
@@ -1210,18 +1558,21 @@ mod tests {
         assert_eq!(events[3]["item"]["tools"][0]["name"], "increment");
     }
 
-    #[test]
-    fn compaction_uses_shared_gateway_event_lifecycle_without_intermediate_event() {
+    #[tokio::test]
+    async fn compaction_uses_shared_gateway_event_lifecycle_without_intermediate_event() {
         let public_output = [OutputItem::Compaction(CompactionItem {
             id: Some("cmp_1".to_owned()),
             encrypted_content: "durable summary".to_owned(),
         })];
         let plans = super::compaction_event_plans(&public_output, 0);
-        let (sender, mut receiver) = mpsc::unbounded_channel();
+        let (sender, mut receiver) = mpsc::channel(32);
         let mut stream_accumulator = crate::executor::gateway_accumulator::GatewayStreamAccumulator::new();
 
-        super::emit_gateway_start_events(&plans, &mut stream_accumulator, &sender).expect("start events");
+        super::emit_gateway_start_events(&plans, &mut stream_accumulator, &sender)
+            .await
+            .expect("start events");
         super::emit_gateway_completed_events(&public_output, &plans, &mut stream_accumulator, &sender)
+            .await
             .expect("completed events");
 
         let chunks = std::iter::from_fn(|| receiver.try_recv().ok())
@@ -1249,8 +1600,8 @@ mod tests {
         assert!(matches!(response.output[0], OutputItem::Compaction(_)));
     }
 
-    #[test]
-    fn mcp_gateway_events_follow_openai_lifecycle() {
+    #[tokio::test]
+    async fn mcp_gateway_events_follow_openai_lifecycle() {
         let call = FunctionToolCall {
             id: "fc_1".to_owned(),
             call_id: "call_1".to_owned(),
@@ -1274,10 +1625,12 @@ mod tests {
             completed_output: None,
             arguments: Some(call.arguments.clone()),
         }];
-        let (sender, mut receiver) = mpsc::unbounded_channel();
+        let (sender, mut receiver) = mpsc::channel(32);
         let mut stream_accumulator = crate::executor::gateway_accumulator::GatewayStreamAccumulator::new();
 
-        super::emit_gateway_start_events(&plans, &mut stream_accumulator, &sender).expect("start events");
+        super::emit_gateway_start_events(&plans, &mut stream_accumulator, &sender)
+            .await
+            .expect("start events");
 
         let mut start_events = Vec::new();
         while let Ok(event) = receiver.try_recv() {
@@ -1330,6 +1683,7 @@ mod tests {
 
         super::complete_gateway_event_plans(&mut plans, &results);
         super::emit_gateway_completed_events(&results, &plans, &mut stream_accumulator, &sender)
+            .await
             .expect("completed events");
 
         let completed = receiver.try_recv().expect("mcp_call.completed");
@@ -1346,8 +1700,8 @@ mod tests {
         assert_eq!(done["item"]["output"], "1");
     }
 
-    #[test]
-    fn failed_mcp_gateway_events_keep_contiguous_sequence_numbers() {
+    #[tokio::test]
+    async fn failed_mcp_gateway_events_keep_contiguous_sequence_numbers() {
         let call = FunctionToolCall {
             id: "fc_1".to_owned(),
             call_id: "call_1".to_owned(),
@@ -1389,12 +1743,15 @@ mod tests {
                 Some(crate::types::io::McpCallError::tool_execution("boom")),
             ))),
         }];
-        let (sender, mut receiver) = mpsc::unbounded_channel();
+        let (sender, mut receiver) = mpsc::channel(32);
         let mut stream_accumulator = crate::executor::gateway_accumulator::GatewayStreamAccumulator::new();
 
-        super::emit_gateway_start_events(&plans, &mut stream_accumulator, &sender).expect("start events");
+        super::emit_gateway_start_events(&plans, &mut stream_accumulator, &sender)
+            .await
+            .expect("start events");
         super::complete_gateway_event_plans(&mut plans, &results);
         super::emit_gateway_completed_events(&results, &plans, &mut stream_accumulator, &sender)
+            .await
             .expect("failed events");
 
         let events = std::iter::from_fn(|| receiver.try_recv().ok())

--- a/crates/agentic-server-core/src/executor/gateway.rs
+++ b/crates/agentic-server-core/src/executor/gateway.rs
@@ -1,3 +1,4 @@
+use std::future::Future;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
@@ -44,11 +45,16 @@ impl GatewaySchedulerPolicy {
     }
 
     /// Acquires one process-wide materialization slot shared by cloned execution contexts.
-    pub(crate) async fn acquire_materialization_permit(self) -> OwnedSemaphorePermit {
-        self.materialization_permits
-            .acquire_owned()
-            .await
-            .expect("materialization semaphore is never closed")
+    pub(crate) fn acquire_materialization_permit(
+        &self,
+    ) -> impl Future<Output = OwnedSemaphorePermit> + Send + 'static + use<> {
+        let materialization_permits = Arc::clone(&self.materialization_permits);
+        async move {
+            materialization_permits
+                .acquire_owned()
+                .await
+                .expect("materialization semaphore is never closed")
+        }
     }
 }
 
@@ -278,6 +284,7 @@ impl GatewayScheduler {
                 &call,
                 &format!("gateway tool '{}' has no registered handler", call.name),
             )?;
+            enforce_gateway_tool_output_size(output.output.len())?;
             response_budget.consume(output.output.len())?;
             return Ok(GatewayCallResult {
                 item_index,
@@ -291,7 +298,7 @@ impl GatewayScheduler {
             None => None,
         };
         let _execution_slot = execution_slots.acquire().await.expect("semaphore is never closed");
-        let _materialization_permit = self.policy.clone().acquire_materialization_permit().await;
+        let _materialization_permit = self.policy.acquire_materialization_permit().await;
 
         let dispatched = if self.timeout.is_zero() {
             binding.execute(&call.call_id, &call.name, &call.arguments).await
@@ -309,13 +316,6 @@ impl GatewayScheduler {
                 ))),
             }
         };
-        match &dispatched {
-            Ok(output) => enforce_gateway_tool_output_size(output.output.len())?,
-            Err(ToolError::Execution(message) | ToolError::Config(message)) => {
-                enforce_gateway_tool_output_size(message.len())?;
-            }
-            Err(ToolError::MissingOutput { .. }) => {}
-        }
         let (output, status) = match dispatched {
             Ok(output) => (output, GatewayCallStatus::Completed),
             Err(ToolError::Execution(message) | ToolError::Config(message)) => {
@@ -323,6 +323,7 @@ impl GatewayScheduler {
             }
             Err(error @ ToolError::MissingOutput { .. }) => return Err(ExecutorError::from(error)),
         };
+        enforce_gateway_tool_output_size(output.output.len())?;
         response_budget.consume(output.output.len())?;
         let public_output = binding.public_output(&call, &output, status);
         Ok(GatewayCallResult {
@@ -822,6 +823,45 @@ mod tests {
         }
     }
 
+    struct SizedErrorExecutor {
+        message: String,
+    }
+
+    impl ToolHandler for SizedErrorExecutor {
+        type ToolParams = WebSearchToolParam;
+
+        fn tool_type(&self) -> ToolType {
+            ToolType::WebSearch
+        }
+
+        fn validate(&self, _params: &WebSearchToolParam) -> Result<(), ToolError> {
+            Ok(())
+        }
+
+        fn normalize(&self, _params: &WebSearchToolParam) -> Vec<FunctionTool> {
+            Vec::new()
+        }
+    }
+
+    impl GatewayExecutor for SizedErrorExecutor {
+        type ExecutionParams = WebSearchToolParam;
+
+        fn execute(
+            &self,
+            _call_id: &str,
+            _tool_name: &str,
+            _arguments: &str,
+            _params: &WebSearchToolParam,
+        ) -> Pin<Box<dyn Future<Output = Result<ToolOutput, ToolError>> + Send + '_>> {
+            let message = self.message.clone();
+            Box::pin(async move { Err(ToolError::Execution(message)) })
+        }
+
+        fn supports_parallel_execution(&self) -> bool {
+            true
+        }
+    }
+
     struct DrainTrackingExecutor {
         slow_call_finished: Arc<AtomicBool>,
     }
@@ -1042,6 +1082,30 @@ mod tests {
             .err()
             .expect("aggregate gateway output must be bounded");
         assert!(error.to_string().contains("executor response budget exceeded"));
+    }
+
+    #[tokio::test]
+    async fn gateway_scheduler_bounds_the_materialized_error_output() {
+        let web_search: ResponsesTool =
+            serde_json::from_value(serde_json::json!({"type": "web_search_preview"})).expect("web_search tool param");
+        let mut executors = GatewayExecutors::default();
+        executors.insert(Arc::new(SizedErrorExecutor {
+            message: "\"".repeat(crate::tool::handler::MAX_GATEWAY_TOOL_OUTPUT_BYTES / 2 + 1),
+        }));
+        let mut tools = [web_search];
+        let registry = ToolRegistry::build_with_handlers(&mut tools, &mut executors)
+            .await
+            .expect("registry builds");
+        let output_items = [OutputItem::FunctionCall(web_search_call("call_escaped_error"))];
+        let mut scheduler = GatewayScheduler::plan(&output_items, &registry, 0, GatewaySchedulerPolicy::default());
+
+        let error = scheduler
+            .execute()
+            .await
+            .err()
+            .expect("materialized gateway error output must be bounded");
+
+        assert!(error.to_string().contains("gateway tool output exceeded"));
     }
 
     #[tokio::test]

--- a/crates/agentic-server-core/src/executor/gateway_accumulator.rs
+++ b/crates/agentic-server-core/src/executor/gateway_accumulator.rs
@@ -16,6 +16,11 @@ pub(super) struct StreamEvent {
     pub(super) sequence_number: u64,
 }
 
+/// Executor streams keep only a small number of bounded-size events ahead of
+/// their consumer so downstream backpressure also pauses upstream reads.
+pub(super) const STREAM_EVENT_BUFFER: usize = 1;
+const MAX_STREAM_EVENT_BYTES: usize = 1024 * 1024;
+
 impl GatewayStreamAccumulator {
     #[must_use]
     pub fn new() -> Self {
@@ -48,14 +53,23 @@ impl GatewayStreamAccumulator {
     pub(crate) fn terminal_response_chunk(&mut self, payload: &ResponsePayload) -> ExecutorResult<String> {
         let mut frame = terminal_response_frame(payload)?;
         self.stamp_event(&mut frame, 0);
-        serialize_sse_frame(&frame)
+        checked_stream_event(&frame)
     }
 
+    #[cfg(test)]
     pub(crate) fn executor_error_chunk(&mut self, error: &ExecutorError) -> String {
         let mut frame = executor_error_frame(error);
         self.stamp_event(&mut frame, 0);
-        serialize_sse_frame(&frame)
+        checked_stream_event(&frame)
             .unwrap_or_else(|_| error_sse_chunk(&error.to_string(), frame.sequence_number().unwrap_or(0)))
+    }
+
+    pub(crate) fn executor_error_chunk_at(error: &ExecutorError, sequence_number: u64) -> String {
+        let mut frame = executor_error_frame(error);
+        frame.wire.sequence_number = Some(sequence_number);
+        checked_stream_event(&frame).unwrap_or_else(|_| {
+            error_sse_chunk("executor error event exceeded the response size limit", sequence_number)
+        })
     }
 
     fn should_emit_lifecycle(&mut self, event_type: SSEEventType) -> bool {
@@ -156,19 +170,31 @@ pub(super) fn synthetic_event(
         .ok_or_else(|| ExecutorError::StreamError("synthetic event has no wire representation".to_owned()))
 }
 
-pub(super) fn emit_sse_frame(
-    sender: &tokio::sync::mpsc::UnboundedSender<StreamEvent>,
+pub(super) async fn emit_sse_frame(
+    sender: &tokio::sync::mpsc::Sender<StreamEvent>,
     frame: &EventFrame,
 ) -> ExecutorResult<()> {
     let sequence_number = frame
         .sequence_number()
         .ok_or_else(|| ExecutorError::StreamError("stream event has no sequence number".to_owned()))?;
+    let content = checked_stream_event(frame)?;
     sender
         .send(StreamEvent {
-            content: serialize_sse_frame(frame)?,
+            content,
             sequence_number,
         })
+        .await
         .map_err(|_| ExecutorError::StreamError("stream receiver closed while emitting gateway event".to_owned()))
+}
+
+fn checked_stream_event(frame: &EventFrame) -> ExecutorResult<String> {
+    let content = serialize_sse_frame(frame)?;
+    if content.len() > MAX_STREAM_EVENT_BYTES {
+        return Err(ExecutorError::StreamError(format!(
+            "stream event exceeded {MAX_STREAM_EVENT_BYTES} bytes"
+        )));
+    }
+    Ok(content)
 }
 
 fn serialize_sse_frame(frame: &EventFrame) -> ExecutorResult<String> {
@@ -230,6 +256,82 @@ mod tests {
         assert_eq!(event["type"], "error");
         assert_eq!(event["sequence_number"], 7);
         assert_eq!(event["error"]["message"], "task failed: \"unexpected\"\nretry");
+    }
+
+    #[test]
+    fn executor_error_chunk_uses_the_consumers_next_sequence_number() {
+        let error = ExecutorError::StreamError("buffer limit".to_owned());
+        let chunk = GatewayStreamAccumulator::executor_error_chunk_at(&error, 4);
+        let (event_name, event) = parse_named_sse_event(&chunk);
+
+        assert_eq!(event_name, "error");
+        assert_eq!(event["sequence_number"], 4);
+    }
+
+    fn test_stream_event(sequence_number: u64) -> EventFrame {
+        let mut wire = WireEvent::new("test.event");
+        wire.sequence_number = Some(sequence_number);
+        EventFrame {
+            event_type: SSEEventType::Other,
+            payload: EventPayload::None,
+            wire,
+        }
+    }
+
+    #[tokio::test]
+    async fn stream_event_sender_waits_for_bounded_capacity() {
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
+        emit_sse_frame(&sender, &test_stream_event(0))
+            .await
+            .expect("first event should fill the channel");
+
+        let blocked_sender = sender.clone();
+        let blocked = tokio::spawn(async move { emit_sse_frame(&blocked_sender, &test_stream_event(1)).await });
+        tokio::task::yield_now().await;
+        assert!(
+            !blocked.is_finished(),
+            "second event should wait for downstream capacity"
+        );
+
+        receiver.recv().await.expect("first buffered event");
+        blocked
+            .await
+            .expect("event task should not panic")
+            .expect("event should send after capacity is released");
+    }
+
+    #[tokio::test]
+    async fn bounded_stream_event_sender_handles_large_healthy_bursts() {
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(STREAM_EVENT_BUFFER);
+        let producer = tokio::spawn(async move {
+            for sequence_number in 0..300 {
+                emit_sse_frame(&sender, &test_stream_event(sequence_number))
+                    .await
+                    .expect("drained event channel should remain writable");
+            }
+        });
+
+        for expected_sequence_number in 0..300 {
+            let event = receiver.recv().await.expect("all burst events should arrive");
+            assert_eq!(event.sequence_number, expected_sequence_number);
+        }
+        producer.await.expect("producer should not panic");
+    }
+
+    #[tokio::test]
+    async fn oversized_stream_event_fails_before_enqueue() {
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
+        let mut frame = test_stream_event(0);
+        frame
+            .wire
+            .rest
+            .insert("delta".to_owned(), Value::String("x".repeat(MAX_STREAM_EVENT_BYTES)));
+
+        let error = emit_sse_frame(&sender, &frame)
+            .await
+            .expect_err("oversized event must be rejected");
+        assert!(error.to_string().contains("stream event exceeded"));
+        assert!(receiver.try_recv().is_err());
     }
 
     #[test]

--- a/crates/agentic-server-core/src/executor/inference.rs
+++ b/crates/agentic-server-core/src/executor/inference.rs
@@ -10,6 +10,7 @@ use async_stream::stream;
 use futures::{Stream, StreamExt};
 
 use crate::executor::error::{ExecutorError, ExecutorResult};
+use crate::executor::response_budget::MAX_EXECUTOR_RESPONSE_BYTES;
 use crate::proxy::processed_response_headers;
 
 /// SSE stream of raw lines sent to the client (`data: …\n\n` per event).
@@ -17,6 +18,7 @@ pub type BoxStream = std::pin::Pin<Box<dyn Stream<Item = String> + Send>>;
 
 /// Wire-format marker signalling end-of-stream to the client.
 pub(super) const DONE_MARKER: &str = "data: [DONE]\n\n";
+const MAX_SSE_LINE_BYTES: usize = 256 * 1024;
 
 /// Fetch the next raw bytes chunk from a streaming response.
 ///
@@ -36,9 +38,14 @@ where
     item.transpose().map_err(ExecutorError::NetworkError)
 }
 
-fn drain_complete_utf8_lines(buffer: &mut Vec<u8>) -> Vec<String> {
+fn drain_complete_utf8_lines(buffer: &mut Vec<u8>) -> ExecutorResult<Vec<String>> {
     let mut lines = Vec::new();
     while let Some(pos) = buffer.iter().position(|byte| *byte == b'\n') {
+        if pos > MAX_SSE_LINE_BYTES {
+            return Err(ExecutorError::StreamError(format!(
+                "upstream SSE line exceeded {MAX_SSE_LINE_BYTES} bytes"
+            )));
+        }
         let line = buffer.drain(..=pos).collect::<Vec<_>>();
         let line_end = if pos > 0 && line.get(pos - 1) == Some(&b'\r') {
             pos - 1
@@ -49,13 +56,34 @@ fn drain_complete_utf8_lines(buffer: &mut Vec<u8>) -> Vec<String> {
             lines.push(line.to_string());
         }
     }
-    lines
+    if buffer.len() > MAX_SSE_LINE_BYTES {
+        return Err(ExecutorError::StreamError(format!(
+            "upstream SSE line exceeded {MAX_SSE_LINE_BYTES} bytes"
+        )));
+    }
+    Ok(lines)
+}
+
+async fn response_text_limited(resp: reqwest::Response) -> ExecutorResult<String> {
+    let mut stream = resp.bytes_stream();
+    let mut body = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(ExecutorError::NetworkError)?;
+        if chunk.len() > MAX_EXECUTOR_RESPONSE_BYTES.saturating_sub(body.len()) {
+            return Err(ExecutorError::StreamError(format!(
+                "upstream response exceeded {MAX_EXECUTOR_RESPONSE_BYTES} bytes"
+            )));
+        }
+        body.extend_from_slice(&chunk);
+    }
+    String::from_utf8(body)
+        .map_err(|_| ExecutorError::StreamError("upstream response body was not valid UTF-8".to_owned()))
 }
 
 /// Build, send, and validate an HTTP POST to the LLM backend.
 ///
-/// Shared by both the blocking path (caller reads `.text()`) and the streaming
-/// path (caller reads `.bytes_stream()`). Maps connect/timeout failures and
+/// Shared by both the blocking path (caller consumes a bounded byte stream) and
+/// the streaming path (caller reads `.bytes_stream()`). Maps connect/timeout failures and
 /// non-2xx status codes to [`ExecutorError::LLMRequest`] and connection
 /// failures to [`ExecutorError::LLMTransport`].
 pub(super) async fn send_request(
@@ -92,10 +120,9 @@ pub(super) async fn send_request(
         let headers = processed_response_headers(resp.headers());
         // Log and discard any error reading the error body — the status code
         // is the primary signal; an empty body is acceptable here.
-        let body = resp
-            .text()
+        let body = response_text_limited(resp)
             .await
-            .inspect_err(|e| tracing::debug!("failed to read error response body: {e}"))
+            .inspect_err(|error| tracing::debug!(%error, "failed to read bounded error response body"))
             .unwrap_or_default();
         return Err(ExecutorError::LLMRequest {
             status: http::StatusCode::from_u16(status).unwrap_or(http::StatusCode::INTERNAL_SERVER_ERROR),
@@ -118,7 +145,7 @@ pub(super) async fn fetch_response_json(
 ) -> ExecutorResult<String> {
     let resp = send_request(client, url, upstream_json, auth, None).await?;
     // Preserve the reqwest::Error as the typed source (NetworkError).
-    resp.text().await.map_err(ExecutorError::NetworkError)
+    response_text_limited(resp).await
 }
 
 /// Makes a non-streaming HTTP POST with caller-supplied upstream headers.
@@ -130,7 +157,7 @@ pub(super) async fn fetch_response_json_with_headers(
 ) -> ExecutorResult<(String, http::HeaderMap)> {
     let resp = send_request(client, url, upstream_json, None, Some(headers)).await?;
     let response_headers = processed_response_headers(resp.headers());
-    let body = resp.text().await.map_err(ExecutorError::NetworkError)?;
+    let body = response_text_limited(resp).await?;
     Ok((body, response_headers))
 }
 
@@ -181,7 +208,14 @@ pub(super) fn response_lines(
 
             buf.extend_from_slice(&chunk);
 
-            for line in drain_complete_utf8_lines(&mut buf) {
+            let lines = match drain_complete_utf8_lines(&mut buf) {
+                Ok(lines) => lines,
+                Err(error) => {
+                    yield Err(error);
+                    return;
+                }
+            };
+            for line in lines {
                 match line.as_str() {
                     "data: [DONE]" => return,
                     l if l.starts_with("data: ") => yield Ok(line),
@@ -194,7 +228,41 @@ pub(super) fn response_lines(
 
 #[cfg(test)]
 mod tests {
+    use std::convert::Infallible;
+
+    use axum::body::Body;
+    use axum::http::StatusCode;
+    use axum::response::Response;
+    use axum::routing::post;
+    use bytes::Bytes;
+    use futures::stream;
+
     use super::*;
+
+    async fn oversized_body_server(status: StatusCode) -> (String, tokio::task::JoinHandle<()>) {
+        let app = axum::Router::new().route(
+            "/v1/responses",
+            post(move || async move {
+                let half = MAX_EXECUTOR_RESPONSE_BYTES / 2;
+                let chunks = stream::iter([
+                    Ok::<_, Infallible>(Bytes::from(vec![b'x'; half + 1])),
+                    Ok(Bytes::from(vec![b'x'; MAX_EXECUTOR_RESPONSE_BYTES - half])),
+                ]);
+                Response::builder()
+                    .status(status)
+                    .body(Body::from_stream(chunks))
+                    .unwrap()
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind response limit server");
+        let address = listener.local_addr().expect("response limit server address");
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.ok();
+        });
+        (format!("http://{address}/v1/responses"), server)
+    }
 
     #[test]
     fn utf8_line_reader_preserves_split_multibyte_characters() {
@@ -208,13 +276,50 @@ mod tests {
             + 1;
         let mut buffer = bytes[..split_at].to_vec();
 
-        assert!(drain_complete_utf8_lines(&mut buffer).is_empty());
+        assert!(
+            drain_complete_utf8_lines(&mut buffer)
+                .expect("partial UTF-8 line")
+                .is_empty()
+        );
 
         buffer.extend_from_slice(&bytes[split_at..]);
-        let lines = drain_complete_utf8_lines(&mut buffer);
+        let lines = drain_complete_utf8_lines(&mut buffer).expect("complete UTF-8 line");
 
         assert!(buffer.is_empty());
         assert_eq!(lines, vec![line]);
         assert!(!lines[0].contains('\u{FFFD}'));
+    }
+
+    #[test]
+    fn utf8_line_reader_rejects_an_oversized_unterminated_line() {
+        let mut buffer = vec![b'x'; MAX_SSE_LINE_BYTES + 1];
+        let error = drain_complete_utf8_lines(&mut buffer).expect_err("oversized SSE line must fail");
+        assert!(error.to_string().contains("upstream SSE line exceeded"));
+    }
+
+    #[tokio::test]
+    async fn blocking_response_reader_rejects_a_cumulative_oversized_body() {
+        let (url, server) = oversized_body_server(StatusCode::OK).await;
+        let error = fetch_response_json("{}".to_owned(), &url, &reqwest::Client::new(), None)
+            .await
+            .expect_err("oversized successful response must fail");
+
+        assert!(error.to_string().contains("upstream response exceeded"));
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn non_success_response_discards_a_cumulative_oversized_body() {
+        let (url, server) = oversized_body_server(StatusCode::BAD_GATEWAY).await;
+        let error = send_request(&reqwest::Client::new(), &url, "{}".to_owned(), None, None)
+            .await
+            .expect_err("non-success response must fail");
+
+        let ExecutorError::LLMRequest { status, body, .. } = error else {
+            panic!("expected upstream request error");
+        };
+        assert_eq!(status, StatusCode::BAD_GATEWAY);
+        assert!(body.is_empty());
+        server.abort();
     }
 }

--- a/crates/agentic-server-core/src/executor/mod.rs
+++ b/crates/agentic-server-core/src/executor/mod.rs
@@ -17,6 +17,7 @@ pub mod request;
 mod gateway;
 pub mod gateway_accumulator;
 mod pending_calls;
+mod response_budget;
 mod upstream;
 
 pub use compaction::compact_response;

--- a/crates/agentic-server-core/src/executor/response_budget.rs
+++ b/crates/agentic-server-core/src/executor/response_budget.rs
@@ -1,0 +1,32 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crate::executor::error::{ExecutorError, ExecutorResult};
+
+pub(super) const MAX_EXECUTOR_RESPONSE_BYTES: usize = 1024 * 1024;
+
+#[derive(Clone)]
+pub(super) struct ExecutorResponseBudget {
+    remaining: Arc<AtomicUsize>,
+}
+
+impl ExecutorResponseBudget {
+    pub(super) fn new() -> Self {
+        Self {
+            remaining: Arc::new(AtomicUsize::new(MAX_EXECUTOR_RESPONSE_BYTES)),
+        }
+    }
+
+    pub(super) fn consume(&self, bytes: usize) -> ExecutorResult<()> {
+        self.remaining
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |remaining| {
+                remaining.checked_sub(bytes)
+            })
+            .map(|_| ())
+            .map_err(|_| {
+                ExecutorError::StreamError(format!(
+                    "executor response budget exceeded {MAX_EXECUTOR_RESPONSE_BYTES} bytes"
+                ))
+            })
+    }
+}

--- a/crates/agentic-server-core/src/executor/upstream.rs
+++ b/crates/agentic-server-core/src/executor/upstream.rs
@@ -15,6 +15,7 @@ use crate::executor::gateway::{
 use crate::executor::gateway_accumulator::{GatewayStreamAccumulator, StreamEvent, emit_sse_frame};
 use crate::executor::inference::{call_inference, fetch_response_json};
 use crate::executor::request::{ExecutionContext, RequestContext};
+use crate::executor::response_budget::ExecutorResponseBudget;
 use crate::tool::ToolRegistry;
 use crate::types::io::OutputItem;
 use crate::types::request_response::ResponsePayload;
@@ -25,7 +26,7 @@ const MAX_DEFERRED_STREAM_BYTES: usize = 256 * 1024;
 struct StreamEmitContext<'a> {
     request: &'a RequestContext,
     registry: &'a ToolRegistry,
-    sender: &'a tokio::sync::mpsc::UnboundedSender<StreamEvent>,
+    sender: &'a tokio::sync::mpsc::Sender<StreamEvent>,
     accumulator: &'a mut GatewayStreamAccumulator,
     output_offset: usize,
 }
@@ -49,12 +50,16 @@ pub(super) async fn fetch_blocking_payload(
     ctx: &RequestContext,
     exec_ctx: &ExecutionContext,
     auth: Option<&str>,
+    response_budget: Option<&ExecutorResponseBudget>,
 ) -> ExecutorResult<ResponsePayload> {
     let url = exec_ctx.responses_url();
     // Non-streaming request: stream=false -> full JSON body -> from_json.
     let upstream_json = upstream_request(ctx, false)?;
 
     let body = fetch_response_json(upstream_json, &url, &exec_ctx.client, auth).await?;
+    if let Some(response_budget) = response_budget {
+        response_budget.consume(body.len())?;
+    }
 
     payload_from_upstream(ctx, UpstreamBody::Json(&body))
 }
@@ -565,11 +570,9 @@ pub(super) async fn fetch_stream_payload(
     exec_ctx: &ExecutionContext,
     auth: Option<&str>,
     registry: &ToolRegistry,
-    mut stream: Option<(
-        &mut GatewayStreamAccumulator,
-        &tokio::sync::mpsc::UnboundedSender<StreamEvent>,
-    )>,
+    mut stream: Option<(&mut GatewayStreamAccumulator, &tokio::sync::mpsc::Sender<StreamEvent>)>,
     output_offset: usize,
+    response_budget: &ExecutorResponseBudget,
 ) -> ExecutorResult<StreamPayload> {
     let url = exec_ctx.responses_url();
     let upstream_json = upstream_request(ctx, true)?;
@@ -587,6 +590,7 @@ pub(super) async fn fetch_stream_payload(
     let mut deferred_bytes = 0;
     while let Some(line_result) = line_stream.next().await {
         let line = line_result?;
+        response_budget.consume(line.len())?;
         if stream.is_none() {
             let _ = absorb_line(&mut acc, ctx, &line);
             continue;
@@ -614,9 +618,10 @@ pub(super) async fn fetch_stream_payload(
                             defer_from_output_index,
                             &mut deferred_events,
                             &mut deferred_bytes,
-                        )?;
+                        )
+                        .await?;
                         if event_type == SSEEventType::ResponseInProgress && emitted {
-                            emit_mcp_discovery_lifecycle(registry, emit_ctx.accumulator, emit_ctx.sender)?;
+                            emit_mcp_discovery_lifecycle(registry, emit_ctx.accumulator, emit_ctx.sender).await?;
                         }
                     }
                 }
@@ -626,7 +631,8 @@ pub(super) async fn fetch_stream_payload(
                         defer_from_output_index,
                         &mut deferred_events,
                         &mut deferred_bytes,
-                    )?;
+                    )
+                    .await?;
                 }
             }
         }
@@ -667,12 +673,12 @@ fn log_upstream_failure(frame: &EventFrame, gateway_response_id: &str) {
     );
 }
 
-pub(super) fn emit_deferred_stream_events(
+pub(super) async fn emit_deferred_stream_events(
     deferred_events: Vec<EventFrame>,
     request: &RequestContext,
     registry: &ToolRegistry,
     accumulator: &mut GatewayStreamAccumulator,
-    sender: &tokio::sync::mpsc::UnboundedSender<StreamEvent>,
+    sender: &tokio::sync::mpsc::Sender<StreamEvent>,
     output_offset: usize,
 ) -> ExecutorResult<()> {
     let mut emit_ctx = StreamEmitContext {
@@ -683,7 +689,7 @@ pub(super) fn emit_deferred_stream_events(
         output_offset,
     };
     for mut frame in deferred_events {
-        emit_stream_frame(&mut frame, &mut emit_ctx)?;
+        emit_stream_frame(&mut frame, &mut emit_ctx).await?;
     }
     Ok(())
 }
@@ -697,17 +703,17 @@ fn should_defer_stream_event(frame: &EventFrame, defer_from_output_index: Option
     })
 }
 
-fn emit_stream_frame(frame: &mut EventFrame, emit_ctx: &mut StreamEmitContext<'_>) -> ExecutorResult<bool> {
+async fn emit_stream_frame(frame: &mut EventFrame, emit_ctx: &mut StreamEmitContext<'_>) -> ExecutorResult<bool> {
     apply_context_response_ids(&mut frame.wire, emit_ctx.request);
     emit_ctx.registry.restore_stream_event_wire(&mut frame.wire);
     let emitted = emit_ctx.accumulator.process_event(frame, emit_ctx.output_offset);
     if emitted {
-        emit_sse_frame(emit_ctx.sender, frame)?;
+        emit_sse_frame(emit_ctx.sender, frame).await?;
     }
     Ok(emitted)
 }
 
-fn emit_or_defer_stream_frame(
+async fn emit_or_defer_stream_frame(
     mut frame: EventFrame,
     emit_ctx: &mut StreamEmitContext<'_>,
     defer_from_output_index: Option<u64>,
@@ -728,10 +734,10 @@ fn emit_or_defer_stream_frame(
         *deferred_bytes = next_bytes;
         return Ok(false);
     }
-    emit_stream_frame(&mut frame, emit_ctx)
+    emit_stream_frame(&mut frame, emit_ctx).await
 }
 
-fn flush_released_stream_frames(
+async fn flush_released_stream_frames(
     emit_ctx: &mut StreamEmitContext<'_>,
     defer_from_output_index: Option<u64>,
     deferred_events: &mut Vec<EventFrame>,
@@ -747,15 +753,16 @@ fn flush_released_stream_frames(
             defer_from_output_index,
             deferred_events,
             deferred_bytes,
-        )?;
+        )
+        .await?;
     }
     Ok(())
 }
 
-fn emit_mcp_discovery_lifecycle(
+async fn emit_mcp_discovery_lifecycle(
     registry: &ToolRegistry,
     stream_accumulator: &mut GatewayStreamAccumulator,
-    stream_sender: &tokio::sync::mpsc::UnboundedSender<StreamEvent>,
+    stream_sender: &tokio::sync::mpsc::Sender<StreamEvent>,
 ) -> ExecutorResult<()> {
     let discovered_output = registry
         .mcp_list_tool_items()
@@ -764,8 +771,8 @@ fn emit_mcp_discovery_lifecycle(
     let public_output = public_output_items(&discovered_output, registry, &[]);
     let event_plans = mcp_list_tools_event_plans(&public_output, 0);
 
-    emit_gateway_start_events(&event_plans, stream_accumulator, stream_sender)?;
-    emit_gateway_completed_events(&public_output, &event_plans, stream_accumulator, stream_sender)
+    emit_gateway_start_events(&event_plans, stream_accumulator, stream_sender).await?;
+    emit_gateway_completed_events(&public_output, &event_plans, stream_accumulator, stream_sender).await
 }
 
 fn is_terminal_response_event(event_type: SSEEventType) -> bool {
@@ -795,6 +802,8 @@ fn apply_context_response_ids(wire: &mut WireEvent, ctx: &RequestContext) {
 mod tests {
     use super::*;
     use crate::events::EventPayload;
+    use crate::executor::modes::{ConversationHandler, ResponseHandler};
+    use crate::storage::{ConversationStore, ResponseStore};
     use crate::types::io::ResponsesInput;
     use crate::types::request_response::RequestPayload;
 
@@ -842,11 +851,11 @@ mod tests {
         }
     }
 
-    #[test]
-    fn released_frames_are_emitted_in_output_index_order() {
+    #[tokio::test]
+    async fn released_frames_are_emitted_in_output_index_order() {
         let request = request_context();
         let registry = ToolRegistry::default();
-        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(4);
         let mut accumulator = GatewayStreamAccumulator::new();
         let mut emit_ctx = StreamEmitContext {
             request: &request,
@@ -864,7 +873,9 @@ mod tests {
             .map(|frame| serialize_to_string(&frame.wire).unwrap().len())
             .sum();
 
-        flush_released_stream_frames(&mut emit_ctx, None, &mut deferred, &mut deferred_bytes).expect("flush succeeds");
+        flush_released_stream_frames(&mut emit_ctx, None, &mut deferred, &mut deferred_bytes)
+            .await
+            .expect("flush succeeds");
         assert_eq!(deferred_bytes, 0);
 
         let indices = [receiver.try_recv().unwrap(), receiver.try_recv().unwrap()].map(|event| {
@@ -880,11 +891,11 @@ mod tests {
         assert_eq!(indices, [2, 3]);
     }
 
-    #[test]
-    fn deferred_frames_have_a_shared_byte_limit() {
+    #[tokio::test]
+    async fn deferred_frames_have_a_shared_byte_limit() {
         let request = request_context();
         let registry = ToolRegistry::default();
-        let (sender, _receiver) = tokio::sync::mpsc::unbounded_channel();
+        let (sender, _receiver) = tokio::sync::mpsc::channel(4);
         let mut accumulator = GatewayStreamAccumulator::new();
         let mut emit_ctx = StreamEmitContext {
             request: &request,
@@ -898,7 +909,72 @@ mod tests {
         let oversized = frame(0, Value::String("x".repeat(256 * 1024 + 1)));
 
         let error = emit_or_defer_stream_frame(oversized, &mut emit_ctx, Some(0), &mut deferred, &mut deferred_bytes)
+            .await
             .expect_err("oversized deferred stream must fail");
         assert!(error.to_string().contains("deferred stream exceeded"));
+    }
+
+    #[test]
+    fn executor_response_budget_is_shared_across_rounds() {
+        let budget = ExecutorResponseBudget::new();
+        budget
+            .consume(crate::executor::response_budget::MAX_EXECUTOR_RESPONSE_BYTES / 2)
+            .expect("first round should fit");
+        budget
+            .consume(crate::executor::response_budget::MAX_EXECUTOR_RESPONSE_BYTES / 2)
+            .expect("second round should consume the budget");
+        let error = budget.consume(1).expect_err("next round must exceed shared budget");
+        assert!(error.to_string().contains("executor response budget exceeded"));
+    }
+
+    #[tokio::test]
+    async fn streamed_response_reader_enforces_the_cumulative_budget() {
+        use std::fmt::Write as _;
+
+        let data = "x".repeat(200 * 1024);
+        let mut response = String::new();
+        for sequence_number in 0..6 {
+            write!(
+                &mut response,
+                "data: {{\"type\":\"test.event\",\"sequence_number\":{sequence_number},\"delta\":\"{data}\"}}\n\n"
+            )
+            .expect("writing to a String cannot fail");
+        }
+        let app = axum::Router::new().route(
+            "/v1/responses",
+            axum::routing::post(move || {
+                let response = response.clone();
+                async move { ([(axum::http::header::CONTENT_TYPE, "text/event-stream")], response) }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind streaming response limit server");
+        let address = listener.local_addr().expect("streaming response limit server address");
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.ok();
+        });
+        let exec_ctx = ExecutionContext::new(
+            ConversationHandler::new(ConversationStore::disabled()),
+            ResponseHandler::new(ResponseStore::disabled()),
+            Arc::new(reqwest::Client::new()),
+            format!("http://{address}"),
+        );
+        let budget = ExecutorResponseBudget::new();
+
+        let error = fetch_stream_payload(
+            &request_context(),
+            &exec_ctx,
+            None,
+            &ToolRegistry::default(),
+            None,
+            0,
+            &budget,
+        )
+        .await
+        .err()
+        .expect("cumulative streamed response must be bounded");
+        assert!(error.to_string().contains("executor response budget exceeded"));
+        server.abort();
     }
 }

--- a/crates/agentic-server-core/src/tool/handler.rs
+++ b/crates/agentic-server-core/src/tool/handler.rs
@@ -4,6 +4,8 @@ use std::pin::Pin;
 use crate::types::io::FunctionTool;
 use crate::types::io::output::{FunctionToolCall, GatewayCallStatus, OutputItem};
 
+pub(crate) const MAX_GATEWAY_TOOL_OUTPUT_BYTES: usize = 1024 * 1024;
+
 #[derive(Debug, Clone)]
 pub struct ToolOutput {
     pub call_id: String,

--- a/crates/agentic-server-core/src/tool/mcp/bounded_http.rs
+++ b/crates/agentic-server-core/src/tool/mcp/bounded_http.rs
@@ -1,0 +1,390 @@
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use futures::{StreamExt, stream::BoxStream};
+use http::header::{HeaderName, HeaderValue, WWW_AUTHENTICATE};
+use rmcp::model::{ClientJsonRpcMessage, JsonRpcMessage, ServerJsonRpcMessage};
+use rmcp::transport::streamable_http_client::{
+    AuthRequiredError, InsufficientScopeError, SseError, StreamableHttpClient, StreamableHttpError,
+    StreamableHttpPostResponse,
+};
+use rmcp_reqwest as http_client;
+use sse_stream::{Sse, SseStream};
+
+use crate::tool::handler::MAX_GATEWAY_TOOL_OUTPUT_BYTES;
+
+const EVENT_STREAM_MIME_TYPE: &str = "text/event-stream";
+const JSON_MIME_TYPE: &str = "application/json";
+const HEADER_SESSION_ID: &str = "Mcp-Session-Id";
+const HEADER_LAST_EVENT_ID: &str = "Last-Event-Id";
+const HEADER_MCP_PROTOCOL_VERSION: &str = "MCP-Protocol-Version";
+const MAX_MCP_HTTP_MESSAGE_BYTES: usize = MAX_GATEWAY_TOOL_OUTPUT_BYTES;
+
+/// Reqwest adapter for rmcp 1.x that rejects oversized JSON bodies and SSE
+/// events while they are being read, before protocol deserialization allocates
+/// a complete untrusted response.
+#[derive(Clone)]
+pub(super) struct BoundedMcpHttpClient {
+    inner: http_client::Client,
+}
+
+impl BoundedMcpHttpClient {
+    pub(super) const fn new(inner: http_client::Client) -> Self {
+        Self { inner }
+    }
+}
+
+impl StreamableHttpClient for BoundedMcpHttpClient {
+    type Error = http_client::Error;
+
+    async fn get_stream(
+        &self,
+        uri: Arc<str>,
+        session_id: Arc<str>,
+        last_event_id: Option<String>,
+        auth_token: Option<String>,
+        custom_headers: HashMap<HeaderName, HeaderValue>,
+    ) -> Result<BoxStream<'static, Result<Sse, SseError>>, StreamableHttpError<Self::Error>> {
+        let mut request = self
+            .inner
+            .get(uri.as_ref())
+            .header(http_client::header::ACCEPT, accept_header())
+            .header(HEADER_SESSION_ID, session_id.as_ref());
+        if let Some(last_event_id) = last_event_id {
+            request = request.header(HEADER_LAST_EVENT_ID, last_event_id);
+        }
+        if let Some(auth_token) = auth_token {
+            request = request.bearer_auth(auth_token);
+        }
+        let response = apply_custom_headers(request, custom_headers)?.send().await?;
+        if response.status() == http_client::StatusCode::METHOD_NOT_ALLOWED {
+            return Err(StreamableHttpError::ServerDoesNotSupportSse);
+        }
+        let response = response.error_for_status()?;
+        validate_stream_content_type(&response)?;
+        Ok(bounded_sse_stream(response))
+    }
+
+    async fn delete_session(
+        &self,
+        uri: Arc<str>,
+        session_id: Arc<str>,
+        auth_token: Option<String>,
+        custom_headers: HashMap<HeaderName, HeaderValue>,
+    ) -> Result<(), StreamableHttpError<Self::Error>> {
+        self.inner
+            .delete_session(uri, session_id, auth_token, custom_headers)
+            .await
+    }
+
+    async fn post_message(
+        &self,
+        uri: Arc<str>,
+        message: ClientJsonRpcMessage,
+        session_id: Option<Arc<str>>,
+        auth_token: Option<String>,
+        custom_headers: HashMap<HeaderName, HeaderValue>,
+    ) -> Result<StreamableHttpPostResponse, StreamableHttpError<Self::Error>> {
+        let mut request = self
+            .inner
+            .post(uri.as_ref())
+            .header(http_client::header::ACCEPT, accept_header());
+        if let Some(auth_token) = auth_token {
+            request = request.bearer_auth(auth_token);
+        }
+        request = apply_custom_headers(request, custom_headers)?;
+        let session_was_attached = session_id.is_some();
+        if let Some(session_id) = session_id {
+            request = request.header(HEADER_SESSION_ID, session_id.as_ref());
+        }
+
+        let response = request.json(&message).send().await?;
+        reject_auth_response(&response)?;
+        let status = response.status();
+        if matches!(
+            status,
+            http_client::StatusCode::ACCEPTED | http_client::StatusCode::NO_CONTENT
+        ) {
+            return Ok(StreamableHttpPostResponse::Accepted);
+        }
+        if status == http_client::StatusCode::NOT_FOUND && session_was_attached {
+            return Err(StreamableHttpError::SessionExpired);
+        }
+
+        let content_type = response_content_type(&response);
+        let content_length = response.content_length();
+        let response_session_id = response
+            .headers()
+            .get(HEADER_SESSION_ID)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_owned);
+        if status.is_success()
+            && content_length == Some(0)
+            && matches!(
+                message,
+                ClientJsonRpcMessage::Notification(_)
+                    | ClientJsonRpcMessage::Response(_)
+                    | ClientJsonRpcMessage::Error(_)
+            )
+        {
+            return Ok(StreamableHttpPostResponse::Accepted);
+        }
+
+        if !status.is_success() {
+            let body = response_body_limited(response).await?;
+            if is_content_type(content_type.as_deref(), JSON_MIME_TYPE) {
+                if let Ok(message @ JsonRpcMessage::Error(_)) = serde_json::from_slice(&body) {
+                    return Ok(StreamableHttpPostResponse::Json(message, response_session_id));
+                }
+            }
+            return Err(StreamableHttpError::UnexpectedServerResponse(Cow::Owned(format!(
+                "HTTP {status}: {}",
+                String::from_utf8_lossy(&body)
+            ))));
+        }
+
+        match content_type.as_deref() {
+            Some(content_type) if content_type.as_bytes().starts_with(EVENT_STREAM_MIME_TYPE.as_bytes()) => Ok(
+                StreamableHttpPostResponse::Sse(bounded_sse_stream(response), response_session_id),
+            ),
+            Some(content_type) if content_type.as_bytes().starts_with(JSON_MIME_TYPE.as_bytes()) => {
+                let body = response_body_limited(response).await?;
+                match serde_json::from_slice::<ServerJsonRpcMessage>(&body) {
+                    Ok(message) => Ok(StreamableHttpPostResponse::Json(message, response_session_id)),
+                    Err(error) => {
+                        tracing::warn!(%error, "could not parse JSON response as an MCP message; treating it as accepted");
+                        Ok(StreamableHttpPostResponse::Accepted)
+                    }
+                }
+            }
+            _ => Err(StreamableHttpError::UnexpectedContentType(content_type)),
+        }
+    }
+}
+
+fn accept_header() -> String {
+    [EVENT_STREAM_MIME_TYPE, JSON_MIME_TYPE].join(", ")
+}
+
+fn apply_custom_headers(
+    mut request: http_client::RequestBuilder,
+    headers: HashMap<HeaderName, HeaderValue>,
+) -> Result<http_client::RequestBuilder, StreamableHttpError<http_client::Error>> {
+    for (name, value) in headers {
+        if ["accept", HEADER_SESSION_ID, HEADER_LAST_EVENT_ID]
+            .iter()
+            .any(|reserved| name.as_str().eq_ignore_ascii_case(reserved))
+            && !name.as_str().eq_ignore_ascii_case(HEADER_MCP_PROTOCOL_VERSION)
+        {
+            return Err(StreamableHttpError::ReservedHeaderConflict(name.to_string()));
+        }
+        request = request.header(name, value);
+    }
+    Ok(request)
+}
+
+fn reject_auth_response(response: &http_client::Response) -> Result<(), StreamableHttpError<http_client::Error>> {
+    let Some(header) = response.headers().get(WWW_AUTHENTICATE) else {
+        return Ok(());
+    };
+    let header = header.to_str().map_err(|_| {
+        StreamableHttpError::UnexpectedServerResponse(Cow::Borrowed("invalid www-authenticate header value"))
+    })?;
+    match response.status() {
+        http_client::StatusCode::UNAUTHORIZED => Err(StreamableHttpError::AuthRequired(AuthRequiredError::new(
+            header.to_owned(),
+        ))),
+        http_client::StatusCode::FORBIDDEN => Err(StreamableHttpError::InsufficientScope(InsufficientScopeError::new(
+            header.to_owned(),
+            scope_from_auth_header(header),
+        ))),
+        _ => Ok(()),
+    }
+}
+
+fn scope_from_auth_header(header: &str) -> Option<String> {
+    let start = header.to_ascii_lowercase().find("scope=")? + "scope=".len();
+    let value = &header[start..];
+    if let Some(value) = value.strip_prefix('"') {
+        return value.find('"').map(|end| value[..end].to_owned());
+    }
+    let end = value
+        .find(|character: char| character == ',' || character == ';' || character.is_whitespace())
+        .unwrap_or(value.len());
+    (end > 0).then(|| value[..end].to_owned())
+}
+
+fn response_content_type(response: &http_client::Response) -> Option<String> {
+    response
+        .headers()
+        .get(http_client::header::CONTENT_TYPE)
+        .map(|value| String::from_utf8_lossy(value.as_bytes()).into_owned())
+}
+
+fn is_content_type(actual: Option<&str>, expected: &str) -> bool {
+    actual.is_some_and(|actual| actual.as_bytes().starts_with(expected.as_bytes()))
+}
+
+fn validate_stream_content_type(
+    response: &http_client::Response,
+) -> Result<(), StreamableHttpError<http_client::Error>> {
+    let content_type = response_content_type(response);
+    if is_content_type(content_type.as_deref(), EVENT_STREAM_MIME_TYPE)
+        || is_content_type(content_type.as_deref(), JSON_MIME_TYPE)
+    {
+        Ok(())
+    } else {
+        Err(StreamableHttpError::UnexpectedContentType(content_type))
+    }
+}
+
+async fn response_body_limited(
+    response: http_client::Response,
+) -> Result<Vec<u8>, StreamableHttpError<http_client::Error>> {
+    if response
+        .content_length()
+        .is_some_and(|length| length > MAX_MCP_HTTP_MESSAGE_BYTES as u64)
+    {
+        return Err(oversized_message_error());
+    }
+    let mut stream = response.bytes_stream();
+    let mut body = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+        if chunk.len() > MAX_MCP_HTTP_MESSAGE_BYTES.saturating_sub(body.len()) {
+            return Err(oversized_message_error());
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
+fn bounded_sse_stream(response: http_client::Response) -> BoxStream<'static, Result<Sse, SseError>> {
+    let bytes = async_stream::stream! {
+        let mut source = response.bytes_stream();
+        let mut event_size = SseEventSize::default();
+        while let Some(chunk) = source.next().await {
+            let chunk = match chunk {
+                Ok(chunk) => chunk,
+                Err(error) => {
+                    yield Err::<bytes::Bytes, _>(std::io::Error::other(error));
+                    return;
+                }
+            };
+            if let Err(error) = event_size.observe(&chunk) {
+                yield Err::<bytes::Bytes, _>(error);
+                return;
+            }
+            yield Ok::<_, std::io::Error>(chunk);
+        }
+    };
+    SseStream::from_byte_stream(bytes).boxed()
+}
+
+#[derive(Default)]
+struct SseEventSize {
+    bytes: usize,
+    at_line_start: bool,
+    last_was_carriage_return: bool,
+}
+
+impl SseEventSize {
+    fn observe(&mut self, chunk: &[u8]) -> std::io::Result<()> {
+        for byte in chunk {
+            self.bytes = self.bytes.saturating_add(1);
+            match *byte {
+                b'\r' => {
+                    if self.at_line_start {
+                        self.bytes = 0;
+                    }
+                    self.at_line_start = true;
+                    self.last_was_carriage_return = true;
+                }
+                b'\n' if self.last_was_carriage_return => {
+                    self.last_was_carriage_return = false;
+                }
+                b'\n' => {
+                    if self.at_line_start {
+                        self.bytes = 0;
+                    }
+                    self.at_line_start = true;
+                }
+                _ => {
+                    self.at_line_start = false;
+                    self.last_was_carriage_return = false;
+                }
+            }
+            if self.bytes > MAX_MCP_HTTP_MESSAGE_BYTES {
+                return Err(std::io::Error::other(format!(
+                    "MCP SSE event exceeded {MAX_MCP_HTTP_MESSAGE_BYTES} bytes"
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+fn oversized_message_error() -> StreamableHttpError<http_client::Error> {
+    StreamableHttpError::UnexpectedServerResponse(Cow::Owned(format!(
+        "MCP HTTP response exceeded {MAX_MCP_HTTP_MESSAGE_BYTES} bytes"
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    use super::{MAX_MCP_HTTP_MESSAGE_BYTES, SseEventSize, response_body_limited};
+
+    #[test]
+    fn sse_event_limit_is_cumulative_across_chunks_and_resets_between_events() {
+        let mut size = SseEventSize::default();
+        size.observe(b"data: ok\n\n").expect("first event fits");
+        size.observe(&vec![b'x'; MAX_MCP_HTTP_MESSAGE_BYTES / 2])
+            .expect("first partial chunk fits");
+        let error = size
+            .observe(&vec![b'x'; MAX_MCP_HTTP_MESSAGE_BYTES / 2 + 1])
+            .expect_err("cumulative oversized event must fail");
+        assert!(error.to_string().contains("MCP SSE event exceeded"));
+    }
+
+    #[tokio::test]
+    async fn json_body_limit_is_cumulative_across_http_chunks() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind bounded MCP response server");
+        let address = listener.local_addr().expect("bounded MCP response server address");
+        let chunk = vec![b'x'; MAX_MCP_HTTP_MESSAGE_BYTES / 2 + 1];
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept MCP response request");
+            let mut request = [0_u8; 1024];
+            let _ = stream.read(&mut request).await.expect("read MCP response request");
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nTransfer-Encoding: chunked\r\n\r\n")
+                .await
+                .expect("write MCP response headers");
+            for _ in 0..2 {
+                stream
+                    .write_all(format!("{:x}\r\n", chunk.len()).as_bytes())
+                    .await
+                    .expect("write MCP response chunk size");
+                stream.write_all(&chunk).await.expect("write MCP response chunk");
+                stream.write_all(b"\r\n").await.expect("finish MCP response chunk");
+            }
+            stream.write_all(b"0\r\n\r\n").await.expect("finish MCP response");
+        });
+        let response = rmcp_reqwest::Client::new()
+            .get(format!("http://{address}/mcp"))
+            .send()
+            .await
+            .expect("fetch chunked MCP response");
+
+        let error = response_body_limited(response)
+            .await
+            .expect_err("cumulative oversized MCP body must fail");
+
+        assert!(error.to_string().contains("MCP HTTP response exceeded"));
+        server.await.expect("bounded MCP response server completes");
+    }
+}

--- a/crates/agentic-server-core/src/tool/mcp/client.rs
+++ b/crates/agentic-server-core/src/tool/mcp/client.rs
@@ -21,6 +21,8 @@ use serde_json::Value;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 
+use super::bounded_http::BoundedMcpHttpClient;
+
 const CONNECTION_TIMEOUT: Duration = Duration::from_secs(30);
 const TOOL_TIMEOUT: Duration = Duration::from_secs(60);
 
@@ -130,7 +132,7 @@ impl McpClient {
             }
             config = config.custom_headers(custom_headers);
         }
-        let transport = StreamableHttpClientTransport::with_client(http_client, config);
+        let transport = StreamableHttpClientTransport::with_client(BoundedMcpHttpClient::new(http_client), config);
         let service = AgenticMcpClientHandler
             .serve(transport)
             .await
@@ -396,6 +398,7 @@ mod tests {
             match listener.accept() {
                 Ok((mut stream, _)) => {
                     accepted.store(true, Ordering::SeqCst);
+                    stream.set_nonblocking(false).unwrap();
                     let mut request = [0_u8; 1024];
                     let _ = stream.read(&mut request).unwrap();
                     write!(

--- a/crates/agentic-server-core/src/tool/mcp/handler.rs
+++ b/crates/agentic-server-core/src/tool/mcp/handler.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use serde_json::Value;
 
+use crate::tool::handler::MAX_GATEWAY_TOOL_OUTPUT_BYTES;
 use crate::tool::{GatewayExecutor, GatewayToolEventPlan, ToolError, ToolHandler, ToolOutput, ToolType};
 use crate::types::io::FunctionTool;
 use crate::types::io::output::{
@@ -318,20 +319,31 @@ fn parse_tool_arguments(arguments: &str) -> Result<Value, ToolError> {
 }
 
 fn mcp_tool_result_text(result: &rmcp::model::CallToolResult) -> Result<String, ToolError> {
-    let text = result
+    let mut text = String::new();
+    for part in result
         .content
         .iter()
         .filter_map(|content| content.as_text().map(|text| text.text.as_str()))
-        .collect::<Vec<_>>()
-        .join("\n");
+    {
+        let separator_bytes = usize::from(!text.is_empty());
+        ensure_mcp_output_size(text.len().saturating_add(separator_bytes).saturating_add(part.len()))?;
+        if separator_bytes == 1 {
+            text.push('\n');
+        }
+        text.push_str(part);
+    }
     let output = if !text.is_empty() {
         text
     } else if let Some(structured_content) = &result.structured_content {
-        serialize_to_string(structured_content)
-            .map_err(|error| ToolError::Execution(format!("failed to serialize MCP structured content: {error}")))?
+        let output = serialize_to_string(structured_content)
+            .map_err(|error| ToolError::Execution(format!("failed to serialize MCP structured content: {error}")))?;
+        ensure_mcp_output_size(output.len())?;
+        output
     } else {
-        serialize_to_string(&result.content)
-            .map_err(|error| ToolError::Execution(format!("failed to serialize MCP tool content: {error}")))?
+        let output = serialize_to_string(&result.content)
+            .map_err(|error| ToolError::Execution(format!("failed to serialize MCP tool content: {error}")))?;
+        ensure_mcp_output_size(output.len())?;
+        output
     };
 
     if result.is_error == Some(true) {
@@ -339,6 +351,15 @@ fn mcp_tool_result_text(result: &rmcp::model::CallToolResult) -> Result<String, 
     } else {
         Ok(output)
     }
+}
+
+fn ensure_mcp_output_size(bytes: usize) -> Result<(), ToolError> {
+    if bytes > MAX_GATEWAY_TOOL_OUTPUT_BYTES {
+        return Err(ToolError::Execution(format!(
+            "MCP tool output exceeded {MAX_GATEWAY_TOOL_OUTPUT_BYTES} bytes"
+        )));
+    }
+    Ok(())
 }
 
 pub(crate) fn discovered_mcp_function_tool(param: &McpDiscoveredToolParam) -> FunctionTool {
@@ -710,6 +731,22 @@ mod tests {
 
         let error = mcp_tool_result_text(&result).unwrap_err();
         assert!(matches!(error, ToolError::Execution(message) if message == "missing field `b`"));
+    }
+
+    #[test]
+    fn mcp_text_result_is_bounded_before_joining_content() {
+        let part = "x".repeat(MAX_GATEWAY_TOOL_OUTPUT_BYTES / 2 + 1);
+        let result = serde_json::from_value::<rmcp::model::CallToolResult>(serde_json::json!({
+            "content": [
+                {"type": "text", "text": part},
+                {"type": "text", "text": part}
+            ],
+            "isError": false
+        }))
+        .expect("valid MCP result");
+
+        let error = mcp_tool_result_text(&result).expect_err("oversized MCP text must fail");
+        assert!(error.to_string().contains("MCP tool output exceeded"));
     }
 
     #[test]

--- a/crates/agentic-server-core/src/tool/mcp/mod.rs
+++ b/crates/agentic-server-core/src/tool/mcp/mod.rs
@@ -1,3 +1,4 @@
+mod bounded_http;
 pub mod client;
 pub mod handler;
 pub mod pool;

--- a/crates/agentic-server-core/src/tool/registry.rs
+++ b/crates/agentic-server-core/src/tool/registry.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
+use std::future::{Future, ready};
 
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
@@ -17,6 +18,10 @@ use crate::events::WireEvent;
 use crate::types::io::output::{FunctionToolCall, McpListTools};
 use crate::types::io::{InputItem, OutputItem, ResponsesInput};
 use crate::types::tools::{CodeInterpreterToolParam, FileSearchToolParam, ResponsesTool};
+
+const MAX_MCP_SERVERS_PER_REQUEST: usize = 64;
+const MAX_DISCOVERED_MCP_TOOLS_PER_REQUEST: usize = 128;
+const MAX_MCP_DISCOVERY_BYTES: usize = 1024 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -180,23 +185,65 @@ impl ToolRegistry {
     /// override a gateway-configured server's connection). Transient MCP
     /// discovery failures (the server could not be reached) are not
     /// returned as errors; they are recorded as failed [`McpListTools`]
-    /// metadata so the rest of the request can proceed.
-    ///
-    /// # Panics
-    ///
-    /// Panics if serialization of a tool param struct fails, which cannot happen
-    /// for the types defined in this module (`#[derive(Serialize)]` on plain structs).
+    /// metadata so the rest of the request can proceed. Returns
+    /// [`ToolError::Execution`] when discovered MCP metadata exceeds its byte
+    /// or tool-count limit.
     pub async fn build_with_handlers(
         tools: &mut [ResponsesTool],
         executors: &mut GatewayExecutors,
     ) -> Result<Self, ToolError> {
+        let mut remaining = MAX_MCP_DISCOVERY_BYTES;
+        Self::build_with_handlers_guarded(
+            tools,
+            executors,
+            |bytes| {
+                remaining = remaining.checked_sub(bytes).ok_or_else(|| {
+                    ToolError::Execution(format!(
+                        "MCP discovery metadata exceeded {MAX_MCP_DISCOVERY_BYTES} bytes"
+                    ))
+                })?;
+                Ok(())
+            },
+            || ready(()),
+        )
+        .await
+    }
+
+    /// Builds a registry while charging each guarded MCP discovery to a caller-owned budget.
+    ///
+    /// The callback runs before discovered metadata is copied into the registry or request, so
+    /// a request-wide executor budget can reject aggregate results without retaining the item
+    /// that crossed the limit. Keeping the callback generic preserves the dependency direction:
+    /// tool registration does not depend on executor error or policy types.
+    pub(crate) async fn build_with_handlers_guarded<E, Acquire, AcquireFuture, Guard>(
+        tools: &mut [ResponsesTool],
+        executors: &mut GatewayExecutors,
+        mut consume_materialized: impl FnMut(usize) -> Result<(), E>,
+        mut acquire_materialization: Acquire,
+    ) -> Result<Self, E>
+    where
+        E: From<ToolError>,
+        Acquire: FnMut() -> AcquireFuture,
+        AcquireFuture: Future<Output = Guard>,
+    {
         let mut entries = HashMap::with_capacity(tools.len());
         let mut mcp_list_tools_items = IndexMap::<String, Vec<McpListTools>>::new();
+        let mut discovered_mcp_tools = 0usize;
         // Namespace members must be keyed by the same flat, model-visible name
         // the model will call, so resolve them first — the same pure pass used
         // to build the upstream request.
         let resolved_tools = CodexNamespaceHandler.resolve_namespace_members(tools)?;
         McpHandler::validate_server_labels(&resolved_tools)?;
+        let mcp_server_count = resolved_tools
+            .iter()
+            .filter(|tool| matches!(tool, ResponsesTool::Mcp(_)))
+            .count();
+        if mcp_server_count > MAX_MCP_SERVERS_PER_REQUEST {
+            return Err(ToolError::Config(format!(
+                "request declared {mcp_server_count} MCP servers; at most {MAX_MCP_SERVERS_PER_REQUEST} MCP server declarations are allowed"
+            ))
+            .into());
+        }
 
         for (index, tool) in resolved_tools.iter().enumerate() {
             match tool {
@@ -204,19 +251,37 @@ impl ToolRegistry {
                     insert_unique_tool_entries(&mut entries, |resolved| insert_function_entry(resolved, p))?;
                 }
                 ResponsesTool::Mcp(p) => {
+                    let _materialization_guard = acquire_materialization().await;
                     let tool_set = match executors.mcp_server_tools(p).await {
                         Ok(tool_set) => tool_set,
                         // Config errors mean the declaration is invalid; the client can fix it.
-                        Err(error @ ToolError::Config(_)) => return Err(error),
+                        Err(error @ ToolError::Config(_)) => return Err(error.into()),
                         Err(error) => {
+                            let list_tools_item = McpHandler::failed_list_tools_item(&p.server_label, &error);
+                            consume_serialized(&list_tools_item, &mut consume_materialized)?;
                             mcp_list_tools_items
                                 .entry(p.server_label.clone())
                                 .or_default()
-                                .push(McpHandler::failed_list_tools_item(&p.server_label, &error));
+                                .push(list_tools_item);
                             continue;
                         }
                     };
                     let handlers = tool_set.discovered_handlers;
+                    discovered_mcp_tools = discovered_mcp_tools.checked_add(handlers.len()).ok_or_else(|| {
+                        E::from(ToolError::Execution(
+                            "discovered MCP tool count overflowed the platform limit".to_owned(),
+                        ))
+                    })?;
+                    if discovered_mcp_tools > MAX_DISCOVERED_MCP_TOOLS_PER_REQUEST {
+                        return Err(ToolError::Execution(format!(
+                            "request discovered {discovered_mcp_tools} MCP tools; at most {MAX_DISCOVERED_MCP_TOOLS_PER_REQUEST} discovered MCP tools are allowed"
+                        ))
+                        .into());
+                    }
+                    for handler in &handlers {
+                        consume_serialized(&handler.param, &mut consume_materialized)?;
+                    }
+                    consume_serialized(&tool_set.list_tools_item, &mut consume_materialized)?;
                     mcp_list_tools_items
                         .entry(p.server_label.clone())
                         .or_default()
@@ -382,6 +447,16 @@ impl ToolRegistry {
     }
 }
 
+fn consume_serialized<T, E>(value: &T, consume_materialized: &mut impl FnMut(usize) -> Result<(), E>) -> Result<(), E>
+where
+    T: Serialize,
+    E: From<ToolError>,
+{
+    let bytes = serde_json::to_vec(value)
+        .map_err(|error| ToolError::Execution(format!("failed to account for MCP discovery metadata: {error}")))?;
+    consume_materialized(bytes.len())
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -415,13 +490,22 @@ mod tests {
     }
 
     fn discovered_handler(server_label: &str, tool_name: &str, internal_name: &str) -> McpDiscoveredHandler {
+        discovered_handler_with_description(server_label, tool_name, internal_name, "Discovered test tool")
+    }
+
+    fn discovered_handler_with_description(
+        server_label: &str,
+        tool_name: &str,
+        internal_name: &str,
+        description: &str,
+    ) -> McpDiscoveredHandler {
         let param = McpDiscoveredToolParam {
             server_label: server_label.to_owned(),
             tool_name: tool_name.to_owned(),
             internal_name: internal_name.to_owned(),
             tool: serde_json::from_value(serde_json::json!({
                 "name": tool_name,
-                "description": "Discovered test tool",
+                "description": description,
                 "inputSchema": {"type": "object"}
             }))
             .expect("discovered MCP tool"),
@@ -430,6 +514,18 @@ mod tests {
             param,
             handler: Arc::new(McpHandler::discovered_tool_spec_only()),
         }
+    }
+
+    fn discovered_handlers(server_label: &str, start: usize, count: usize) -> Vec<McpDiscoveredHandler> {
+        (start..start + count)
+            .map(|index| {
+                discovered_handler(
+                    server_label,
+                    &format!("tool-{index}"),
+                    &format!("mcp__{server_label}__tool_{index}"),
+                )
+            })
+            .collect()
     }
 
     fn mixed_tool_declarations() -> Vec<ResponsesTool> {
@@ -712,6 +808,152 @@ mod tests {
                 .is_some_and(|error| error.contains("failed"))
         );
         assert!(registry.is_empty());
+    }
+
+    #[tokio::test]
+    async fn build_with_handlers_guarded_rejects_aggregate_mcp_discovery_bytes() {
+        let mut executors = GatewayExecutors::default();
+        let description = "x".repeat(600);
+        for server_label in ["first", "second"] {
+            executors.insert(GatewayExecutorRegistration::Mcp {
+                server_label: server_label.to_owned(),
+                handlers: vec![discovered_handler_with_description(
+                    server_label,
+                    "tool",
+                    &format!("mcp__{server_label}__tool"),
+                    &description,
+                )],
+            });
+        }
+        let mut tools = vec![configured_declaration("first"), configured_declaration("second")];
+        let mut consumed = 0usize;
+
+        let error = ToolRegistry::build_with_handlers_guarded(
+            &mut tools,
+            &mut executors,
+            |bytes| {
+                consumed = consumed.saturating_add(bytes);
+                if consumed > 2_048 {
+                    return Err(ToolError::Execution("test MCP discovery budget exceeded".to_owned()));
+                }
+                Ok(())
+            },
+            || std::future::ready(()),
+        )
+        .await
+        .expect_err("aggregate MCP discovery must use the caller's shared budget");
+
+        assert!(matches!(error, ToolError::Execution(message) if message.contains("budget exceeded")));
+    }
+
+    #[tokio::test]
+    async fn build_with_handlers_applies_a_default_mcp_discovery_budget() {
+        let mut executors = GatewayExecutors::default();
+        let description = "x".repeat(MAX_MCP_DISCOVERY_BYTES / 4);
+        for server_label in ["first", "second"] {
+            executors.insert(GatewayExecutorRegistration::Mcp {
+                server_label: server_label.to_owned(),
+                handlers: vec![discovered_handler_with_description(
+                    server_label,
+                    "tool",
+                    &format!("mcp__{server_label}__tool"),
+                    &description,
+                )],
+            });
+        }
+        let mut tools = vec![configured_declaration("first"), configured_declaration("second")];
+
+        let error = ToolRegistry::build_with_handlers(&mut tools, &mut executors)
+            .await
+            .expect_err("the standalone registry builder must enforce its own discovery budget");
+
+        assert!(matches!(
+            error,
+            ToolError::Execution(message)
+                if message.contains("MCP discovery metadata exceeded")
+                    && message.contains(&MAX_MCP_DISCOVERY_BYTES.to_string())
+        ));
+    }
+
+    #[tokio::test]
+    async fn build_with_handlers_rejects_too_many_mcp_declarations_before_discovery() {
+        let mut accepted_executors = GatewayExecutors::default();
+        let mut exact_limit = Vec::new();
+        for index in 0..MAX_MCP_SERVERS_PER_REQUEST {
+            let server_label = format!("accepted-server-{index}");
+            accepted_executors.insert(GatewayExecutorRegistration::Mcp {
+                server_label: server_label.clone(),
+                handlers: vec![discovered_handler(
+                    &server_label,
+                    "tool",
+                    &format!("mcp__accepted_server_{index}__tool"),
+                )],
+            });
+            exact_limit.push(configured_declaration(&server_label));
+        }
+        ToolRegistry::build_with_handlers(&mut exact_limit, &mut accepted_executors)
+            .await
+            .expect("the documented MCP declaration limit must be accepted");
+
+        let mut tools = (0..=MAX_MCP_SERVERS_PER_REQUEST)
+            .map(|index| configured_declaration(&format!("server-{index}")))
+            .collect::<Vec<_>>();
+        let mut executors = GatewayExecutors::default();
+
+        let error = ToolRegistry::build_with_handlers(&mut tools, &mut executors)
+            .await
+            .expect_err("too many MCP declarations must fail before discovery");
+
+        assert!(matches!(
+            error,
+            ToolError::Config(message)
+                if message.contains("MCP server declarations")
+                    && message.contains(&MAX_MCP_SERVERS_PER_REQUEST.to_string())
+        ));
+    }
+
+    #[tokio::test]
+    async fn build_with_handlers_rejects_too_many_discovered_mcp_tools() {
+        let first_count = MAX_DISCOVERED_MCP_TOOLS_PER_REQUEST / 2;
+        let second_count = MAX_DISCOVERED_MCP_TOOLS_PER_REQUEST - first_count;
+        let mut accepted_executors = GatewayExecutors::default();
+        accepted_executors.insert(GatewayExecutorRegistration::Mcp {
+            server_label: "accepted-first".to_owned(),
+            handlers: discovered_handlers("accepted-first", 0, first_count),
+        });
+        accepted_executors.insert(GatewayExecutorRegistration::Mcp {
+            server_label: "accepted-second".to_owned(),
+            handlers: discovered_handlers("accepted-second", first_count, second_count),
+        });
+        let mut accepted_tools = vec![
+            configured_declaration("accepted-first"),
+            configured_declaration("accepted-second"),
+        ];
+        ToolRegistry::build_with_handlers(&mut accepted_tools, &mut accepted_executors)
+            .await
+            .expect("the documented discovered MCP tool limit must be accepted across servers");
+
+        let mut executors = GatewayExecutors::default();
+        executors.insert(GatewayExecutorRegistration::Mcp {
+            server_label: "first".to_owned(),
+            handlers: discovered_handlers("first", 0, first_count),
+        });
+        executors.insert(GatewayExecutorRegistration::Mcp {
+            server_label: "second".to_owned(),
+            handlers: discovered_handlers("second", first_count, second_count + 1),
+        });
+        let mut tools = vec![configured_declaration("first"), configured_declaration("second")];
+
+        let error = ToolRegistry::build_with_handlers(&mut tools, &mut executors)
+            .await
+            .expect_err("too many discovered MCP tools must fail");
+
+        assert!(matches!(
+            error,
+            ToolError::Execution(message)
+                if message.contains("discovered MCP tools")
+                    && message.contains(&MAX_DISCOVERED_MCP_TOOLS_PER_REQUEST.to_string())
+        ));
     }
 
     #[tokio::test]

--- a/crates/agentic-server-core/src/tool/web_search.rs
+++ b/crates/agentic-server-core/src/tool/web_search.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::sync::Semaphore;
 
+use super::handler::MAX_GATEWAY_TOOL_OUTPUT_BYTES;
 use super::handler::{GatewayExecutor, GatewayToolEventPlan, ToolError, ToolHandler, ToolOutput};
 use super::ownership::GatewayBinding;
 use super::registry::{ToolEntry, ToolType};
@@ -207,31 +208,42 @@ impl WebSearchHandler {
         let args = WebSearchArguments::from_json(arguments)?;
         let queries = args.all_queries();
         let args_ref = &args;
-        let responses = futures::stream::iter(queries.iter().cloned())
-            .map(|query| {
-                let provider = Arc::clone(provider);
-                let query_permits = Arc::clone(&self.query_permits);
-                async move {
-                    let _permit = query_permits
-                        .acquire_owned()
-                        .await
-                        .map_err(|error| ToolError::Execution(format!("web_search query scheduler closed: {error}")))?;
-                    provider.search(&query, args_ref, params).await
-                }
-            })
-            .buffered(self.max_concurrent_queries.get())
-            .try_collect::<Vec<_>>()
-            .await?;
+        let mut responses = Box::pin(
+            futures::stream::iter(queries.iter().cloned())
+                .map(|query| {
+                    let provider = Arc::clone(provider);
+                    let query_permits = Arc::clone(&self.query_permits);
+                    async move {
+                        let _permit = query_permits.acquire_owned().await.map_err(|error| {
+                            ToolError::Execution(format!("web_search query scheduler closed: {error}"))
+                        })?;
+                        provider.search(&query, args_ref, params).await
+                    }
+                })
+                .buffered(self.max_concurrent_queries.get()),
+        );
 
         let mut web = Vec::new();
         let mut news = Vec::new();
         let mut metadata = Vec::new();
-        for response in responses {
-            if let Some(results) = response.results.get("web").and_then(Value::as_array) {
-                web.extend(results.iter().cloned());
+        let mut accumulated_bytes = 0usize;
+        while let Some(mut response) = responses.try_next().await? {
+            let response_bytes = serde_json::to_vec(&response.results)
+                .and_then(|results| {
+                    serde_json::to_vec(&response.metadata).map(|metadata| results.len() + metadata.len())
+                })
+                .map_err(|error| ToolError::Execution(format!("failed to size web_search output: {error}")))?;
+            accumulated_bytes = accumulated_bytes.saturating_add(response_bytes);
+            if accumulated_bytes > MAX_GATEWAY_TOOL_OUTPUT_BYTES {
+                return Err(ToolError::Execution(format!(
+                    "web_search output exceeded {MAX_GATEWAY_TOOL_OUTPUT_BYTES} bytes"
+                )));
             }
-            if let Some(results) = response.results.get("news").and_then(Value::as_array) {
-                news.extend(results.iter().cloned());
+            if let Some(results) = response.results.get_mut("web").and_then(Value::as_array_mut) {
+                web.append(results);
+            }
+            if let Some(results) = response.results.get_mut("news").and_then(Value::as_array_mut) {
+                news.append(results);
             }
             metadata.push(response.metadata);
         }
@@ -242,6 +254,11 @@ impl WebSearchHandler {
             "metadata": metadata
         }))
         .map_err(|e| ToolError::Execution(format!("failed to serialize web_search output: {e}")))?;
+        if output.len() > MAX_GATEWAY_TOOL_OUTPUT_BYTES {
+            return Err(ToolError::Execution(format!(
+                "web_search output exceeded {MAX_GATEWAY_TOOL_OUTPUT_BYTES} bytes"
+            )));
+        }
 
         Ok(ToolOutput {
             call_id: call_id.to_owned(),
@@ -320,16 +337,13 @@ impl WebSearchProvider for YouSearchProvider {
 
             if !resp.status().is_success() {
                 let status = resp.status();
-                let body = resp.text().await.unwrap_or_default();
+                let body = read_search_response_limited(resp).await.unwrap_or_default();
                 return Err(ToolError::Execution(format!(
                     "You.com search returned {status}: {body}"
                 )));
             }
 
-            let response_text = resp
-                .text()
-                .await
-                .map_err(|e| ToolError::Execution(format!("failed to read You.com search response: {e}")))?;
+            let response_text = read_search_response_limited(resp).await?;
             let response: Value = serde_json::from_str(&response_text)
                 .map_err(|e| ToolError::Execution(format!("You.com search returned invalid JSON: {e}")))?;
             Ok(WebSearchProviderResponse {
@@ -341,6 +355,22 @@ impl WebSearchProvider for YouSearchProvider {
             })
         })
     }
+}
+
+async fn read_search_response_limited(resp: reqwest::Response) -> Result<String, ToolError> {
+    let mut stream = resp.bytes_stream();
+    let mut body = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        let chunk =
+            chunk.map_err(|error| ToolError::Execution(format!("failed to read You.com search response: {error}")))?;
+        if chunk.len() > MAX_GATEWAY_TOOL_OUTPUT_BYTES.saturating_sub(body.len()) {
+            return Err(ToolError::Execution(format!(
+                "You.com search response exceeded {MAX_GATEWAY_TOOL_OUTPUT_BYTES} bytes"
+            )));
+        }
+        body.extend_from_slice(&chunk);
+    }
+    String::from_utf8(body).map_err(|_| ToolError::Execution("You.com search response was not valid UTF-8".to_owned()))
 }
 
 impl ToolHandler for WebSearchHandler {
@@ -666,6 +696,9 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 
+    use axum::body::Body;
+    use bytes::Bytes;
+
     use super::*;
 
     #[derive(Debug)]
@@ -690,6 +723,28 @@ mod tests {
                         "news": []
                     }),
                     metadata: serde_json::json!({"provider": "mock"}),
+                })
+            })
+        }
+    }
+
+    #[derive(Debug)]
+    struct LargeSearchProvider;
+
+    impl WebSearchProvider for LargeSearchProvider {
+        fn search<'a>(
+            &'a self,
+            _query: &'a str,
+            _args: &'a WebSearchArguments,
+            _config: &'a WebSearchToolParam,
+        ) -> Pin<Box<dyn Future<Output = Result<WebSearchProviderResponse, ToolError>> + Send + 'a>> {
+            Box::pin(async move {
+                Ok(WebSearchProviderResponse {
+                    results: serde_json::json!({
+                        "web": [{"snippet": "x".repeat(600 * 1024)}],
+                        "news": []
+                    }),
+                    metadata: Value::Null,
                 })
             })
         }
@@ -725,6 +780,36 @@ mod tests {
     fn web_search_schema_caps_batched_queries() {
         let parameters = web_search_function_tool().parameters.expect("web_search parameters");
         assert_eq!(parameters["properties"]["queries"]["maxItems"], MAX_WEB_SEARCH_QUERIES);
+    }
+
+    #[tokio::test]
+    async fn you_search_response_body_is_bounded_while_reading() {
+        let chunk = Bytes::from(vec![b'x'; MAX_GATEWAY_TOOL_OUTPUT_BYTES / 2 + 1]);
+        let app = axum::Router::new().route(
+            "/v1/search",
+            axum::routing::get(move || {
+                let chunks = [Ok::<_, std::convert::Infallible>(chunk.clone()), Ok(chunk.clone())];
+                async move { Body::from_stream(futures::stream::iter(chunks)) }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind search response limit server");
+        let address = listener.local_addr().expect("search response limit server address");
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.ok();
+        });
+        let response = reqwest::Client::new()
+            .get(format!("http://{address}/v1/search"))
+            .send()
+            .await
+            .expect("fetch oversized search response");
+
+        let error = read_search_response_limited(response)
+            .await
+            .expect_err("oversized search response must fail");
+        assert!(error.to_string().contains("search response exceeded"));
+        server.abort();
     }
 
     #[tokio::test]
@@ -764,6 +849,22 @@ mod tests {
         assert_eq!(body["queries"], serde_json::json!(["potato", "tomato"]));
         assert_eq!(body["results"]["web"].as_array().unwrap().len(), 2);
         assert_eq!(body["metadata"].as_array().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn web_search_handler_bounds_aggregate_query_results() {
+        let handler = WebSearchHandler::with_provider(Arc::new(LargeSearchProvider));
+        let error = handler
+            .execute(
+                "call_search",
+                "web_search",
+                r#"{"queries":["potato","tomato"]}"#,
+                &WebSearchToolParam::default(),
+            )
+            .await
+            .expect_err("aggregate query results must be bounded");
+
+        assert!(error.to_string().contains("web_search output exceeded"));
     }
 
     #[tokio::test]

--- a/crates/agentic-server-core/src/tool/web_search.rs
+++ b/crates/agentic-server-core/src/tool/web_search.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::future::Future;
+use std::io::{self, Write};
 use std::num::NonZeroUsize;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -21,6 +22,25 @@ use crate::types::tools::{WebSearchContextSize, WebSearchToolParam};
 const YOU_API_KEY: &str = "YOU_API_KEY";
 const YOU_API_BASE_URL: &str = "YOU_API_BASE_URL";
 const MAX_WEB_SEARCH_QUERIES: usize = 5;
+
+#[derive(Default)]
+struct CountingWriter {
+    bytes: usize,
+}
+
+impl Write for CountingWriter {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        self.bytes = self
+            .bytes
+            .checked_add(buffer.len())
+            .ok_or_else(|| io::Error::other("serialized JSON size overflow"))?;
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
 
 pub(crate) type WebSearchExecutor =
     dyn GatewayExecutor<ToolParams = WebSearchToolParam, ExecutionParams = WebSearchToolParam>;
@@ -228,12 +248,11 @@ impl WebSearchHandler {
         let mut metadata = Vec::new();
         let mut accumulated_bytes = 0usize;
         while let Some(mut response) = responses.try_next().await? {
-            let response_bytes = serde_json::to_vec(&response.results)
-                .and_then(|results| {
-                    serde_json::to_vec(&response.metadata).map(|metadata| results.len() + metadata.len())
-                })
+            let mut counter = CountingWriter::default();
+            serde_json::to_writer(&mut counter, &response.results)
+                .and_then(|()| serde_json::to_writer(&mut counter, &response.metadata))
                 .map_err(|error| ToolError::Execution(format!("failed to size web_search output: {error}")))?;
-            accumulated_bytes = accumulated_bytes.saturating_add(response_bytes);
+            accumulated_bytes = accumulated_bytes.saturating_add(counter.bytes);
             if accumulated_bytes > MAX_GATEWAY_TOOL_OUTPUT_BYTES {
                 return Err(ToolError::Execution(format!(
                     "web_search output exceeded {MAX_GATEWAY_TOOL_OUTPUT_BYTES} bytes"

--- a/crates/agentic-server/src/handler/websocket/error.rs
+++ b/crates/agentic-server/src/handler/websocket/error.rs
@@ -21,14 +21,11 @@ pub(super) enum WsError {
     #[error("websocket messages must be JSON text frames")]
     BinaryFrame,
 
+    #[error("too many outstanding websocket response.create requests")]
+    TooManyRequests,
+
     #[error("websocket send failed")]
     SendFailed,
-
-    #[error("websocket client disconnected")]
-    ClientDisconnected,
-
-    #[error("websocket receive failed: {0}")]
-    Receive(String),
 }
 
 impl From<ExecutorError> for WsError {
@@ -42,9 +39,8 @@ impl WsError {
         match self {
             Self::Executor(err) => err.http_status(),
             Self::InvalidJson(_) | Self::UnexpectedType | Self::BinaryFrame => StatusCode::BAD_REQUEST,
-            Self::SerializeJson(_) | Self::SendFailed | Self::ClientDisconnected | Self::Receive(_) => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
+            Self::TooManyRequests => StatusCode::TOO_MANY_REQUESTS,
+            Self::SerializeJson(_) | Self::SendFailed => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 
@@ -53,7 +49,8 @@ impl WsError {
             Self::Executor(err) => err.error_code(),
             Self::InvalidJson(_) => "invalid_json",
             Self::UnexpectedType | Self::BinaryFrame => "invalid_request_error",
-            Self::SerializeJson(_) | Self::SendFailed | Self::ClientDisconnected | Self::Receive(_) => "server_error",
+            Self::TooManyRequests => "rate_limit_exceeded",
+            Self::SerializeJson(_) | Self::SendFailed => "server_error",
         }
     }
 
@@ -62,7 +59,8 @@ impl WsError {
             Self::Executor(err) => err.error_type(),
             Self::InvalidJson(_) => "invalid_json",
             Self::UnexpectedType | Self::BinaryFrame => "invalid_request_error",
-            Self::SerializeJson(_) | Self::SendFailed | Self::ClientDisconnected | Self::Receive(_) => "server_error",
+            Self::TooManyRequests => "rate_limit_error",
+            Self::SerializeJson(_) | Self::SendFailed => "server_error",
         }
     }
 
@@ -81,10 +79,7 @@ impl WsError {
     }
 
     pub(super) fn to_ws_frame(&self) -> Option<Value> {
-        if matches!(
-            self,
-            Self::SerializeJson(_) | Self::SendFailed | Self::ClientDisconnected | Self::Receive(_)
-        ) {
+        if matches!(self, Self::SerializeJson(_) | Self::SendFailed) {
             return None;
         }
 

--- a/crates/agentic-server/src/handler/websocket/responses.rs
+++ b/crates/agentic-server/src/handler/websocket/responses.rs
@@ -59,6 +59,14 @@ impl TryFrom<String> for StreamId {
     }
 }
 
+impl TryFrom<&str> for StreamId {
+    type Error = String;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::try_from(value.to_owned())
+    }
+}
+
 struct WsRequest {
     payload: RequestPayload,
     stream_id: Option<StreamId>,
@@ -515,10 +523,15 @@ fn parse_ws_request(text: &str) -> Result<WsRequest, WsRequestParseError> {
     })?;
     let stream_id = value
         .get("stream_id")
-        .map(|value| serde_json::from_value::<StreamId>(value.clone()))
+        .map(|value| {
+            value
+                .as_str()
+                .ok_or_else(|| "stream_id must be a string".to_owned())
+                .and_then(StreamId::try_from)
+        })
         .transpose()
         .map_err(|error| WsRequestParseError {
-            error: WsError::from(ExecutorError::from(error)),
+            error: WsError::from(ExecutorError::InvalidRequest(error)),
             stream_id: None,
         })?;
 

--- a/crates/agentic-server/src/handler/websocket/responses.rs
+++ b/crates/agentic-server/src/handler/websocket/responses.rs
@@ -1,4 +1,4 @@
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
@@ -6,9 +6,12 @@ use axum::extract::{Extension, State};
 use axum::http::HeaderMap;
 use axum::response::Response;
 use either::Either;
-use futures::stream::{SplitSink, SplitStream};
+use futures::stream::SplitSink;
 use futures::{Sink, SinkExt, Stream, StreamExt};
+use serde::Deserialize;
 use serde_json::Value;
+use tokio::sync::mpsc;
+use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
@@ -25,7 +28,241 @@ use crate::app::AppState;
 use crate::auth::AuthenticatedPrincipal;
 
 type WsSender = SplitSink<WebSocket, Message>;
-type WsReceiver = SplitStream<WebSocket>;
+
+const WS_OUTBOUND_BUFFER: usize = 64;
+const WS_MAX_OUTSTANDING_REQUESTS: usize = 64;
+const WS_MAX_OUTSTANDING_BYTES: usize = 12 * 1024 * 1024;
+const WS_MAX_STREAM_ID_CHARS: usize = 256;
+
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq)]
+#[serde(try_from = "String")]
+struct StreamId(String);
+
+impl StreamId {
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl TryFrom<String> for StreamId {
+    type Error = String;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        let character_count = value.chars().count();
+        if (1..=WS_MAX_STREAM_ID_CHARS).contains(&character_count) {
+            Ok(Self(value))
+        } else {
+            Err(format!(
+                "stream_id must contain between 1 and {WS_MAX_STREAM_ID_CHARS} characters"
+            ))
+        }
+    }
+}
+
+struct WsRequest {
+    payload: RequestPayload,
+    stream_id: Option<StreamId>,
+    generate: Option<bool>,
+}
+
+#[derive(Debug)]
+struct WsRequestParseError {
+    error: WsError,
+    stream_id: Option<StreamId>,
+}
+
+enum WsWorkItem {
+    Execute {
+        request: Box<WsRequest>,
+        input_bytes: usize,
+    },
+    Reject {
+        error: WsRequestParseError,
+        input_bytes: usize,
+    },
+}
+
+impl WsWorkItem {
+    fn stream_id(&self) -> Option<&StreamId> {
+        match self {
+            Self::Execute { request, .. } => request.stream_id.as_ref(),
+            Self::Reject { error, .. } => error.stream_id.as_ref(),
+        }
+    }
+
+    fn lane(&self) -> Option<StreamId> {
+        self.stream_id().cloned()
+    }
+
+    fn input_bytes(&self) -> usize {
+        match self {
+            Self::Execute { input_bytes, .. } | Self::Reject { input_bytes, .. } => *input_bytes,
+        }
+    }
+}
+
+struct WsAdmissionError {
+    stream_id: Option<StreamId>,
+}
+
+struct RequestCompletion {
+    lane: Option<StreamId>,
+    input_bytes: usize,
+    result: Result<(), WsError>,
+}
+
+#[derive(Default)]
+struct WsByteBudget {
+    used: usize,
+}
+
+impl WsByteBudget {
+    fn can_reserve(&self, input_bytes: usize) -> bool {
+        input_bytes <= WS_MAX_OUTSTANDING_BYTES.saturating_sub(self.used)
+    }
+
+    fn reserve(&mut self, input_bytes: usize) {
+        debug_assert!(self.can_reserve(input_bytes));
+        self.used += input_bytes;
+    }
+
+    fn release(&mut self, input_bytes: usize) {
+        self.used = self.used.saturating_sub(input_bytes);
+    }
+}
+
+struct WsMultiplexer {
+    state: Arc<AppState>,
+    auth: Option<String>,
+    outbound_tx: mpsc::Sender<Value>,
+    lanes: HashMap<Option<StreamId>, VecDeque<WsWorkItem>>,
+    request_tasks: JoinSet<RequestCompletion>,
+    queued_requests: usize,
+    byte_budget: WsByteBudget,
+    shutdown_token: CancellationToken,
+}
+
+impl WsMultiplexer {
+    fn new(
+        state: Arc<AppState>,
+        auth: Option<String>,
+        outbound_tx: mpsc::Sender<Value>,
+        shutdown_token: CancellationToken,
+    ) -> Self {
+        Self {
+            state,
+            auth,
+            outbound_tx,
+            lanes: HashMap::new(),
+            request_tasks: JoinSet::new(),
+            queued_requests: 0,
+            byte_budget: WsByteBudget::default(),
+            shutdown_token,
+        }
+    }
+
+    fn has_capacity_for(&self, input_bytes: usize) -> bool {
+        self.request_tasks.len() + self.queued_requests < WS_MAX_OUTSTANDING_REQUESTS
+            && self.byte_budget.can_reserve(input_bytes)
+    }
+
+    fn schedule(&mut self, work: WsWorkItem) -> Result<(), WsAdmissionError> {
+        if !self.has_capacity_for(work.input_bytes()) {
+            return Err(WsAdmissionError {
+                stream_id: work.stream_id().cloned(),
+            });
+        }
+
+        self.byte_budget.reserve(work.input_bytes());
+        let lane = work.lane();
+        if let Some(queue) = self.lanes.get_mut(&lane) {
+            queue.push_back(work);
+            self.queued_requests += 1;
+            debug!(stream_id = ?lane, queued_requests = queue.len(), "queued websocket request on active lane");
+            return Ok(());
+        }
+
+        self.lanes.insert(lane.clone(), VecDeque::new());
+        self.spawn(lane, work);
+        Ok(())
+    }
+
+    fn schedule_next(&mut self, lane: Option<StreamId>) {
+        let next = self.lanes.get_mut(&lane).and_then(VecDeque::pop_front);
+        if let Some(work) = next {
+            self.queued_requests -= 1;
+            self.spawn(lane, work);
+        } else {
+            self.lanes.remove(&lane);
+        }
+    }
+
+    fn discard_queued(&mut self) {
+        let discarded_bytes = self
+            .lanes
+            .values()
+            .flat_map(|queue| queue.iter())
+            .map(WsWorkItem::input_bytes)
+            .sum::<usize>();
+        self.byte_budget.release(discarded_bytes);
+        self.lanes.clear();
+        self.queued_requests = 0;
+    }
+
+    fn finish(&mut self, completion: Result<RequestCompletion, tokio::task::JoinError>, draining: bool) -> bool {
+        let completion = match completion {
+            Ok(completion) => completion,
+            Err(error) => {
+                warn!(%error, "responses websocket request task failed");
+                return false;
+            }
+        };
+        self.byte_budget.release(completion.input_bytes);
+        if let Err(error) = completion.result {
+            warn!(%error, "responses websocket request failed without a client-visible event");
+            return false;
+        }
+        if !draining && !self.shutdown_token.is_cancelled() {
+            self.schedule_next(completion.lane);
+        }
+        true
+    }
+
+    fn reap_ready(&mut self, draining: bool) -> bool {
+        while let Some(completion) = self.request_tasks.try_join_next() {
+            if !self.finish(completion, draining) {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn spawn(&mut self, lane: Option<StreamId>, work: WsWorkItem) {
+        let state = Arc::clone(&self.state);
+        let auth = self.auth.clone();
+        let outbound_tx = self.outbound_tx.clone();
+        let shutdown_token = self.shutdown_token.clone();
+        let stream_id = work.stream_id().cloned();
+        let input_bytes = work.input_bytes();
+        self.request_tasks.spawn(async move {
+            let result = match work {
+                WsWorkItem::Execute { request, .. } => {
+                    handle_ws_request(*request, &state, auth, &outbound_tx, &shutdown_token).await
+                }
+                WsWorkItem::Reject { error, .. } => Err(error.error),
+            };
+            let result = match result {
+                Ok(()) => Ok(()),
+                Err(error) => queue_ws_error(&outbound_tx, error, stream_id.as_ref()).await,
+            };
+            RequestCompletion {
+                lane,
+                input_bytes,
+                result,
+            }
+        });
+    }
+}
 
 pub async fn responses_ws(State(state): State<AppState>, headers: HeaderMap, ws: WebSocketUpgrade) -> Response {
     upgrade_responses_ws(state, headers, ws, None)
@@ -55,6 +292,15 @@ fn upgrade_responses_ws(
         })
 }
 
+fn begin_ws_draining(multiplexer: &mut WsMultiplexer, draining: &mut bool) {
+    *draining = true;
+    multiplexer.discard_queued();
+    debug!(
+        active_streams = multiplexer.request_tasks.len(),
+        "draining responses websocket session"
+    );
+}
+
 async fn responses_ws_loop(
     socket: WebSocket,
     state: AppState,
@@ -63,73 +309,163 @@ async fn responses_ws_loop(
 ) {
     debug!("responses websocket session opened");
     let shutdown_token = state.shutdown_token.clone();
+    let state = Arc::new(state);
     let (mut sender, mut receiver) = socket.split();
-
-    // Requests received while a stream is active, processed in order after it completes.
-    let mut queue: VecDeque<String> = VecDeque::new();
+    let auth = extract_bearer(&headers, state.openai_api_key.as_deref());
+    let (outbound_tx, mut outbound_rx) = mpsc::channel(WS_OUTBOUND_BUFFER);
+    let mut multiplexer = WsMultiplexer::new(state, auth, outbound_tx, shutdown_token.clone());
+    let mut draining = false;
+    let mut client_disconnected = false;
 
     loop {
-        if shutdown_token.is_cancelled() {
+        if shutdown_token.is_cancelled() && !draining {
+            begin_ws_draining(&mut multiplexer, &mut draining);
+        }
+        if draining && multiplexer.request_tasks.is_empty() && outbound_rx.is_empty() {
             break;
         }
-        let text = if let Some(buffered) = queue.pop_front() {
-            buffered
-        } else {
-            let message = next_ws_message(&shutdown_token, &mut receiver).await;
 
-            let Some(message) = message else {
-                break;
-            };
-
-            match message {
-                Ok(Message::Text(text)) => text.to_string(),
-                Ok(Message::Binary(_)) => {
-                    if !handle_ws_error(&mut sender, WsError::BinaryFrame).await {
-                        break;
-                    }
+        tokio::select! {
+            () = shutdown_token.cancelled(), if !draining => {
+                begin_ws_draining(&mut multiplexer, &mut draining);
+            }
+            outbound = outbound_rx.recv() => {
+                let Some(value) = outbound else {
                     continue;
-                }
-                Ok(Message::Close(_)) => break,
-                Ok(Message::Ping(payload)) => {
-                    if sender.send(Message::Pong(payload)).await.is_err() {
-                        break;
-                    }
-                    continue;
-                }
-                Ok(Message::Pong(_)) => continue,
-                Err(e) => {
-                    warn!("responses websocket receive error: {e}");
+                };
+                if send_ws_json(&mut sender, value).await.is_err() {
+                    client_disconnected = true;
                     break;
                 }
             }
-        };
-
-        if let Some(event) = websocket_identity_error_event(principal.as_ref()) {
-            let _ = send_ws_json(&mut sender, event).await;
-            break;
-        }
-
-        match handle_ws_text(
-            &mut sender,
-            &mut receiver,
-            &state,
-            &headers,
-            &text,
-            &shutdown_token,
-            &mut queue,
-        )
-        .await
-        {
-            Ok(()) => {}
-            Err(err) => {
-                if !handle_ws_error(&mut sender, err).await {
+            completion = multiplexer.request_tasks.join_next(), if !multiplexer.request_tasks.is_empty() => {
+                let Some(completion) = completion else {
+                    continue;
+                };
+                if !multiplexer.finish(completion, draining) {
+                    client_disconnected = true;
                     break;
+                }
+                if shutdown_token.is_cancelled() && !draining {
+                    begin_ws_draining(&mut multiplexer, &mut draining);
+                }
+            }
+            message = receiver.next() => {
+                if shutdown_token.is_cancelled() && !draining {
+                    begin_ws_draining(&mut multiplexer, &mut draining);
+                    debug!("discarded websocket message received during shutdown");
+                    continue;
+                }
+                let Some(message) = message else {
+                    client_disconnected = true;
+                    break;
+                };
+                match message {
+                    Ok(message) => {
+                        if !handle_ws_client_message(
+                            message,
+                            &mut sender,
+                            &mut multiplexer,
+                            principal.as_ref(),
+                            &mut draining,
+                        )
+                        .await
+                        {
+                            client_disconnected = true;
+                            break;
+                        }
+                    }
+                    Err(error) => {
+                        warn!(%error, "responses websocket receive error");
+                        client_disconnected = true;
+                        break;
+                    }
                 }
             }
         }
     }
+
+    if client_disconnected {
+        multiplexer.request_tasks.abort_all();
+        while multiplexer.request_tasks.join_next().await.is_some() {}
+    }
+    drop(multiplexer.outbound_tx);
     close_ws(&mut sender, &mut receiver).await;
     debug!("responses websocket session closed");
+}
+
+async fn handle_ws_client_message(
+    message: Message,
+    sender: &mut WsSender,
+    multiplexer: &mut WsMultiplexer,
+    principal: Option<&AuthenticatedPrincipal>,
+    draining: &mut bool,
+) -> bool {
+    match message {
+        Message::Text(_) if *draining => {
+            debug!("discarded websocket response.create during shutdown");
+            true
+        }
+        Message::Text(text) => {
+            if let Some(event) = websocket_identity_error_event(principal) {
+                let stream_id = stream_id_from_text(&text);
+                let send_succeeded = match attach_stream_id(event, stream_id.as_ref()) {
+                    Ok(event) => send_ws_json(sender, event).await.is_ok(),
+                    Err(error) => {
+                        warn!(%error, "failed to build websocket identity error event");
+                        false
+                    }
+                };
+                *draining = true;
+                multiplexer.discard_queued();
+                return send_succeeded;
+            }
+
+            if !multiplexer.reap_ready(*draining) {
+                return false;
+            }
+            if multiplexer.shutdown_token.is_cancelled() {
+                begin_ws_draining(multiplexer, draining);
+                debug!("discarded websocket response.create during shutdown");
+                return true;
+            }
+            let input_bytes = text.len();
+            if !multiplexer.has_capacity_for(input_bytes) {
+                let stream_id = stream_id_from_text(&text);
+                return handle_ws_error(sender, WsError::TooManyRequests, stream_id.as_ref()).await;
+            }
+            let work = match parse_ws_request(&text) {
+                Ok(request) => WsWorkItem::Execute {
+                    request: Box::new(request),
+                    input_bytes,
+                },
+                Err(error) => WsWorkItem::Reject { error, input_bytes },
+            };
+            if multiplexer.shutdown_token.is_cancelled() {
+                begin_ws_draining(multiplexer, draining);
+                debug!("discarded websocket response.create during shutdown");
+                return true;
+            }
+            match multiplexer.schedule(work) {
+                Ok(()) => true,
+                Err(rejected) => handle_ws_error(sender, WsError::TooManyRequests, rejected.stream_id.as_ref()).await,
+            }
+        }
+        Message::Binary(_) if *draining => true,
+        Message::Binary(_) => handle_ws_error(sender, WsError::BinaryFrame, None).await,
+        Message::Close(_) => false,
+        Message::Ping(payload) => sender.send(Message::Pong(payload)).await.is_ok(),
+        Message::Pong(_) => true,
+    }
+}
+
+fn stream_id_from_text(text: &str) -> Option<StreamId> {
+    #[derive(Deserialize)]
+    struct StreamIdEnvelope {
+        stream_id: Option<StreamId>,
+    }
+
+    serde_json::from_str::<StreamIdEnvelope>(text).ok()?.stream_id
 }
 
 fn websocket_identity_error_event(principal: Option<&AuthenticatedPrincipal>) -> Option<Value> {
@@ -142,26 +478,6 @@ fn websocket_identity_error_event(principal: Option<&AuthenticatedPrincipal>) ->
             "sequence_number": 0,
         })
     })
-}
-
-async fn next_ws_message<Receiver>(
-    shutdown_token: &CancellationToken,
-    receiver: &mut Receiver,
-) -> Option<Receiver::Item>
-where
-    Receiver: Stream + Unpin,
-{
-    tokio::select! {
-        biased;
-        () = shutdown_token.cancelled() => None,
-        message = receiver.next() => {
-            if shutdown_token.is_cancelled() {
-                None
-            } else {
-                message
-            }
-        },
-    }
 }
 
 fn keep_if_running<T>(shutdown_token: &CancellationToken, value: T) -> Option<T> {
@@ -192,27 +508,32 @@ where
     }
 }
 
-/// Process one `response.create` message.
-///
-/// Any requests received from the client while the stream is active are
-/// pushed onto `queue` and processed by the caller in order after this returns.
-async fn handle_ws_text(
-    sender: &mut WsSender,
-    receiver: &mut WsReceiver,
-    state: &AppState,
-    headers: &HeaderMap,
-    text: &str,
-    shutdown_token: &CancellationToken,
-    queue: &mut VecDeque<String>,
-) -> Result<(), WsError> {
-    let value = serde_json::from_str::<Value>(text).map_err(WsError::InvalidJson)?;
+fn parse_ws_request(text: &str) -> Result<WsRequest, WsRequestParseError> {
+    let value = serde_json::from_str::<Value>(text).map_err(|error| WsRequestParseError {
+        error: WsError::InvalidJson(error),
+        stream_id: None,
+    })?;
+    let stream_id = value
+        .get("stream_id")
+        .map(|value| serde_json::from_value::<StreamId>(value.clone()))
+        .transpose()
+        .map_err(|error| WsRequestParseError {
+            error: WsError::from(ExecutorError::from(error)),
+            stream_id: None,
+        })?;
 
     if value.get("type").and_then(Value::as_str) != Some("response.create") {
-        return Err(WsError::UnexpectedType);
+        return Err(WsRequestParseError {
+            error: WsError::UnexpectedType,
+            stream_id,
+        });
     }
 
     let generate = value.get("generate").and_then(Value::as_bool);
-    let mut payload = serde_json::from_value::<RequestPayload>(value).map_err(ExecutorError::from)?;
+    let mut payload = serde_json::from_value::<RequestPayload>(value).map_err(|error| WsRequestParseError {
+        error: WsError::from(ExecutorError::from(error)),
+        stream_id: stream_id.clone(),
+    })?;
     let requested_stream = payload.stream;
     let requested_store = payload.store;
     payload.stream = true;
@@ -224,17 +545,37 @@ async fn handle_ws_text(
         forced_store = payload.store,
         has_previous_response_id = payload.previous_response_id.is_some(),
         has_conversation_id = payload.conversation_id.is_some(),
+        stream_id = stream_id.as_ref().map(StreamId::as_str),
         ?generate,
         tools = payload.tools.as_ref().map_or(0, Vec::len),
         "accepted websocket response.create"
     );
 
+    Ok(WsRequest {
+        payload,
+        stream_id,
+        generate,
+    })
+}
+
+async fn handle_ws_request(
+    request: WsRequest,
+    state: &AppState,
+    auth: Option<String>,
+    outbound_tx: &mpsc::Sender<Value>,
+    shutdown_token: &CancellationToken,
+) -> Result<(), WsError> {
+    let WsRequest {
+        payload,
+        stream_id,
+        generate,
+    } = request;
+
     if generate == Some(false) {
         debug!("handling non-generating websocket request locally");
-        return complete_without_inference(sender, state, payload).await;
+        return complete_without_inference(outbound_tx, state, payload, stream_id.as_ref()).await;
     }
 
-    let auth = extract_bearer(headers, state.openai_api_key.as_deref());
     let result = ExecuteRequest::new(payload, Arc::clone(&state.exec_ctx))
         .with_auth(auth)
         .run()
@@ -249,13 +590,14 @@ async fn handle_ws_text(
         ))));
     };
 
-    stream_ws_response(sender, receiver, stream, shutdown_token, queue).await
+    stream_ws_response(outbound_tx, stream, stream_id.as_ref()).await
 }
 
 async fn complete_without_inference(
-    sender: &mut WsSender,
+    outbound_tx: &mpsc::Sender<Value>,
     state: &AppState,
     payload: RequestPayload,
+    stream_id: Option<&StreamId>,
 ) -> Result<(), WsError> {
     let ctx = rehydrate_conversation(payload, &state.exec_ctx).await?;
     let created_at = utcnow_str();
@@ -279,8 +621,8 @@ async fn complete_without_inference(
     )
     .await?;
 
-    send_ws_json(sender, created_event).await?;
-    send_ws_json(sender, completed_event).await
+    queue_ws_json(outbound_tx, created_event, stream_id).await?;
+    queue_ws_json(outbound_tx, completed_event, stream_id).await
 }
 
 fn empty_response_event(
@@ -311,108 +653,14 @@ fn empty_response_event(
     })
 }
 
-enum ShutdownInput<ReceiverItem, UpstreamItem> {
-    Receiver(Option<ReceiverItem>),
-    Upstream(Option<UpstreamItem>),
-}
-
-async fn next_shutdown_input<Receiver, Upstream>(
-    receiver: &mut Receiver,
-    upstream: &mut Upstream,
-    prefer_receiver: bool,
-) -> ShutdownInput<Receiver::Item, Upstream::Item>
-where
-    Receiver: Stream + Unpin,
-    Upstream: Stream + Unpin,
-{
-    if prefer_receiver {
-        tokio::select! {
-            biased;
-            message = receiver.next() => ShutdownInput::Receiver(message),
-            line = upstream.next() => ShutdownInput::Upstream(line),
-        }
-    } else {
-        tokio::select! {
-            biased;
-            line = upstream.next() => ShutdownInput::Upstream(line),
-            message = receiver.next() => ShutdownInput::Receiver(message),
-        }
-    }
-}
-
-/// Stream a response from the executor to the client.
-///
-/// Requests arriving from the client while the stream is active are pushed
-/// onto `queue` so the caller can process them in order after this returns.
 async fn stream_ws_response(
-    sender: &mut WsSender,
-    receiver: &mut WsReceiver,
+    outbound_tx: &mpsc::Sender<Value>,
     mut stream: BoxStream,
-    shutdown_token: &CancellationToken,
-    queue: &mut VecDeque<String>,
+    stream_id: Option<&StreamId>,
 ) -> Result<(), WsError> {
-    let mut prefer_shutdown_receiver = true;
-    'stream: loop {
-        if shutdown_token.is_cancelled() {
-            match next_shutdown_input(receiver, &mut stream, prefer_shutdown_receiver).await {
-                ShutdownInput::Receiver(message) => {
-                    prefer_shutdown_receiver = false;
-                    match message {
-                        None | Some(Ok(Message::Close(_))) => return Err(WsError::ClientDisconnected),
-                        Some(Ok(Message::Ping(payload))) => {
-                            sender
-                                .send(Message::Pong(payload))
-                                .await
-                                .map_err(|_| WsError::SendFailed)?;
-                        }
-                        Some(Ok(Message::Text(_) | Message::Binary(_) | Message::Pong(_))) => {}
-                        Some(Err(error)) => return Err(WsError::Receive(error.to_string())),
-                    }
-                    continue 'stream;
-                }
-                ShutdownInput::Upstream(line) => {
-                    prefer_shutdown_receiver = true;
-                    let Some(line) = line else {
-                        break;
-                    };
-                    forward_ws_stream_chunk(sender, &line).await?;
-                }
-            }
-            continue;
-        }
-
-        let next_line = tokio::select! {
-            () = shutdown_token.cancelled() => continue 'stream,
-            message = receiver.next() => {
-                match message {
-                    None | Some(Ok(Message::Close(_))) => return Err(WsError::ClientDisconnected),
-                    Some(Ok(Message::Ping(payload))) => {
-                        sender.send(Message::Pong(payload)).await.map_err(|_| WsError::SendFailed)?;
-                        continue 'stream;
-                    }
-                    Some(Ok(Message::Pong(_))) => continue 'stream,
-                    Some(Ok(Message::Binary(_))) => return Err(WsError::BinaryFrame),
-                    Some(Ok(Message::Text(text))) => {
-                        // Client pipelined the next request while we are still streaming.
-                        // Enqueue it and keep draining the current stream.
-                        queue.push_back(text.to_string());
-                        debug!(
-                            queued_requests = queue.len(),
-                            "queued pipelined websocket response.create while stream is active"
-                        );
-                        continue 'stream;
-                    }
-                    Some(Err(e)) => return Err(WsError::Receive(e.to_string())),
-                }
-            }
-            line = stream.next() => line,
-        };
-        let Some(line) = next_line else {
-            break;
-        };
-        forward_ws_stream_chunk(sender, &line).await?;
+    while let Some(line) = stream.next().await {
+        forward_ws_stream_chunk(outbound_tx, &line, stream_id).await?;
     }
-
     Ok(())
 }
 
@@ -424,32 +672,68 @@ fn sse_json_data_lines(chunk: &str) -> impl Iterator<Item = &str> {
         .filter(|data| *data != "[DONE]")
 }
 
-async fn forward_ws_stream_chunk(sender: &mut WsSender, chunk: &str) -> Result<(), WsError> {
+async fn forward_ws_stream_chunk(
+    outbound_tx: &mpsc::Sender<Value>,
+    chunk: &str,
+    stream_id: Option<&StreamId>,
+) -> Result<(), WsError> {
     for data in sse_json_data_lines(chunk) {
         let value = serde_json::from_str::<Value>(data)
             .map_err(ExecutorError::from)
             .map_err(WsError::from)?;
-        send_ws_json(sender, value).await?;
+        queue_ws_json(outbound_tx, value, stream_id).await?;
     }
     Ok(())
 }
 
-async fn handle_ws_error(sender: &mut WsSender, err: WsError) -> bool {
+fn attach_stream_id(mut value: Value, stream_id: Option<&StreamId>) -> Result<Value, WsError> {
+    let event = value.as_object_mut().ok_or_else(|| {
+        WsError::from(ExecutorError::StreamError(
+            "upstream WebSocket event must be a JSON object".to_owned(),
+        ))
+    })?;
+    if let Some(stream_id) = stream_id {
+        event.insert("stream_id".to_owned(), Value::String(stream_id.as_str().to_owned()));
+    } else {
+        event.remove("stream_id");
+    }
+    Ok(value)
+}
+
+async fn queue_ws_json(
+    outbound_tx: &mpsc::Sender<Value>,
+    value: Value,
+    stream_id: Option<&StreamId>,
+) -> Result<(), WsError> {
+    outbound_tx
+        .send(attach_stream_id(value, stream_id)?)
+        .await
+        .map_err(|_| WsError::SendFailed)
+}
+
+async fn queue_ws_error(
+    outbound_tx: &mpsc::Sender<Value>,
+    err: WsError,
+    stream_id: Option<&StreamId>,
+) -> Result<(), WsError> {
+    let Some(frame) = err.to_ws_frame() else {
+        return Err(err);
+    };
+    queue_ws_json(outbound_tx, frame, stream_id).await
+}
+
+async fn handle_ws_error(sender: &mut WsSender, err: WsError, stream_id: Option<&StreamId>) -> bool {
     match err {
-        WsError::ClientDisconnected | WsError::SendFailed => false,
-        WsError::Receive(message) => {
-            warn!("responses websocket receive error: {message}");
-            false
-        }
-        err => send_ws_error(sender, &err).await.is_ok(),
+        WsError::SendFailed => false,
+        err => send_ws_error(sender, &err, stream_id).await.is_ok(),
     }
 }
 
-async fn send_ws_error(sender: &mut WsSender, err: &WsError) -> Result<(), WsError> {
+async fn send_ws_error(sender: &mut WsSender, err: &WsError, stream_id: Option<&StreamId>) -> Result<(), WsError> {
     let Some(frame) = err.to_ws_frame() else {
         return Err(WsError::SendFailed);
     };
-    send_ws_json(sender, frame).await
+    send_ws_json(sender, attach_stream_id(frame, stream_id)?).await
 }
 
 async fn send_ws_json(sender: &mut WsSender, value: Value) -> Result<(), WsError> {
@@ -466,22 +750,18 @@ mod tests {
     use std::task::{Context, Poll};
 
     use axum::extract::ws::Message;
-    use futures::{Sink, Stream, StreamExt, sink, stream};
+    use futures::{Sink, StreamExt, sink, stream};
     use serde_json::json;
     use tokio_util::sync::CancellationToken;
 
     use super::{
-        ShutdownInput, WsError, close_ws, keep_if_running, next_shutdown_input, next_ws_message, sse_json_data_lines,
+        StreamId, WS_MAX_OUTSTANDING_BYTES, WS_MAX_OUTSTANDING_REQUESTS, WS_MAX_STREAM_ID_CHARS, WsByteBudget, WsError,
+        attach_stream_id, close_ws, keep_if_running, parse_ws_request, sse_json_data_lines,
         websocket_identity_error_event,
     };
     use crate::auth::AuthenticatedPrincipal;
 
     struct CloseErrorSink;
-
-    struct CancellingStream {
-        shutdown_token: CancellationToken,
-        item: Option<&'static str>,
-    }
 
     #[test]
     fn sse_json_data_lines_accept_named_and_data_only_frames() {
@@ -497,13 +777,62 @@ mod tests {
         );
     }
 
-    impl Stream for CancellingStream {
-        type Item = &'static str;
-
-        fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-            self.shutdown_token.cancel();
-            Poll::Ready(self.item.take())
+    #[test]
+    fn stream_id_must_contain_between_one_and_256_characters() {
+        for invalid in [String::new(), "a".repeat(WS_MAX_STREAM_ID_CHARS + 1)] {
+            let request = json!({
+                "type": "response.create",
+                "stream_id": invalid,
+                "model": "test-model",
+                "input": "hello"
+            });
+            assert!(parse_ws_request(&request.to_string()).is_err());
         }
+        let null_request = json!({
+            "type": "response.create",
+            "stream_id": null,
+            "model": "test-model",
+            "input": "hello"
+        });
+        assert!(parse_ws_request(&null_request.to_string()).is_err());
+
+        let maximum = "🦀".repeat(WS_MAX_STREAM_ID_CHARS);
+        let request = json!({
+            "type": "response.create",
+            "stream_id": maximum,
+            "model": "test-model",
+            "input": "hello"
+        });
+        let parsed = parse_ws_request(&request.to_string()).expect("256-character stream_id should be valid");
+        assert_eq!(parsed.stream_id.expect("stream_id").as_str(), maximum);
+    }
+
+    #[test]
+    fn websocket_capacity_is_bounded_by_count_and_input_bytes() {
+        assert_eq!(WS_MAX_OUTSTANDING_REQUESTS, 64);
+        let mut budget = WsByteBudget::default();
+        budget.reserve(WS_MAX_OUTSTANDING_BYTES - 1);
+        assert!(budget.can_reserve(1));
+        budget.reserve(1);
+        assert!(!budget.can_reserve(1));
+        budget.release(WS_MAX_OUTSTANDING_BYTES);
+        assert!(budget.can_reserve(WS_MAX_OUTSTANDING_BYTES));
+    }
+
+    #[test]
+    fn stream_id_attachment_normalizes_routing_metadata() {
+        let requested = StreamId::try_from("requested".to_owned()).expect("valid stream ID");
+        let tagged = attach_stream_id(
+            json!({"type": "response.created", "stream_id": "spoofed"}),
+            Some(&requested),
+        )
+        .expect("object event");
+        assert_eq!(tagged["stream_id"], "requested");
+
+        let untagged =
+            attach_stream_id(json!({"type": "response.created", "stream_id": "spoofed"}), None).expect("object event");
+        assert!(untagged.get("stream_id").is_none());
+        assert!(attach_stream_id(json!(["response.created"]), Some(&requested)).is_err());
     }
 
     impl Sink<Message> for CloseErrorSink {
@@ -524,29 +853,6 @@ mod tests {
         fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
             Poll::Ready(Err("close failed"))
         }
-    }
-
-    #[tokio::test]
-    async fn cancelled_shutdown_wins_over_ready_websocket_message() {
-        let shutdown_token = CancellationToken::new();
-        shutdown_token.cancel();
-        let mut receiver = stream::iter(["must remain unread"]);
-
-        assert!(next_ws_message(&shutdown_token, &mut receiver).await.is_none());
-        assert_eq!(receiver.next().await, Some("must remain unread"));
-    }
-
-    #[tokio::test]
-    async fn cancellation_during_receive_discards_websocket_message() {
-        let shutdown_token = CancellationToken::new();
-        let mut receiver = CancellingStream {
-            shutdown_token: shutdown_token.clone(),
-            item: Some("must be discarded"),
-        };
-
-        assert!(next_ws_message(&shutdown_token, &mut receiver).await.is_none());
-        assert!(shutdown_token.is_cancelled());
-        assert_eq!(receiver.next().await, None);
     }
 
     #[test]
@@ -614,20 +920,5 @@ mod tests {
         close_ws(&mut sender, &mut receiver).await;
 
         assert!(matches!(receiver.next().await, Some(Ok(Message::Close(None)))));
-    }
-
-    #[tokio::test]
-    async fn shutdown_input_priority_alternates_when_both_streams_are_ready() {
-        let mut receiver = stream::repeat(());
-        let mut upstream = stream::repeat(());
-
-        assert!(matches!(
-            next_shutdown_input(&mut receiver, &mut upstream, true).await,
-            ShutdownInput::Receiver(Some(()))
-        ));
-        assert!(matches!(
-            next_shutdown_input(&mut receiver, &mut upstream, false).await,
-            ShutdownInput::Upstream(Some(()))
-        ));
     }
 }

--- a/crates/agentic-server/src/handler/websocket/responses.rs
+++ b/crates/agentic-server/src/handler/websocket/responses.rs
@@ -30,9 +30,26 @@ use crate::auth::AuthenticatedPrincipal;
 type WsSender = SplitSink<WebSocket, Message>;
 
 const WS_OUTBOUND_BUFFER: usize = 64;
+const WS_MAX_EVENT_BYTES: usize = 1024 * 1024;
 const WS_MAX_OUTSTANDING_REQUESTS: usize = 64;
 const WS_MAX_OUTSTANDING_BYTES: usize = 12 * 1024 * 1024;
 const WS_MAX_STREAM_ID_CHARS: usize = 256;
+
+/// Serialized and size-checked before entering the bounded outbound queue.
+struct WsOutboundEvent(String);
+
+impl WsOutboundEvent {
+    fn new(value: Value, stream_id: Option<&StreamId>) -> Result<Self, WsError> {
+        let value = attach_stream_id(value, stream_id)?;
+        let text = serde_json::to_string(&value).map_err(WsError::SerializeJson)?;
+        if text.len() > WS_MAX_EVENT_BYTES {
+            return Err(WsError::from(ExecutorError::StreamError(format!(
+                "websocket event exceeded {WS_MAX_EVENT_BYTES} bytes"
+            ))));
+        }
+        Ok(Self(text))
+    }
+}
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq)]
 #[serde(try_from = "String")]
@@ -142,7 +159,8 @@ impl WsByteBudget {
 struct WsMultiplexer {
     state: Arc<AppState>,
     auth: Option<String>,
-    outbound_tx: mpsc::Sender<Value>,
+    principal: Option<Arc<AuthenticatedPrincipal>>,
+    outbound_tx: mpsc::Sender<WsOutboundEvent>,
     lanes: HashMap<Option<StreamId>, VecDeque<WsWorkItem>>,
     request_tasks: JoinSet<RequestCompletion>,
     queued_requests: usize,
@@ -154,12 +172,14 @@ impl WsMultiplexer {
     fn new(
         state: Arc<AppState>,
         auth: Option<String>,
-        outbound_tx: mpsc::Sender<Value>,
+        principal: Option<AuthenticatedPrincipal>,
+        outbound_tx: mpsc::Sender<WsOutboundEvent>,
         shutdown_token: CancellationToken,
     ) -> Self {
         Self {
             state,
             auth,
+            principal: principal.map(Arc::new),
             outbound_tx,
             lanes: HashMap::new(),
             request_tasks: JoinSet::new(),
@@ -248,11 +268,21 @@ impl WsMultiplexer {
     fn spawn(&mut self, lane: Option<StreamId>, work: WsWorkItem) {
         let state = Arc::clone(&self.state);
         let auth = self.auth.clone();
+        let principal = self.principal.clone();
         let outbound_tx = self.outbound_tx.clone();
         let shutdown_token = self.shutdown_token.clone();
         let stream_id = work.stream_id().cloned();
         let input_bytes = work.input_bytes();
         self.request_tasks.spawn(async move {
+            // Admission may precede dispatch by an entire inference/tool round.
+            // Recheck here for both new lanes and work dequeued by schedule_next.
+            if let Some(event) = websocket_identity_error_event(principal.as_deref()) {
+                return RequestCompletion {
+                    lane,
+                    input_bytes,
+                    result: queue_ws_json(&outbound_tx, event, stream_id.as_ref()).await,
+                };
+            }
             let result = match work {
                 WsWorkItem::Execute { request, .. } => {
                     handle_ws_request(*request, &state, auth, &outbound_tx, &shutdown_token).await
@@ -321,7 +351,7 @@ async fn responses_ws_loop(
     let (mut sender, mut receiver) = socket.split();
     let auth = extract_bearer(&headers, state.openai_api_key.as_deref());
     let (outbound_tx, mut outbound_rx) = mpsc::channel(WS_OUTBOUND_BUFFER);
-    let mut multiplexer = WsMultiplexer::new(state, auth, outbound_tx, shutdown_token.clone());
+    let mut multiplexer = WsMultiplexer::new(state, auth, principal, outbound_tx, shutdown_token.clone());
     let mut draining = false;
     let mut client_disconnected = false;
 
@@ -341,7 +371,7 @@ async fn responses_ws_loop(
                 let Some(value) = outbound else {
                     continue;
                 };
-                if send_ws_json(&mut sender, value).await.is_err() {
+                if send_ws_event(&mut sender, value).await.is_err() {
                     client_disconnected = true;
                     break;
                 }
@@ -374,7 +404,6 @@ async fn responses_ws_loop(
                             message,
                             &mut sender,
                             &mut multiplexer,
-                            principal.as_ref(),
                             &mut draining,
                         )
                         .await
@@ -406,7 +435,6 @@ async fn handle_ws_client_message(
     message: Message,
     sender: &mut WsSender,
     multiplexer: &mut WsMultiplexer,
-    principal: Option<&AuthenticatedPrincipal>,
     draining: &mut bool,
 ) -> bool {
     match message {
@@ -415,10 +443,10 @@ async fn handle_ws_client_message(
             true
         }
         Message::Text(text) => {
-            if let Some(event) = websocket_identity_error_event(principal) {
+            if let Some(event) = websocket_identity_error_event(multiplexer.principal.as_deref()) {
                 let stream_id = stream_id_from_text(&text);
-                let send_succeeded = match attach_stream_id(event, stream_id.as_ref()) {
-                    Ok(event) => send_ws_json(sender, event).await.is_ok(),
+                let send_succeeded = match WsOutboundEvent::new(event, stream_id.as_ref()) {
+                    Ok(event) => send_ws_event(sender, event).await.is_ok(),
                     Err(error) => {
                         warn!(%error, "failed to build websocket identity error event");
                         false
@@ -575,7 +603,7 @@ async fn handle_ws_request(
     request: WsRequest,
     state: &AppState,
     auth: Option<String>,
-    outbound_tx: &mpsc::Sender<Value>,
+    outbound_tx: &mpsc::Sender<WsOutboundEvent>,
     shutdown_token: &CancellationToken,
 ) -> Result<(), WsError> {
     let WsRequest {
@@ -607,7 +635,7 @@ async fn handle_ws_request(
 }
 
 async fn complete_without_inference(
-    outbound_tx: &mpsc::Sender<Value>,
+    outbound_tx: &mpsc::Sender<WsOutboundEvent>,
     state: &AppState,
     payload: RequestPayload,
     stream_id: Option<&StreamId>,
@@ -624,6 +652,12 @@ async fn complete_without_inference(
         Some(ResponseUsage::default()),
     );
 
+    // Validate both lifecycle events, including routing metadata, before any
+    // persistence or delivery. Completion metadata can exceed the limit even
+    // when the created event fits.
+    let created_event = WsOutboundEvent::new(created_event, stream_id)?;
+    let completed_event = WsOutboundEvent::new(completed_event, stream_id)?;
+
     #[cfg(debug_assertions)]
     state.websocket_tracker.pause_local_completion_after_rehydration().await;
     persist_turn(
@@ -634,8 +668,8 @@ async fn complete_without_inference(
     )
     .await?;
 
-    queue_ws_json(outbound_tx, created_event, stream_id).await?;
-    queue_ws_json(outbound_tx, completed_event, stream_id).await
+    outbound_tx.send(created_event).await.map_err(|_| WsError::SendFailed)?;
+    outbound_tx.send(completed_event).await.map_err(|_| WsError::SendFailed)
 }
 
 fn empty_response_event(
@@ -667,7 +701,7 @@ fn empty_response_event(
 }
 
 async fn stream_ws_response(
-    outbound_tx: &mpsc::Sender<Value>,
+    outbound_tx: &mpsc::Sender<WsOutboundEvent>,
     mut stream: BoxStream,
     stream_id: Option<&StreamId>,
 ) -> Result<(), WsError> {
@@ -686,7 +720,7 @@ fn sse_json_data_lines(chunk: &str) -> impl Iterator<Item = &str> {
 }
 
 async fn forward_ws_stream_chunk(
-    outbound_tx: &mpsc::Sender<Value>,
+    outbound_tx: &mpsc::Sender<WsOutboundEvent>,
     chunk: &str,
     stream_id: Option<&StreamId>,
 ) -> Result<(), WsError> {
@@ -714,18 +748,18 @@ fn attach_stream_id(mut value: Value, stream_id: Option<&StreamId>) -> Result<Va
 }
 
 async fn queue_ws_json(
-    outbound_tx: &mpsc::Sender<Value>,
+    outbound_tx: &mpsc::Sender<WsOutboundEvent>,
     value: Value,
     stream_id: Option<&StreamId>,
 ) -> Result<(), WsError> {
     outbound_tx
-        .send(attach_stream_id(value, stream_id)?)
+        .send(WsOutboundEvent::new(value, stream_id)?)
         .await
         .map_err(|_| WsError::SendFailed)
 }
 
 async fn queue_ws_error(
-    outbound_tx: &mpsc::Sender<Value>,
+    outbound_tx: &mpsc::Sender<WsOutboundEvent>,
     err: WsError,
     stream_id: Option<&StreamId>,
 ) -> Result<(), WsError> {
@@ -746,13 +780,12 @@ async fn send_ws_error(sender: &mut WsSender, err: &WsError, stream_id: Option<&
     let Some(frame) = err.to_ws_frame() else {
         return Err(WsError::SendFailed);
     };
-    send_ws_json(sender, attach_stream_id(frame, stream_id)?).await
+    send_ws_event(sender, WsOutboundEvent::new(frame, stream_id)?).await
 }
 
-async fn send_ws_json(sender: &mut WsSender, value: Value) -> Result<(), WsError> {
-    let text = serde_json::to_string(&value).map_err(WsError::SerializeJson)?;
+async fn send_ws_event(sender: &mut WsSender, event: WsOutboundEvent) -> Result<(), WsError> {
     sender
-        .send(Message::Text(text.into()))
+        .send(Message::Text(event.0.into()))
         .await
         .map_err(|_| WsError::SendFailed)
 }
@@ -769,12 +802,42 @@ mod tests {
 
     use super::{
         StreamId, WS_MAX_OUTSTANDING_BYTES, WS_MAX_OUTSTANDING_REQUESTS, WS_MAX_STREAM_ID_CHARS, WsByteBudget, WsError,
-        attach_stream_id, close_ws, keep_if_running, parse_ws_request, sse_json_data_lines,
-        websocket_identity_error_event,
+        attach_stream_id, close_ws, forward_ws_stream_chunk, keep_if_running, parse_ws_request, queue_ws_json,
+        sse_json_data_lines, websocket_identity_error_event,
     };
     use crate::auth::AuthenticatedPrincipal;
 
     struct CloseErrorSink;
+
+    #[tokio::test]
+    async fn outbound_event_limit_counts_routing_metadata_and_json_escaping() {
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
+        // The JSON envelope {"text":"","type":"test"} occupies 25 bytes.
+        let event = json!({"text": "x".repeat(1024 * 1024 - 25), "type": "test"});
+        queue_ws_json(&sender, event.clone(), None)
+            .await
+            .expect("exact limit is accepted");
+        assert_eq!(receiver.recv().await.unwrap().0.len(), 1024 * 1024);
+
+        let stream_id = StreamId::try_from("🦀").unwrap();
+        let chunk = format!("data: {event}\n\n");
+        assert!(
+            forward_ws_stream_chunk(&sender, &chunk, Some(&stream_id))
+                .await
+                .is_err()
+        );
+        assert!(
+            receiver.try_recv().is_err(),
+            "routing metadata must count toward the limit"
+        );
+
+        let escaped = json!({"type": "test", "text": "\n".repeat(512 * 1024)});
+        assert!(queue_ws_json(&sender, escaped, None).await.is_err());
+        assert!(
+            receiver.try_recv().is_err(),
+            "escaped JSON bytes must count toward the limit"
+        );
+    }
 
     #[test]
     fn sse_json_data_lines_accept_named_and_data_only_frames() {

--- a/crates/agentic-server/tests/oidc_auth_test.rs
+++ b/crates/agentic-server/tests/oidc_auth_test.rs
@@ -1066,9 +1066,13 @@ async fn authenticated_websocket_rejects_requests_after_identity_expiry() {
     }
     websocket
         .send(TungsteniteMessage::Text(
-            json!({"type": "response.create", "response": {"input": "must not run"}})
-                .to_string()
-                .into(),
+            json!({
+                "type": "response.create",
+                "stream_id": "expired-lane",
+                "response": {"input": "must not run"}
+            })
+            .to_string()
+            .into(),
         ))
         .await
         .expect("send post-expiry request");
@@ -1086,7 +1090,8 @@ async fn authenticated_websocket_rejects_requests_after_identity_expiry() {
             "code": "invalid_token",
             "message": "OIDC bearer token expired",
             "param": null,
-            "sequence_number": 0
+            "sequence_number": 0,
+            "stream_id": "expired-lane"
         })
     );
     assert!(matches!(

--- a/crates/agentic-server/tests/oidc_auth_test.rs
+++ b/crates/agentic-server/tests/oidc_auth_test.rs
@@ -1044,6 +1044,113 @@ async fn every_v1_route_rejects_missing_credentials() {
 }
 
 #[tokio::test]
+async fn authenticated_websocket_rechecks_queued_named_lane_after_identity_expiry() {
+    assert_queued_request_rejected_after_expiry(Some("queued-lane")).await;
+}
+
+#[tokio::test]
+async fn authenticated_websocket_rechecks_queued_default_lane_after_identity_expiry() {
+    assert_queued_request_rejected_after_expiry(None).await;
+}
+
+async fn assert_queued_request_rejected_after_expiry(stream_id: Option<&str>) {
+    use std::sync::Arc;
+    use std::time::Duration;
+    use tokio::sync::Notify;
+
+    let (issuer, private_key, _, _, _provider) = spawn_oidc_provider().await;
+    let authenticator = discover_test_authenticator(&issuer).await;
+    let arrived = Arc::new(Notify::new());
+    let release = Arc::new(Notify::new());
+    let calls = Arc::new(AtomicUsize::new(0));
+    let upstream = spawn_router(Router::new().route(
+        "/v1/responses",
+        post({
+            let arrived = Arc::clone(&arrived);
+            let release = Arc::clone(&release);
+            let calls = Arc::clone(&calls);
+            move |_body: Bytes| {
+                let arrived = Arc::clone(&arrived);
+                let release = Arc::clone(&release);
+                let calls = Arc::clone(&calls);
+                async move {
+                    if calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                        arrived.notify_one();
+                        release.notified().await;
+                    }
+                    (
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        Json(json!({"error": {"message": "upstream unavailable"}})),
+                    )
+                }
+            }
+        }),
+    ))
+    .await;
+    let gateway = spawn_gateway(authenticator, &format!("http://{}", upstream.address)).await;
+    // Exercise expiry including the configured 60-second clock skew.
+    let expires_at = jsonwebtoken::get_current_timestamp().saturating_sub(55);
+    let token = identity_token(&issuer, TEST_AUDIENCE, expires_at, "test-key", &private_key);
+    let mut request = format!("ws://{}/v1/responses", gateway.address)
+        .into_client_request()
+        .unwrap();
+    request.headers_mut().insert(
+        reqwest::header::AUTHORIZATION,
+        HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+    );
+    let (mut ws, _) = tokio_tungstenite::connect_async(request).await.unwrap();
+    let mut payload = json!({"type": "response.create", "model": "test-model", "input": "hello"});
+    if let Some(stream_id) = stream_id {
+        payload["stream_id"] = json!(stream_id);
+    }
+    ws.send(TungsteniteMessage::Text(payload.to_string().into()))
+        .await
+        .unwrap();
+    tokio::time::timeout(Duration::from_secs(2), arrived.notified())
+        .await
+        .expect("first request reached inference");
+    ws.send(TungsteniteMessage::Text(payload.to_string().into()))
+        .await
+        .unwrap();
+    ws.send(TungsteniteMessage::Ping(vec![1].into())).await.unwrap();
+    // The pong proves the server read the second request while the first is gated.
+    let pong = tokio::time::timeout(Duration::from_secs(2), ws.next())
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert!(matches!(pong, TungsteniteMessage::Pong(_)));
+    assert!(
+        jsonwebtoken::get_current_timestamp() <= expires_at + 60,
+        "requests must queue before expiry"
+    );
+    while jsonwebtoken::get_current_timestamp() <= expires_at + 60 {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    release.notify_one();
+    let mut events = Vec::new();
+    for _ in 0..2 {
+        let frame = tokio::time::timeout(Duration::from_secs(2), ws.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        events.push(serde_json::from_str::<Value>(&frame.into_text().unwrap()).unwrap());
+    }
+    assert_eq!(events[0]["status"], 503);
+    assert_eq!(
+        events[1]["code"], "invalid_token",
+        "queued work must be rejected at dispatch"
+    );
+    assert_eq!(events[1].get("stream_id").and_then(Value::as_str), stream_id);
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "expired queued work must never reach inference"
+    );
+}
+
+#[tokio::test]
 async fn authenticated_websocket_rejects_requests_after_identity_expiry() {
     let (issuer, private_key, _public_jwk, _jwks_requests, _provider) = spawn_oidc_provider().await;
     let authenticator = discover_test_authenticator(&issuer).await;

--- a/crates/agentic-server/tests/responses_websocket_test.rs
+++ b/crates/agentic-server/tests/responses_websocket_test.rs
@@ -111,6 +111,17 @@ enum MockResponse {
         arrived: oneshot::Sender<()>,
         release: oneshot::Receiver<()>,
     },
+    ObservedGated {
+        response: String,
+        arrived: oneshot::Sender<Value>,
+        release: oneshot::Receiver<()>,
+    },
+    ObservedPhased {
+        first_chunk: String,
+        remaining_chunks: String,
+        arrived: oneshot::Sender<Value>,
+        release: oneshot::Receiver<()>,
+    },
     Hanging {
         first_chunk: String,
         drop_tx: oneshot::Sender<()>,
@@ -189,7 +200,7 @@ impl MockResponsesServer {
                 let requests = Arc::clone(&route_requests);
                 async move {
                     let body = serde_json::from_slice::<Value>(&body).expect("request body should be JSON");
-                    requests.lock().await.push(body);
+                    requests.lock().await.push(body.clone());
                     let response = queue.lock().await.pop_front().expect("mock response queue exhausted");
                     let body = match response {
                         MockResponse::Static(response) => axum::body::Body::from(response),
@@ -201,6 +212,30 @@ impl MockResponsesServer {
                             let _ = arrived.send(());
                             let _ = release.await;
                             axum::body::Body::from(response)
+                        }
+                        MockResponse::ObservedGated {
+                            response,
+                            arrived,
+                            release,
+                        } => {
+                            let _ = arrived.send(body);
+                            let _ = release.await;
+                            axum::body::Body::from(response)
+                        }
+                        MockResponse::ObservedPhased {
+                            first_chunk,
+                            remaining_chunks,
+                            arrived,
+                            release,
+                        } => {
+                            let _ = arrived.send(body);
+                            let first =
+                                futures::stream::once(async move { Ok::<_, Infallible>(Bytes::from(first_chunk)) });
+                            let remaining = futures::stream::once(async move {
+                                let _ = release.await;
+                                Ok::<_, Infallible>(Bytes::from(remaining_chunks))
+                            });
+                            axum::body::Body::from_stream(first.chain(remaining))
                         }
                         MockResponse::Hanging { first_chunk, drop_tx } => {
                             axum::body::Body::from_stream(HangingSse::new(first_chunk, drop_tx))
@@ -526,6 +561,13 @@ fn sse_response(response_id: &str, message_id: &str, text: &str) -> String {
         "response": {"id": response_id, "status": "completed", "usage": null}
     });
     format!("data: {created}\n\ndata: {added}\n\ndata: {delta}\n\ndata: {completed}\n\ndata: [DONE]\n\n")
+}
+
+fn phased_sse_response(response_id: &str, message_id: &str, text: &str) -> (String, String) {
+    let response = sse_response(response_id, message_id, text);
+    let split_at = response.find("\n\n").expect("SSE response has a first event") + 2;
+    let (first_chunk, remaining_chunks) = response.split_at(split_at);
+    (first_chunk.to_owned(), remaining_chunks.to_owned())
 }
 
 fn sse_failed_response() -> String {
@@ -879,6 +921,529 @@ async fn test_websocket_first_turn_forwards_incremental_events_and_final_payload
 }
 
 #[tokio::test]
+async fn websocket_distinct_stream_ids_run_concurrently_and_tag_every_event() {
+    // Arrange: hold both upstream responses so the second request can arrive
+    // only if the WebSocket handler starts distinct lanes concurrently.
+    let (first_arrived_tx, first_arrived_rx) = oneshot::channel();
+    let (first_release_tx, first_release_rx) = oneshot::channel();
+    let (second_arrived_tx, second_arrived_rx) = oneshot::channel();
+    let (second_release_tx, second_release_rx) = oneshot::channel();
+    let (first_chunk, first_remaining) = phased_sse_response("resp_upstream_first", "msg_upstream_first", "FIRST");
+    let (second_chunk, second_remaining) = phased_sse_response("resp_upstream_second", "msg_upstream_second", "SECOND");
+    let mock = MockResponsesServer::start_with_responses(vec![
+        MockResponse::Static(sse_response("resp_upstream_parent", "msg_upstream_parent", "PARENT")),
+        MockResponse::ObservedPhased {
+            first_chunk,
+            remaining_chunks: first_remaining,
+            arrived: first_arrived_tx,
+            release: first_release_rx,
+        },
+        MockResponse::ObservedPhased {
+            first_chunk: second_chunk,
+            remaining_chunks: second_remaining,
+            arrived: second_arrived_tx,
+            release: second_release_rx,
+        },
+    ])
+    .await;
+    let fixture = storage_backed_state(&mock.url).await;
+    let (gateway_url, _gateway) = spawn_gateway(fixture.state.clone()).await;
+    let mut ws = connect_responses_ws(&gateway_url).await;
+
+    send_json(
+        &mut ws,
+        json!({
+            "type": "response.create",
+            "model": "test-model",
+            "input": "remember the parent context",
+            "store": true
+        }),
+    )
+    .await;
+    let parent = recv_until_completed(&mut ws).await;
+    let parent_response_id = parent
+        .last()
+        .and_then(|event| event["response"]["id"].as_str())
+        .expect("parent response id")
+        .to_owned();
+
+    // Act: fork the stored parent into two independent lanes.
+    send_json(
+        &mut ws,
+        json!({
+            "type": "response.create",
+            "stream_id": "lane-a",
+            "model": "test-model",
+            "previous_response_id": &parent_response_id,
+            "input": "request-a",
+            "metadata": {"test_lane": "lane-a"}
+        }),
+    )
+    .await;
+    send_json(
+        &mut ws,
+        json!({
+            "type": "response.create",
+            "stream_id": "lane-b",
+            "model": "test-model",
+            "previous_response_id": &parent_response_id,
+            "input": "request-b",
+            "metadata": {"test_lane": "lane-b"}
+        }),
+    )
+    .await;
+
+    let first_request = tokio::time::timeout(std::time::Duration::from_secs(2), first_arrived_rx)
+        .await
+        .expect("first lane did not reach upstream")
+        .expect("first arrival sender dropped");
+    let second_request = tokio::time::timeout(std::time::Duration::from_secs(2), second_arrived_rx)
+        .await
+        .expect("distinct WebSocket lane was serialized behind the active lane")
+        .expect("second arrival sender dropped");
+    assert!(first_request.get("stream_id").is_none());
+    assert!(second_request.get("stream_id").is_none());
+
+    let first_stream_id = first_request["metadata"]["test_lane"]
+        .as_str()
+        .expect("first request test lane");
+    let second_stream_id = second_request["metadata"]["test_lane"]
+        .as_str()
+        .expect("second request test lane");
+    assert_ne!(first_stream_id, second_stream_id);
+
+    // Both lanes publish an initial event before either completes. Releasing
+    // the first lane then proves its remaining events can follow an event from
+    // the still-active second lane: first, second, first.
+    let created_events = [recv_json(&mut ws).await, recv_json(&mut ws).await];
+    assert!(created_events.iter().all(|event| event["type"] == "response.created"));
+    assert!(created_events.iter().any(|event| event["stream_id"] == first_stream_id));
+    assert!(
+        created_events
+            .iter()
+            .any(|event| event["stream_id"] == second_stream_id)
+    );
+
+    first_release_tx.send(()).expect("release first upstream response");
+    let first_events = recv_until_completed(&mut ws).await;
+    assert_eq!(first_events.len(), 3);
+    assert!(first_events.iter().all(|event| event["stream_id"] == first_stream_id));
+
+    second_release_tx.send(()).expect("release second upstream response");
+    let second_events = recv_until_completed(&mut ws).await;
+    assert_eq!(second_events.len(), 3);
+    assert!(second_events.iter().all(|event| event["stream_id"] == second_stream_id));
+}
+
+#[tokio::test]
+async fn websocket_requests_with_the_same_stream_id_run_fifo() {
+    let (first_arrived_tx, first_arrived_rx) = oneshot::channel();
+    let (first_release_tx, first_release_rx) = oneshot::channel();
+    let (second_arrived_tx, mut second_arrived_rx) = oneshot::channel();
+    let (second_release_tx, second_release_rx) = oneshot::channel();
+    let mock = MockResponsesServer::start_with_responses(vec![
+        MockResponse::ObservedGated {
+            response: sse_response("resp_upstream_first", "msg_upstream_first", "FIRST"),
+            arrived: first_arrived_tx,
+            release: first_release_rx,
+        },
+        MockResponse::ObservedGated {
+            response: sse_response("resp_upstream_second", "msg_upstream_second", "SECOND"),
+            arrived: second_arrived_tx,
+            release: second_release_rx,
+        },
+    ])
+    .await;
+    let fixture = storage_backed_state(&mock.url).await;
+    let (gateway_url, _gateway) = spawn_gateway(fixture.state.clone()).await;
+    let mut ws = connect_responses_ws(&gateway_url).await;
+
+    for input in ["first", "second"] {
+        send_json(
+            &mut ws,
+            json!({
+                "type": "response.create",
+                "stream_id": "ordered-lane",
+                "model": "test-model",
+                "input": input
+            }),
+        )
+        .await;
+    }
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), first_arrived_rx)
+        .await
+        .expect("timed out waiting for first request to reach upstream")
+        .expect("first arrival sender dropped");
+    send_ping_and_wait_for_pong(&mut ws, Bytes::from_static(b"same-lane-request-received")).await;
+    assert_eq!(
+        mock.request_bodies().await.len(),
+        1,
+        "second request on the same lane started before the first completed"
+    );
+
+    first_release_tx.send(()).expect("release first response");
+    let first_events = recv_until_completed(&mut ws).await;
+    assert!(first_events.iter().all(|event| event["stream_id"] == "ordered-lane"));
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), &mut second_arrived_rx)
+        .await
+        .expect("second request did not start after first completed")
+        .expect("second arrival sender dropped");
+    second_release_tx.send(()).expect("release second response");
+    let second_events = recv_until_completed(&mut ws).await;
+    assert!(second_events.iter().all(|event| event["stream_id"] == "ordered-lane"));
+}
+
+async fn assert_validation_error_waits_for_active_lane(stream_id: Option<&str>) {
+    let (mock, arrived, release) =
+        MockResponsesServer::start_gated(sse_response("resp_upstream_first", "msg_upstream_first", "FIRST")).await;
+    let fixture = storage_backed_state(&mock.url).await;
+    let (gateway_url, _gateway) = spawn_gateway(fixture.state.clone()).await;
+    let mut ws = connect_responses_ws(&gateway_url).await;
+
+    let mut valid = json!({
+        "type": "response.create",
+        "model": "test-model",
+        "input": "first"
+    });
+    let mut invalid = json!({
+        "type": "response.create",
+        "input": "missing model"
+    });
+    if let Some(stream_id) = stream_id {
+        valid["stream_id"] = json!(stream_id);
+        invalid["stream_id"] = json!(stream_id);
+    }
+
+    send_json(&mut ws, valid).await;
+    tokio::time::timeout(std::time::Duration::from_secs(2), arrived)
+        .await
+        .expect("timed out waiting for first request to reach upstream")
+        .expect("first arrival sender dropped");
+    send_json(&mut ws, invalid).await;
+    send_ping_and_wait_for_pong(&mut ws, Bytes::from_static(b"validation-error-queued")).await;
+
+    release.send(()).expect("release first response");
+    let events = recv_until_completed(&mut ws).await;
+    assert_eq!(events.last().expect("terminal event")["type"], "response.completed");
+
+    let error = recv_json(&mut ws).await;
+    assert_eq!(error["type"], "error");
+    assert_eq!(error["status"], StatusCode::BAD_REQUEST.as_u16());
+    if let Some(stream_id) = stream_id {
+        assert_eq!(error["stream_id"], stream_id);
+    } else {
+        assert!(error.get("stream_id").is_none());
+    }
+}
+
+#[tokio::test]
+async fn websocket_validation_errors_wait_for_their_named_lane() {
+    assert_validation_error_waits_for_active_lane(Some("ordered-lane")).await;
+}
+
+#[tokio::test]
+async fn websocket_validation_errors_wait_for_the_default_lane() {
+    assert_validation_error_waits_for_active_lane(None).await;
+}
+
+#[tokio::test]
+async fn websocket_invalid_stream_ids_return_400_and_leave_connection_usable() {
+    let mock = MockResponsesServer::start(vec![sse_response("resp_valid", "msg_valid", "done")]).await;
+    let fixture = storage_backed_state(&mock.url).await;
+    let (gateway_url, _gateway) = spawn_gateway(fixture.state.clone()).await;
+    let mut ws = connect_responses_ws(&gateway_url).await;
+
+    for stream_id in [json!(""), json!("x".repeat(257)), json!(42)] {
+        send_json(
+            &mut ws,
+            json!({
+                "type": "response.create",
+                "stream_id": stream_id,
+                "model": "test-model",
+                "input": "invalid stream ID"
+            }),
+        )
+        .await;
+        let error = recv_json(&mut ws).await;
+        assert_eq!(error["type"], "error");
+        assert_eq!(error["status"], StatusCode::BAD_REQUEST.as_u16());
+        assert!(error.get("stream_id").is_none());
+        assert!(mock.request_bodies().await.is_empty());
+    }
+
+    send_json(
+        &mut ws,
+        json!({
+            "type": "response.create",
+            "stream_id": "x",
+            "model": "test-model",
+            "input": "valid request"
+        }),
+    )
+    .await;
+    let events = recv_until_completed(&mut ws).await;
+    assert!(events.iter().all(|event| event["stream_id"] == "x"));
+    assert_eq!(mock.request_bodies().await.len(), 1);
+}
+
+#[tokio::test]
+async fn websocket_rejects_more_than_64_outstanding_requests() {
+    let first_chunk = format!(
+        "data: {}\n\n",
+        json!({
+            "type": "response.created",
+            "sequence_number": 0,
+            "response": {"id": "resp_upstream_hanging", "status": "in_progress"}
+        })
+    );
+    let (mock, upstream_dropped) = MockResponsesServer::start_hanging(first_chunk).await;
+    let fixture = storage_backed_state(&mock.url).await;
+    let (gateway_url, _gateway) = spawn_gateway(fixture.state.clone()).await;
+    let mut ws = connect_responses_ws(&gateway_url).await;
+
+    for index in 0..64 {
+        send_json(
+            &mut ws,
+            json!({
+                "type": "response.create",
+                "stream_id": "capacity-lane",
+                "model": "test-model",
+                "input": format!("request {index}")
+            }),
+        )
+        .await;
+    }
+    wait_for_request_count(&mock, 1).await;
+    send_json(
+        &mut ws,
+        json!({
+            "type": "response.create",
+            "stream_id": "capacity-lane",
+            "model": "test-model",
+            "input": "request 65"
+        }),
+    )
+    .await;
+
+    let overload = loop {
+        let event = recv_json(&mut ws).await;
+        if event["type"] == "error" {
+            break event;
+        }
+    };
+    assert_eq!(overload["status"], StatusCode::TOO_MANY_REQUESTS.as_u16());
+    assert_eq!(overload["error"]["code"], "rate_limit_exceeded");
+    assert_eq!(overload["stream_id"], "capacity-lane");
+    assert_eq!(mock.request_bodies().await.len(), 1);
+
+    ws.close(None).await.expect("close websocket");
+    tokio::time::timeout(std::time::Duration::from_secs(2), upstream_dropped)
+        .await
+        .expect("timed out waiting for upstream stream cancellation")
+        .expect("upstream drop sender should notify");
+}
+
+#[tokio::test]
+async fn websocket_rejects_a_65th_active_stream_lane() {
+    let mut responses = Vec::new();
+    let mut upstream_drops = Vec::new();
+    for index in 0..64 {
+        let first_chunk = format!(
+            "data: {}\n\n",
+            json!({
+                "type": "response.created",
+                "sequence_number": 0,
+                "response": {"id": format!("resp_active_{index}"), "status": "in_progress"}
+            })
+        );
+        let (drop_tx, drop_rx) = oneshot::channel();
+        responses.push(MockResponse::Hanging { first_chunk, drop_tx });
+        upstream_drops.push(drop_rx);
+    }
+    let mock = MockResponsesServer::start_with_responses(responses).await;
+    let fixture = storage_backed_state(&mock.url).await;
+    let (gateway_url, _gateway) = spawn_gateway(fixture.state.clone()).await;
+    let mut ws = connect_responses_ws(&gateway_url).await;
+
+    for index in 0..64 {
+        send_json(
+            &mut ws,
+            json!({
+                "type": "response.create",
+                "stream_id": format!("active-{index}"),
+                "model": "test-model",
+                "input": format!("request {index}")
+            }),
+        )
+        .await;
+    }
+    wait_for_request_count(&mock, 64).await;
+    send_json(
+        &mut ws,
+        json!({
+            "type": "response.create",
+            "stream_id": "active-64",
+            "model": "test-model",
+            "input": "request 65"
+        }),
+    )
+    .await;
+
+    let overload = loop {
+        let event = recv_json(&mut ws).await;
+        if event["type"] == "error" {
+            break event;
+        }
+    };
+    assert_eq!(overload["status"], StatusCode::TOO_MANY_REQUESTS.as_u16());
+    assert_eq!(overload["stream_id"], "active-64");
+    assert_eq!(mock.request_bodies().await.len(), 64);
+
+    ws.close(None).await.expect("close websocket");
+    for upstream_dropped in upstream_drops {
+        tokio::time::timeout(std::time::Duration::from_secs(2), upstream_dropped)
+            .await
+            .expect("timed out waiting for active upstream stream cancellation")
+            .expect("upstream drop sender should notify");
+    }
+}
+
+#[tokio::test]
+async fn websocket_rejects_requests_over_the_aggregate_input_budget() {
+    let (mock, arrived, release) =
+        MockResponsesServer::start_gated(sse_response("resp_large", "msg_large", "done")).await;
+    let fixture = storage_backed_state(&mock.url).await;
+    let (gateway_url, _gateway) = spawn_gateway(fixture.state.clone()).await;
+    let mut ws = connect_responses_ws(&gateway_url).await;
+
+    send_json(
+        &mut ws,
+        json!({
+            "type": "response.create",
+            "stream_id": "large-a",
+            "model": "test-model",
+            "input": "x".repeat(512 * 1024)
+        }),
+    )
+    .await;
+    tokio::time::timeout(std::time::Duration::from_secs(10), arrived)
+        .await
+        .expect("timed out waiting for large request to reach upstream")
+        .expect("arrival sender dropped");
+
+    for index in 1..23 {
+        send_json(
+            &mut ws,
+            json!({
+                "type": "response.create",
+                "stream_id": "large-a",
+                "model": "test-model",
+                "input": "q".repeat(512 * 1024),
+                "metadata": {"queued_index": index}
+            }),
+        )
+        .await;
+    }
+    send_json(
+        &mut ws,
+        json!({
+            "type": "response.create",
+            "stream_id": "large-b",
+            "model": "test-model",
+            "input": "y".repeat(512 * 1024)
+        }),
+    )
+    .await;
+    let overload = recv_json(&mut ws).await;
+    assert_eq!(overload["type"], "error");
+    assert_eq!(overload["status"], StatusCode::TOO_MANY_REQUESTS.as_u16());
+    assert_eq!(overload["error"]["code"], "rate_limit_exceeded");
+    assert_eq!(overload["stream_id"], "large-b");
+    assert_eq!(mock.request_bodies().await.len(), 1);
+
+    release.send(()).expect("release large response");
+    let events = recv_until_completed(&mut ws).await;
+    assert!(events.iter().all(|event| event["stream_id"] == "large-a"));
+}
+
+#[tokio::test]
+async fn websocket_reclaims_completed_request_capacity_before_admission() {
+    let (first_arrived_tx, first_arrived_rx) = oneshot::channel();
+    let (first_release_tx, first_release_rx) = oneshot::channel();
+    let (second_drop_tx, second_drop_rx) = oneshot::channel();
+    let second_chunk = format!(
+        "data: {}\n\n",
+        json!({
+            "type": "response.created",
+            "sequence_number": 0,
+            "response": {"id": "resp_capacity_second", "status": "in_progress"}
+        })
+    );
+    let mock = MockResponsesServer::start_with_responses(vec![
+        MockResponse::Gated {
+            response: sse_response("resp_capacity_first", "msg_capacity_first", "first"),
+            arrived: first_arrived_tx,
+            release: first_release_rx,
+        },
+        MockResponse::Hanging {
+            first_chunk: second_chunk,
+            drop_tx: second_drop_tx,
+        },
+    ])
+    .await;
+    let fixture = storage_backed_state(&mock.url).await;
+    let (gateway_url, _gateway) = spawn_gateway(fixture.state.clone()).await;
+    let mut ws = connect_responses_ws(&gateway_url).await;
+
+    for index in 0..64 {
+        send_json(
+            &mut ws,
+            json!({
+                "type": "response.create",
+                "stream_id": "capacity-lane",
+                "model": "test-model",
+                "input": format!("request {index}")
+            }),
+        )
+        .await;
+    }
+    tokio::time::timeout(std::time::Duration::from_secs(2), first_arrived_rx)
+        .await
+        .expect("timed out waiting for first request to reach upstream")
+        .expect("first arrival sender dropped");
+    first_release_tx.send(()).expect("release first response");
+    let first_events = recv_until_completed(&mut ws).await;
+    assert_eq!(
+        first_events.last().expect("terminal event")["type"],
+        "response.completed"
+    );
+
+    send_json(
+        &mut ws,
+        json!({
+            "type": "response.create",
+            "stream_id": "capacity-lane",
+            "model": "test-model",
+            "input": "request after completed capacity is reclaimed"
+        }),
+    )
+    .await;
+
+    let second_created = recv_json(&mut ws).await;
+    assert_eq!(second_created["type"], "response.created");
+    assert_eq!(second_created["stream_id"], "capacity-lane");
+    send_ping_and_wait_for_pong(&mut ws, Bytes::from_static(b"capacity-reclaimed")).await;
+
+    ws.close(None).await.expect("close websocket");
+    tokio::time::timeout(std::time::Duration::from_secs(2), second_drop_rx)
+        .await
+        .expect("timed out waiting for upstream stream cancellation")
+        .expect("upstream drop sender should notify");
+}
+
+#[tokio::test]
 async fn websocket_conversation_conflict_ends_request_without_persisting_stale_turn() {
     // Arrange
     let (mock, arrived, release) =
@@ -1118,6 +1683,7 @@ async fn test_websocket_generate_false_is_local_and_reusable() {
         &mut ws,
         json!({
             "type": "response.create",
+            "stream_id": "warmup-lane",
             "model": "test-model",
             "input": [],
             "generate": false,
@@ -1134,6 +1700,7 @@ async fn test_websocket_generate_false_is_local_and_reusable() {
     assert_eq!(warmup[0]["response"]["id"], warmup[1]["response"]["id"]);
     assert_eq!(warmup[1]["response"]["output"], json!([]));
     assert_eq!(warmup[1]["response"]["usage"]["total_tokens"], 0);
+    assert!(warmup.iter().all(|event| event["stream_id"] == "warmup-lane"));
     assert!(mock.request_bodies().await.is_empty());
 
     let warmup_id = warmup[1]["response"]["id"].as_str().unwrap();
@@ -1152,6 +1719,7 @@ async fn test_websocket_generate_false_is_local_and_reusable() {
 
     let response = recv_until_completed(&mut ws).await;
     assert_eq!(response.last().unwrap()["response"]["previous_response_id"], warmup_id);
+    assert!(response.iter().all(|event| event.get("stream_id").is_none()));
     let requests = mock.request_bodies().await;
     assert_eq!(requests.len(), 1);
     assert_eq!(requests[0]["input"].as_array().unwrap().len(), 1);
@@ -1612,6 +2180,7 @@ async fn test_websocket_unknown_previous_response_returns_error_event() {
         &mut ws,
         json!({
             "type": "response.create",
+            "stream_id": "missing-response-lane",
             "model": "test-model",
             "previous_response_id": "resp_missing",
             "input": [{"type": "message", "role": "user", "content": "continue"}],
@@ -1625,6 +2194,7 @@ async fn test_websocket_unknown_previous_response_returns_error_event() {
     assert_eq!(error["type"], "error");
     assert_eq!(error["status"], StatusCode::NOT_FOUND.as_u16());
     assert_eq!(error["error"]["code"], "not_found");
+    assert_eq!(error["stream_id"], "missing-response-lane");
     assert!(mock.request_bodies().await.is_empty());
 }
 
@@ -1724,7 +2294,10 @@ async fn test_websocket_shutdown_drains_active_response_before_closing() {
         }),
     )
     .await;
-    arrived.await.expect("upstream request should arrive");
+    tokio::time::timeout(std::time::Duration::from_secs(2), arrived)
+        .await
+        .expect("timed out waiting for shutdown request to reach upstream")
+        .expect("arrival sender dropped");
 
     shutdown_token.cancel();
     send_json(
@@ -1749,6 +2322,81 @@ async fn test_websocket_shutdown_drains_active_response_before_closing() {
         .await
         .expect("server did not receive the websocket close acknowledgement");
     assert_eq!(mock.request_bodies().await.len(), 1);
+}
+
+#[tokio::test]
+async fn websocket_shutdown_drains_all_active_lanes_and_discards_queued_work() {
+    let (first_arrived_tx, first_arrived_rx) = oneshot::channel();
+    let (first_release_tx, first_release_rx) = oneshot::channel();
+    let (second_arrived_tx, second_arrived_rx) = oneshot::channel();
+    let (second_release_tx, second_release_rx) = oneshot::channel();
+    let mock = MockResponsesServer::start_with_responses(vec![
+        MockResponse::Gated {
+            response: sse_response("resp_shutdown_a", "msg_shutdown_a", "A"),
+            arrived: first_arrived_tx,
+            release: first_release_rx,
+        },
+        MockResponse::Gated {
+            response: sse_response("resp_shutdown_b", "msg_shutdown_b", "B"),
+            arrived: second_arrived_tx,
+            release: second_release_rx,
+        },
+    ])
+    .await;
+    let fixture = storage_backed_state(&mock.url).await;
+    let shutdown_token = fixture.state.shutdown_token.clone();
+    let (gateway_url, _gateway) = spawn_gateway(fixture.state.clone()).await;
+    let mut ws = connect_responses_ws(&gateway_url).await;
+
+    for (stream_id, input) in [("shutdown-a", "active a"), ("shutdown-b", "active b")] {
+        send_json(
+            &mut ws,
+            json!({
+                "type": "response.create",
+                "stream_id": stream_id,
+                "model": "test-model",
+                "input": input
+            }),
+        )
+        .await;
+    }
+    tokio::time::timeout(std::time::Duration::from_secs(2), first_arrived_rx)
+        .await
+        .expect("timed out waiting for first shutdown lane")
+        .expect("first arrival sender dropped");
+    tokio::time::timeout(std::time::Duration::from_secs(2), second_arrived_rx)
+        .await
+        .expect("timed out waiting for second shutdown lane")
+        .expect("second arrival sender dropped");
+    send_json(
+        &mut ws,
+        json!({
+            "type": "response.create",
+            "stream_id": "shutdown-a",
+            "model": "test-model",
+            "input": "queued and discarded"
+        }),
+    )
+    .await;
+    send_ping_and_wait_for_pong(&mut ws, Bytes::from_static(b"queued-before-shutdown")).await;
+
+    shutdown_token.cancel();
+    first_release_tx.send(()).expect("release first shutdown lane");
+    second_release_tx.send(()).expect("release second shutdown lane");
+
+    let mut events = Vec::new();
+    let mut terminal_count = 0;
+    while terminal_count < 2 {
+        let event = recv_json(&mut ws).await;
+        if event["type"] == "response.completed" {
+            terminal_count += 1;
+        }
+        events.push(event);
+    }
+    assert!(events.iter().any(|event| event["stream_id"] == "shutdown-a"));
+    assert!(events.iter().any(|event| event["stream_id"] == "shutdown-b"));
+    recv_clean_close(&mut ws).await;
+    assert_eq!(mock.request_bodies().await.len(), 2);
 }
 
 #[tokio::test]
@@ -1786,4 +2434,49 @@ async fn test_websocket_client_close_cancels_hanging_upstream_stream() {
         .expect("timed out waiting for upstream stream to be dropped")
         .expect("upstream drop sender should notify");
     assert_eq!(mock.request_bodies().await.len(), 1);
+}
+
+#[tokio::test]
+async fn websocket_client_close_cancels_all_active_stream_lanes() {
+    let mut responses = Vec::new();
+    let mut upstream_drops = Vec::new();
+    for stream_id in ["disconnect-a", "disconnect-b"] {
+        let first_chunk = format!(
+            "data: {}\n\n",
+            json!({
+                "type": "response.created",
+                "sequence_number": 0,
+                "response": {"id": format!("resp_{stream_id}"), "status": "in_progress"}
+            })
+        );
+        let (drop_tx, drop_rx) = oneshot::channel();
+        responses.push(MockResponse::Hanging { first_chunk, drop_tx });
+        upstream_drops.push(drop_rx);
+    }
+    let mock = MockResponsesServer::start_with_responses(responses).await;
+    let fixture = storage_backed_state(&mock.url).await;
+    let (gateway_url, _gateway) = spawn_gateway(fixture.state.clone()).await;
+    let mut ws = connect_responses_ws(&gateway_url).await;
+
+    for stream_id in ["disconnect-a", "disconnect-b"] {
+        send_json(
+            &mut ws,
+            json!({
+                "type": "response.create",
+                "stream_id": stream_id,
+                "model": "test-model",
+                "input": "hang"
+            }),
+        )
+        .await;
+    }
+    wait_for_request_count(&mock, 2).await;
+    ws.close(None).await.expect("close websocket");
+
+    for upstream_dropped in upstream_drops {
+        tokio::time::timeout(std::time::Duration::from_secs(2), upstream_dropped)
+            .await
+            .expect("timed out waiting for active upstream stream cancellation")
+            .expect("upstream drop sender should notify");
+    }
 }

--- a/crates/agentic-server/tests/responses_websocket_test.rs
+++ b/crates/agentic-server/tests/responses_websocket_test.rs
@@ -729,6 +729,64 @@ fn web_search_function_call_sse_response() -> String {
 }
 
 #[tokio::test]
+async fn websocket_generate_false_rejects_oversized_events_before_persistence() {
+    assert_oversized_local_completion_rejected(false).await;
+}
+
+#[tokio::test]
+async fn websocket_generate_false_checks_completed_event_before_persistence_or_delivery() {
+    assert_oversized_local_completion_rejected(true).await;
+}
+
+async fn assert_oversized_local_completion_rejected(only_completion_oversized: bool) {
+    let fixture = storage_backed_state("http://127.0.0.1:9").await;
+    let (gateway_url, gateway) = spawn_gateway(fixture.state.clone()).await;
+    let mut ws = connect_responses_ws(&gateway_url).await;
+    let mut payload = json!({
+        "type": "response.create", "model": "test-model", "input": [],
+        "generate": false, "stream_id": "oversized-local", "instructions": ""
+    });
+    let instruction_bytes = if only_completion_oversized {
+        send_json(&mut ws, payload.clone()).await;
+        let baseline = recv_until_completed(&mut ws).await;
+        assert_eq!(baseline.len(), 2);
+        let created_bytes = baseline[0].to_string().len();
+        assert!(baseline[1].to_string().len() > created_bytes);
+        // Fill the created event exactly to the wire limit. The completed event
+        // is larger because it includes usage, so both must be checked up front.
+        1024 * 1024 - created_bytes
+    } else {
+        2 * 1024 * 1024
+    };
+    payload["instructions"] = json!("x".repeat(instruction_bytes));
+    payload["input"] = json!("must not be stored");
+    send_json(&mut ws, payload).await;
+    let event = recv_json(&mut ws).await;
+    assert_eq!(
+        event["type"], "error",
+        "no lifecycle event may be emitted for an oversized local response"
+    );
+    assert_eq!(event["stream_id"], "oversized-local");
+    assert!(event["error"]["message"].as_str().unwrap().contains("exceeded"));
+    assert!(event.to_string().len() <= 1024 * 1024);
+    let responses = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM responses")
+        .fetch_one(fixture.pool.as_ref())
+        .await
+        .unwrap();
+    assert_eq!(
+        responses,
+        i64::from(only_completion_oversized),
+        "rejected response must not be persisted"
+    );
+    let items = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM items")
+        .fetch_one(fixture.pool.as_ref())
+        .await
+        .unwrap();
+    assert_eq!(items, 0, "rejected response must not leave orphaned items");
+    gateway.abort();
+}
+
+#[tokio::test]
 async fn test_websocket_generate_false_prewarm_persists_context_without_inference() {
     let mock = MockResponsesServer::start(vec![sse_response("resp_upstream_1", "msg_upstream_1", "READY")]).await;
     let fixture = storage_backed_state(&mock.url).await;

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -55,6 +55,10 @@ with `store=true`, `previous_response_id`, `conversation_id`, compaction input,
 or `context_management` run through the executor. Other stateless `store=false`
 requests are passed directly to the configured vLLM backend.
 
+Executor-backed requests accept at most 64 MCP server declarations and 128
+discovered MCP tools. MCP discovery metadata shares the request's 1 MiB
+response budget with upstream rounds and gateway tool output.
+
 ### `POST /v1/responses/compact`
 
 Compacts direct input or a stored previous-response chain into a canonical
@@ -70,6 +74,7 @@ continuations. Send one JSON text frame per turn:
 ```json
 {
   "type": "response.create",
+  "stream_id": "turn-1",
   "model": "test-model",
   "input": [{"type": "message", "role": "user", "content": "hi"}],
   "previous_response_id": "resp_optional",
@@ -84,11 +89,24 @@ JSON Responses stream events, including `response.created`,
 `response.output_item.added`, `response.output_text.delta`, and
 `response.completed`.
 
+Set `stream_id` to a string containing 1 to 256 characters to multiplex
+responses over one connection. Requests with different `stream_id` values can
+run concurrently, while requests with the same value run first in, first out.
+Every event for an accepted request, including an execution error event, echoes
+its `stream_id`.
+Requests that omit `stream_id` share a default first-in, first-out lane for
+backward compatibility. A connection accepts at most 64 outstanding requests and
+12 MiB of aggregate request data; additional requests receive a `429` error event
+until capacity is available. Upstream SSE lines are limited to 256 KiB, normalized
+executor events are limited to 1 MiB, and each request shares a 1 MiB response
+budget across MCP discovery, upstream rounds, and normalized gateway tool output.
+
 Invalid requests are returned as JSON WebSocket error events:
 
 ```json
 {
   "type": "error",
+  "stream_id": "turn-1",
   "status": 404,
   "error": {
     "message": "human-readable error details",

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -100,6 +100,11 @@ backward compatibility. A connection accepts at most 64 outstanding requests and
 until capacity is available. Upstream SSE lines are limited to 256 KiB, normalized
 executor events are limited to 1 MiB, and each request shares a 1 MiB response
 budget across MCP discovery, upstream rounds, and normalized gateway tool output.
+Every outbound WebSocket event, including `stream_id`, is limited to 1 MiB of
+serialized JSON. Local `generate: false` requests validate both lifecycle events
+before storing the response or emitting either event. OIDC identity expiry is
+checked again when queued work starts, including work in the default lane;
+expired work receives a tagged `invalid_token` event without reaching inference.
 
 Invalid requests are returned as JSON WebSocket error events:
 


### PR DESCRIPTION
## Summary

- add typed `stream_id` routing to the Responses WebSocket API and echo it on every event, including local and execution errors
- run distinct stream lanes concurrently while preserving FIFO execution within the same stream and the backward-compatible default lane
- bound outstanding requests, aggregate input, event queues, upstream responses, gateway outputs, and MCP discovery/materialization so multiplexing cannot grow memory without limit
- document the WebSocket contract and add unit/integration coverage for interleaving, ordering, capacity, shutdown, cancellation, and resource limits

## Test Plan

- [x] `cargo test --workspace` (all runnable tests pass; PostgreSQL-only tests remain ignored without `TEST_POSTGRES_URL`)
- [x] `cargo build --workspace --bins`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `uvx pre-commit run --all-files`
- [x] gstack review, Rust-specific review, adversarial review, and final testing/performance review report no remaining findings

Closes #239
