### PR TITLE
ci: stabilize readiness retry test

### DIFF
--- a/tests/python/test_process.py
+++ b/tests/python/test_process.py
@@ -6,6 +6,8 @@ import socket
 import sys
 import threading
 import time
+import urllib.error
+import urllib.request
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from subprocess import TimeoutExpired
@@ -386,41 +388,33 @@ def test_wait_for_vllm_ready_accepts_authenticated_models_response(
     assert ModelsHandler.auth_headers == ["Bearer secret-token"]
 
 
-def test_wait_for_vllm_ready_recovers_from_transient_connection_failures(monkeypatch: pytest.MonkeyPatch) -> None:
-    port = reserve_tcp_port()
-    base_url = f"http://127.0.0.1:{port}"
-    server_ready = threading.Event()
-    stop_server = threading.Event()
+def test_wait_for_vllm_ready_recovers_from_transient_connection_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    models_server: tuple[ThreadingHTTPServer, str],
+) -> None:
+    _, base_url = models_server
+    original_urlopen = urllib.request.urlopen
+    attempts = 0
 
-    def delayed_server() -> None:
-        time.sleep(0.1)
-        server = ThreadingHTTPServer(("127.0.0.1", port), ModelsHandler)
-        server.timeout = 0.05
-        server_ready.set()
-        try:
-            while not stop_server.is_set():
-                server.handle_request()
-        finally:
-            server.server_close()
+    def transient_urlopen(request: urllib.request.Request, *, timeout: float) -> Any:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise urllib.error.URLError(ConnectionRefusedError("simulated connection refusal"))
+        return original_urlopen(request, timeout=timeout)
 
-    thread = threading.Thread(target=delayed_server, daemon=True)
-    thread.start()
-    try:
-        wait_for_vllm_ready(
-            base_url=base_url,
-            api_key=None,
-            process=DummyProcess([None] * 20),
-            timeout=1.0,
-            interval=0.02,
-        )
-    finally:
-        stop_server.set()
-        if server_ready.wait(timeout=1):
-            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
-                pass
-        thread.join(timeout=1)
+    monkeypatch.setattr("agentic_api.process.urllib.request.urlopen", transient_urlopen)
 
-    assert ModelsHandler.requests_seen >= 1
+    wait_for_vllm_ready(
+        base_url=base_url,
+        api_key=None,
+        process=DummyProcess([None] * 20),
+        timeout=0.5,
+        interval=0.01,
+    )
+
+    assert attempts == 3
+    assert ModelsHandler.requests_seen == 1
 
 
 def test_wait_for_vllm_ready_times_out_without_leaking_api_key() -> None:


### PR DESCRIPTION
## Summary

- replace the retry test delayed listener and wake-up cleanup with two deterministic `URLError` failures followed by a real `/v1/models` success through the shared server fixture
- assert exactly three attempts and one actual server request, preserving the retry contract without port-reservation or listener-shutdown races
- leave production code and behavior unchanged

On unmodified `main` at `661d8db`, the [Python 3.13 job](https://github.com/vllm-project/agentic-api/actions/runs/33826508151/job/100880201066) completed the readiness request and then failed in test cleanup when its wake-up connection raced the listener closing: `ConnectionRefusedError` with 113 tests already passing. Python 3.10-3.12 passed in the same matrix. A 200-run local stress control on the untouched test did not reproduce the scheduling-dependent failure.

## Test Plan

- focused Python 3.13 regression repeated 50 times: 50 passed
- CI-style Python 3.13 wheel build, install, full suite, and wheel validation: 114 passed; wheel validation passed
- full editable Python 3.13 suite: 111 passed, 3 skipped
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features` (passed; 5 PostgreSQL tests ignored locally without `TEST_POSTGRES_URL`)
- launcher contracts and CLI end-to-end tests
- cassette validation: 108/108 cassettes, 238 turns
- strict MkDocs build

Local repository-wide pre-commit hooks passed except that the platform-hanging `check-added-large-files` all-files invocation was skipped; that hook passed directly against the only changed file.

Rebased the unchanged patch onto current `main` at `c04ac196`. All 12 hosted checks pass on head `6455cae`, including Python 3.10-3.13, Rust, PostgreSQL, both CLI harnesses, pre-commit, and DCO.
