### PR TITLE
fix: clean up model subprocesses during startup shutdown

### DIFF
--- a/crates/agentic-server/src/server.rs
+++ b/crates/agentic-server/src/server.rs
@@ -83,8 +83,7 @@ async fn serve_gateway_until_signal(
 
     tokio::select! {
         result = &mut gateway => result,
-        signal = shutdown_signal() => {
-            signal?;
+        () = shutdown_signal()? => {
             info!("shutdown signal received");
             shutdown_token.cancel();
             drain_gateway(gateway.as_mut()).await
@@ -108,18 +107,24 @@ where
 }
 
 #[cfg(unix)]
-async fn shutdown_signal() -> Result<(), std::io::Error> {
+fn shutdown_signal() -> Result<impl Future<Output = ()>, std::io::Error> {
     let mut terminate = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
+    let mut interrupt = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())?;
 
-    tokio::select! {
-        signal = tokio::signal::ctrl_c() => signal,
-        _ = terminate.recv() => Ok(()),
-    }
+    Ok(async move {
+        tokio::select! {
+            _ = interrupt.recv() => {},
+            _ = terminate.recv() => {},
+        }
+    })
 }
 
 #[cfg(not(unix))]
-async fn shutdown_signal() -> Result<(), std::io::Error> {
-    tokio::signal::ctrl_c().await
+fn shutdown_signal() -> Result<impl Future<Output = ()>, std::io::Error> {
+    let mut interrupt = tokio::signal::windows::ctrl_c()?;
+    Ok(async move {
+        interrupt.recv().await;
+    })
 }
 
 async fn wait_until_llm_ready(config: &Config) -> Result<(), ServerError> {
@@ -166,67 +171,54 @@ pub async fn run_with_llm(
         Some(config) => Some(OidcAuthenticator::discover(config).await?),
         None => None,
     };
+    // Register signal handlers before spawning the owned subprocess, and
+    // retain the same listener across startup and serving so no signal is lost.
+    let shutdown = shutdown_signal()?;
+    tokio::pin!(shutdown);
     let mut cmd = tokio::process::Command::new("python");
     cmd.arg("-m").arg("vllm.entrypoints.openai.api_server");
     cmd.args(&llm_args);
+    cmd.kill_on_drop(true);
 
     let mut child = cmd.spawn()?;
     info!("spawned vLLM subprocess (pid {})", child.id().unwrap_or(0));
 
-    let readiness_result = if config.skip_llm_ready_check {
-        info!("skipping LLM readiness check: {}", config.llm_api_base);
-        Ok(false)
-    } else {
-        tokio::select! {
-            ready = wait_llm_ready(&config) => ready.map(|()| true).map_err(ServerError::from),
+    let shutdown_token = CancellationToken::new();
+    let result = async {
+        let state = tokio::select! {
+            biased;
+            () = &mut shutdown => {
+                info!("shutdown signal received during startup");
+                return Ok(());
+            }
             status = child.wait() => {
                 let status = status?;
-                Err(ServerError::from(CoreError::LlmProcessExited { status: status.to_string() }))
+                return Err(ServerError::from(CoreError::LlmProcessExited { status: status.to_string() }));
             }
-        }
-    };
+            state = async {
+                wait_until_llm_ready(&config).await?;
+                build_state(&config, shutdown_token.clone()).await
+            } => state?,
+        };
 
-    match readiness_result {
-        Ok(true) => info!("LLM ready: {}", config.llm_api_base),
-        Ok(false) => {}
-        Err(err) => {
-            let _ = child.kill().await;
-            let _ = child.wait().await;
-            return Err(err);
+        let gateway = serve_gateway(state, host, port, authenticator);
+        tokio::pin!(gateway);
+
+        tokio::select! {
+            gateway = &mut gateway => gateway,
+            status = child.wait() => {
+                shutdown_token.cancel();
+                let status = status?;
+                Err(ServerError::from(CoreError::LlmProcessExited { status: status.to_string() }))
+            },
+            () = &mut shutdown => {
+                info!("shutdown signal received");
+                shutdown_token.cancel();
+                drain_gateway(gateway.as_mut()).await
+            }
         }
     }
-
-    let shutdown_token = CancellationToken::new();
-    let state = match build_state(&config, shutdown_token.clone()).await {
-        Ok(s) => s,
-        Err(err) => {
-            let _ = child.kill().await;
-            let _ = child.wait().await;
-            return Err(err);
-        }
-    };
-
-    let gateway = serve_gateway(state, host, port, authenticator);
-    tokio::pin!(gateway);
-
-    let result = tokio::select! {
-        gateway = &mut gateway => gateway,
-        status = child.wait() => {
-            shutdown_token.cancel();
-            let status = status?;
-            Err(ServerError::from(CoreError::LlmProcessExited { status: status.to_string() }))
-        },
-        signal = shutdown_signal() => {
-            match signal {
-                Ok(()) => {
-                    info!("shutdown signal received");
-                    shutdown_token.cancel();
-                    drain_gateway(gateway.as_mut()).await
-                }
-                Err(err) => Err(err.into()),
-            }
-        }
-    };
+    .await;
 
     let _ = child.kill().await;
     let _ = child.wait().await;

--- a/crates/agentic-server/tests/server_lifecycle_test.rs
+++ b/crates/agentic-server/tests/server_lifecycle_test.rs
@@ -1,0 +1,237 @@
+//! Process-level coverage of gateway-owned model startup and shutdown.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::time::{sleep, timeout};
+
+const TEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+struct ServerProcess {
+    child: Child,
+    directory: tempfile::TempDir,
+}
+
+impl ServerProcess {
+    fn start(upstream_port: u16, extra_args: &[&str]) -> Self {
+        let directory = tempfile::tempdir().expect("temporary server home");
+        let python = directory.path().join("python");
+        // exec preserves the child PID without spawning any grandchildren.
+        fs::write(&python, "#!/bin/sh\nexec /bin/sleep 120\n").unwrap();
+        fs::set_permissions(&python, fs::Permissions::from_mode(0o755)).unwrap();
+        let log = fs::File::create(directory.path().join("server.log")).unwrap();
+        let child = Command::new(env!("CARGO_BIN_EXE_agentic-server"))
+            .env_clear()
+            .env("PATH", directory.path())
+            .env("AGENTIC_API_HOME", directory.path())
+            .args([
+                "serve",
+                "mock-model",
+                "--port",
+                &upstream_port.to_string(),
+                "--gateway-host",
+                "127.0.0.1",
+                "--gateway-port",
+                "0",
+                "--llm-ready-interval-s",
+                "60",
+            ])
+            .args(extra_args)
+            .stdin(Stdio::null())
+            .stdout(log.try_clone().unwrap())
+            .stderr(log)
+            .spawn()
+            .expect("agentic-server must start");
+        Self { child, directory }
+    }
+
+    fn log(&self) -> String {
+        fs::read_to_string(self.directory.path().join("server.log")).unwrap()
+    }
+
+    fn recorded_model_pid(&self) -> Option<u32> {
+        self.log().lines().find_map(|line| {
+            line.split_once("spawned vLLM subprocess (pid ")?
+                .1
+                .split_once(')')?
+                .0
+                .parse()
+                .ok()
+        })
+    }
+
+    fn model_pid(&self) -> u32 {
+        self.recorded_model_pid()
+            .unwrap_or_else(|| panic!("model did not start: {}", self.log()))
+    }
+
+    async fn wait(&mut self) -> ExitStatus {
+        timeout(TEST_TIMEOUT, async {
+            loop {
+                if let Some(status) = self.child.try_wait().unwrap() {
+                    return status;
+                }
+                sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| panic!("server did not exit promptly: {}", self.log()))
+    }
+
+    async fn stop(&mut self, signal: &str) {
+        let pid = self.model_pid();
+        send_signal(self.child.id(), signal);
+        let status = self.wait().await;
+        assert!(!process_exists(pid), "owned model subprocess survived shutdown");
+        assert!(status.success(), "shutdown failed: {status}; {}", self.log());
+    }
+}
+
+impl Drop for ServerProcess {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        // Also clean up the model when a regression leaves it orphaned.
+        if let Some(pid) = self.recorded_model_pid() {
+            let _ = Command::new("kill").args(["-KILL", &pid.to_string()]).output();
+        }
+    }
+}
+
+fn process_exists(pid: u32) -> bool {
+    Command::new("kill")
+        .args(["-0", &pid.to_string()])
+        .output()
+        .expect("check subprocess existence")
+        .status
+        .success()
+}
+
+fn send_signal(pid: u32, signal: &str) {
+    assert!(
+        Command::new("kill")
+            .args([signal, &pid.to_string()])
+            .status()
+            .expect("send signal")
+            .success()
+    );
+}
+
+async fn listener() -> TcpListener {
+    TcpListener::bind("127.0.0.1:0").await.unwrap()
+}
+
+async fn health_request(listener: &TcpListener) -> TcpStream {
+    timeout(TEST_TIMEOUT, async {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut request = Vec::new();
+        while !request.ends_with(b"\r\n\r\n") {
+            assert!(request.len() < 4096, "unexpected health request length");
+            request.push(stream.read_u8().await.unwrap());
+        }
+        assert!(request.starts_with(b"GET /health HTTP/1.1\r\n"));
+        stream
+    })
+    .await
+    .expect("server must send a real readiness request")
+}
+
+async fn stop_during_readiness(signal: &str) {
+    let upstream = listener().await;
+    let mut server = ServerProcess::start(upstream.local_addr().unwrap().port(), &["--db-url", "sqlite::memory:"]);
+    let _stalled_probe = health_request(&upstream).await;
+    server.stop(signal).await;
+}
+
+#[tokio::test]
+async fn sigterm_during_readiness_reaps_model() {
+    stop_during_readiness("-TERM").await;
+}
+
+#[tokio::test]
+async fn sigint_during_readiness_reaps_model() {
+    stop_during_readiness("-INT").await;
+}
+
+async fn stalled_storage_startup() -> (ServerProcess, TcpStream) {
+    let database = listener().await;
+    let url = format!("postgres://test:test@{}/test", database.local_addr().unwrap());
+    let server = ServerProcess::start(0, &["--skip-llm-ready-check", "--db-url", &url]);
+    let (stream, _) = timeout(TEST_TIMEOUT, database.accept())
+        .await
+        .expect("server must attempt its configured database connection")
+        .unwrap();
+    (server, stream)
+}
+
+#[tokio::test]
+async fn sigterm_during_storage_startup_reaps_model() {
+    let (mut server, _stalled_database) = stalled_storage_startup().await;
+    server.stop("-TERM").await;
+}
+
+#[tokio::test]
+async fn sigint_during_storage_startup_reaps_model() {
+    let (mut server, _stalled_database) = stalled_storage_startup().await;
+    server.stop("-INT").await;
+}
+
+#[tokio::test]
+async fn model_exit_during_storage_startup_is_reported_promptly() {
+    let (mut server, _stalled_database) = stalled_storage_startup().await;
+    let pid = server.model_pid();
+    send_signal(pid, "-KILL");
+    let status = server.wait().await;
+    assert!(!status.success());
+    assert!(server.log().contains("LlmProcessExited"), "{}", server.log());
+    assert!(!process_exists(pid), "exited model must be reaped");
+}
+
+#[tokio::test]
+async fn readiness_timeout_still_reaps_model_and_returns_error() {
+    let upstream = listener().await;
+    let mut server = ServerProcess::start(
+        upstream.local_addr().unwrap().port(),
+        &["--llm-ready-timeout-s", "1", "--db-url", "sqlite::memory:"],
+    );
+    let _stalled_probe = health_request(&upstream).await;
+    let pid = server.model_pid();
+    assert!(!server.wait().await.success());
+    assert!(server.log().contains("LlmTimeout"), "{}", server.log());
+    assert!(!process_exists(pid), "timed-out model must be reaped");
+}
+
+#[tokio::test]
+async fn storage_startup_failure_still_reaps_model_and_returns_error() {
+    let directory = tempfile::tempdir().unwrap();
+    let url = format!("sqlite://{}", directory.path().display());
+    let mut server = ServerProcess::start(0, &["--skip-llm-ready-check", "--db-url", &url]);
+    assert!(!server.wait().await.success());
+    assert!(server.log().contains("Error:"), "{}", server.log());
+    assert!(!process_exists(server.model_pid()));
+}
+
+#[tokio::test]
+async fn sigterm_after_gateway_startup_still_reaps_model() {
+    let upstream = listener().await;
+    let mut server = ServerProcess::start(upstream.local_addr().unwrap().port(), &["--db-url", "sqlite::memory:"]);
+    health_request(&upstream)
+        .await
+        .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+        .await
+        .unwrap();
+    timeout(TEST_TIMEOUT, async {
+        while !server.log().contains("gateway listening on") {
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("gateway did not start: {}", server.log()));
+    server.stop("-TERM").await;
+}


### PR DESCRIPTION
## Summary

`agentic-server serve` can exit on SIGTERM or SIGINT while leaving its model subprocess alive if readiness polling or database initialization is still pending. A model that exits during database initialization also goes unnoticed until storage startup finishes or times out.

Register shutdown handlers before spawning the model, retain one listener across startup and serving, and monitor shutdown and child exit throughout readiness and state initialization. Route every result after spawning through the existing awaited child cleanup, with kill-on-drop as a cancellation fallback. Preserve the bounded gateway drain after serving begins.

Add eight tests that run the real gateway executable with an owned lightweight subprocess and local HTTP/database fixtures. Against unchanged main production at `40b98c4`, five regressions fail for the intended reasons: four surviving children and one unreported child exit. Three existing-behavior controls pass. All eight pass with this fix.

## Test Plan

Verified commit `110eb4e6b95759902b3d7f5cb9cf19ba81187bb0` from a clean detached worktree with Rust 1.98.0 on macOS:

- `cargo test --workspace --all-features`: 915 passed; eight PostgreSQL tests and one existing doctest ignored.
- Lifecycle suite repeated in 25 fresh processes, including three concurrent processes: 200 tests passed. Forty additional executable checks cover SIGTERM/SIGINT during a readiness probe and from the model stub's first instructions.
- Interrupted startup while a real SQLite database was exclusively locked, verified child cleanup, then released the lock and successfully restarted against the same database.
- Workspace formatting, all-target/all-feature check and Clippy with warnings denied; all applicable changed-file hooks, plus the remaining repository-wide hooks.
- Python suite: 111 passed, three installation-only skips. Launcher contracts and the full source-install CLI E2E passed using a development-profile wheel.
- Cross-compiled and linted the exact Windows signal helper for `x86_64-pc-windows-gnu`; Windows runtime behavior was not exercised. No live model or GPU was needed for these process-lifecycle checks.
