### PR TITLE
fix: query crates.io during release checks

### DIFF
--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -134,12 +134,12 @@ jobs:
           set -euo pipefail
           version="${{ steps.version.outputs.version }}"
 
-          if cargo info "agentic-server-core@$version" >/dev/null 2>&1; then
+          if cargo info --registry crates-io "agentic-server-core@$version" >/dev/null 2>&1; then
             echo "::error::agentic-server-core $version is already published"
             exit 1
           fi
 
-          if cargo info "agentic-server@$version" >/dev/null 2>&1; then
+          if cargo info --registry crates-io "agentic-server@$version" >/dev/null 2>&1; then
             echo "::error::agentic-server $version is already published"
             exit 1
           fi

--- a/tests/python/test_release_version.py
+++ b/tests/python/test_release_version.py
@@ -95,6 +95,13 @@ def test_crate_release_dry_run_packages_server_against_the_local_core() -> None:
     assert (REPO_ROOT / "target" / "package" / f"agentic-server-{WORKSPACE_VERSION}.crate").is_file()
 
 
+def test_crate_release_published_version_checks_query_crates_io() -> None:
+    workflow = CRATE_RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    published_check = next(block for block in _workflow_run_blocks(workflow) if "is already published" in block)
+
+    assert published_check.count("cargo info --registry crates-io") == 2
+
+
 def test_python_workflows_pin_build_tools_and_manylinux_artifact_contract() -> None:
     release_workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
     python_workflow = PYTHON_WORKFLOW.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- query the explicit crates.io registry when checking whether release versions already exist
- avoid resolving the local workspace package as a false positive
- add regression coverage for both core and server publication checks

## Test Plan

- `CARGO_NET_OFFLINE=true uv run --no-project --python 3.12 --with pytest==9.1.1 python -m pytest tests/python/test_release_version.py -q` (8 passed)
- `CARGO_NET_OFFLINE=true uv run --no-project --python 3.12 --with maturin==1.14.1 --with pytest==9.1.1 python -m pytest tests/python -q` (115 passed, 3 skipped)
- `uv tool run pre-commit run --files .github/workflows/release-crates.yml tests/python/test_release_version.py`