### PR TITLE
chore: add haoshan98 as a maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Maintainers of vLLM Agentic API
 # Default - root-level owners as fallback
-* @bbrowning @franciscojavierarceo @jiahuei @leseb @maralbahari @noobHappylife @qandrew @tjtanaa
+* @bbrowning @franciscojavierarceo @haoshan98 @jiahuei @leseb @maralbahari @noobHappylife @qandrew @tjtanaa


### PR DESCRIPTION
## Summary
Add @haoshan98 to the default maintainers in `.github/CODEOWNERS`.

## Test Plan
- `uvx pre-commit run --all-files` passed.
- `git diff --check` passed.
