### PR TITLE
chore: prepare release v0.7.0

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -9,7 +9,7 @@ on:
         description: "Build-only Python release version already merged into main"
         required: true
         type: string
-        default: "0.6.0"
+        default: "0.7.0"
 
 concurrency:
   group: release-python-${{ inputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to Agentic API are documented here.
 
+## [0.7.0] - 2026-09-11
+
+### Added
+
+- Added client-executed shell tools with typed `shell_call` and `shell_call_output` items, incremental command
+  streaming, explicit tool selection, and stored-history continuation (#264).
+- Added a configurable serialized request size limit for HTTP bodies and WebSocket messages through
+  `--max-request-body-size-bytes`, `AGENTIC_MAX_REQUEST_BODY_SIZE_BYTES`, or `[server] max_request_body_size_bytes`,
+  retaining the 10 MiB default (#260).
+- Added the Agentic API website, versioned documentation navigation, contributor profiles, and automatic website
+  deployment after crate releases (#272, #285, #287).
+
+### Changed
+
+- Unified Responses JSON and SSE processing under `AgentPipeline`, sharing synchronous ingestion, typed output-item
+  assembly, tool-call translation, lifecycle validation, and ordered client delivery (#274).
+- Introduced `MessagesRequestContext` for the Messages tool loop, preserving unmodeled upstream fields while
+  centralizing request mutation and web-search budgets (#249).
+- Changed Rust integration APIs: Messages loops now accept `MessagesRequestContext`, the public `function_sse` module
+  was removed, and gateway configuration uses `GatewayOptions`. Downstream crate consumers must adapt affected
+  integrations (#249, #274, #260).
+
+### Fixed
+
+- Preserved incomplete upstream terminal status when an SSE completion event carries an incomplete response (#277).
+- Honored Responses WebSocket storage settings with bounded connection-local sessions (#257).
+- Applied the configured streaming chunk timeout to stalled upstream error-body reads in Responses streaming and
+  Messages tool-loop requests (#286).
+
+### Testing
+
+- Expanded shell-tool replay and continuation coverage, shared-ingestion lifecycle checks, WebSocket session and
+  storage tests, request-size boundary tests, and stalled upstream error-body regressions.
+
 ## [0.6.0] - 2026-09-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agentic-llm-d"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "agentic-server-core",
  "axum",
@@ -23,14 +23,14 @@ dependencies = [
 
 [[package]]
 name = "agentic-praxis"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "agentic-server-core",
 ]
 
 [[package]]
 name = "agentic-server"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "agentic-server-core",
  "axum",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentic-server-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/vllm-project/agentic-api"
@@ -16,7 +16,7 @@ all = { level = "deny", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
 
 [workspace.dependencies]
-agentic-core = { package = "agentic-server-core", path = "crates/agentic-server-core", version = "0.6.0" }
+agentic-core = { package = "agentic-server-core", path = "crates/agentic-server-core", version = "0.7.0" }
 async-stream = "0.3"
 axum = { version = "0.8", features = ["ws"] }
 either = "1"

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ permission checks and disables Codex approvals and sandboxing.
 ### Python distribution
 
 The `agentic-api` wheel packages the Rust gateway and a small Python launcher. This release produces wheel artifacts
-for 0.6.0 as a build-only release: download the wheel for your platform from the release workflow, then install that
+for 0.7.0 as a build-only release: download the wheel for your platform from the release workflow, then install that
 local file. It is not published on PyPI yet.
 
 ```bash

--- a/docs/guides/python-installation.md
+++ b/docs/guides/python-installation.md
@@ -8,7 +8,7 @@ The Rust-native `agentic` CLI remains supported for `run codex`, `run claude`, `
 
 ## Install the release artifact
 
-This release produces wheel artifacts for 0.6.0 on supported platforms but does not publish them to PyPI yet.
+This release produces wheel artifacts for 0.7.0 on supported platforms but does not publish them to PyPI yet.
 Download the wheel for your platform from the release workflow and use its absolute path below:
 
 ```bash

--- a/website/components/site/quickstart.tsx
+++ b/website/components/site/quickstart.tsx
@@ -3,7 +3,8 @@ import { useEffect, useState } from 'react';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { Check, Copy, Terminal, Code2, ArrowUpRight } from 'lucide-react';
 import {
-  BUILD_COMMAND,
+  CARGO_COMMAND,
+  PYTHON_COMMAND,
   LAUNCH_COMMANDS,
   getLaunchInstructions,
 } from '@/lib/quickstart';
@@ -116,10 +117,10 @@ export function Quickstart() {
             <li>
               <span>02</span>
               <div>
-                <strong>Build Agentic API</strong>
+                <strong>Install and start Agentic API</strong>
                 <p>
-                  Install Rust, clone the repository, and build the gateway and
-                  CLI.
+                  Install the Python wheel with pip, or install the Rust CLI
+                  with Cargo. Start the gateway against your vLLM upstream.
                 </p>
               </div>
             </li>
@@ -128,8 +129,9 @@ export function Quickstart() {
               <div>
                 <strong>Launch your client</strong>
                 <p>
-                  Install Codex or Claude Code, then choose your client and
-                  served model.
+                  For the Cargo CLI, choose Codex or Claude Code below. The
+                  client launcher starts its own gateway; use it instead of the
+                  standalone serve command.
                 </p>
               </div>
             </li>
@@ -148,7 +150,40 @@ export function Quickstart() {
             <span>QUICKSTART</span>
             <span>bash</span>
           </div>
-          <CopyCode code={BUILD_COMMAND} label="Build from source" />
+          <Tabs defaultValue="python" className="launch-tabs">
+            <TabsList
+              className="launch-tab-list"
+              aria-label="Choose installation method"
+            >
+              <TabsTrigger value="python">Python / pip</TabsTrigger>
+              <TabsTrigger value="cargo">Cargo</TabsTrigger>
+            </TabsList>
+            <TabsContent value="python">
+              <CopyCode
+                code={PYTHON_COMMAND}
+                label="Install and start with Python"
+              />
+              <div className="terminal-note">
+                <p>
+                  Python 3.10+. Download your platform wheel from the{' '}
+                  <a href={`${REPO}/actions/workflows/release-python.yml`}>
+                    release workflow
+                  </a>
+                  . PyPI publication is pending; once published, install with{' '}
+                  <code>python -m pip install agentic-api</code>.
+                </p>
+              </div>
+            </TabsContent>
+            <TabsContent value="cargo">
+              <CopyCode
+                code={CARGO_COMMAND}
+                label="Install and start with Cargo"
+              />
+            </TabsContent>
+          </Tabs>
+          <p className="terminal-note">
+            Coding clients with the Cargo-installed CLI
+          </p>
           <Tabs defaultValue="codex" className="launch-tabs">
             <TabsList
               className="launch-tab-list"

--- a/website/lib/quickstart.ts
+++ b/website/lib/quickstart.ts
@@ -1,12 +1,17 @@
 import { REPO } from './site';
-export const BUILD_COMMAND = `git clone https://github.com/vllm-project/agentic-api.git
-cd agentic-api
-cargo build -p agentic-server --bins`;
+export const BUILD_COMMAND = 'cargo install agentic-server --locked';
+export const PYTHON_COMMAND = `python -m venv .venv
+source .venv/bin/activate
+# Download the wheel for your platform first.
+python -m pip install /absolute/path/to/agentic_api-PLATFORM.whl
+python -m agentic_api serve --vllm-base-url http://127.0.0.1:5050`;
+export const CARGO_COMMAND = `${BUILD_COMMAND}
+agentic serve --upstream http://127.0.0.1:5050`;
 export const LAUNCH_COMMANDS = {
   codex:
-    './target/debug/agentic run codex \\\n  --upstream http://127.0.0.1:5050 \\\n  --model Qwen/Qwen3-30B-A3B-FP8',
+    'agentic run codex \\\n  --upstream http://127.0.0.1:5050 \\\n  --model Qwen/Qwen3-30B-A3B-FP8',
   claude:
-    './target/debug/agentic run claude \\\n  --upstream http://127.0.0.1:5050 \\\n  --model Qwen/Qwen3-30B-A3B-FP8',
+    'agentic run claude \\\n  --upstream http://127.0.0.1:5050 \\\n  --model Qwen/Qwen3-30B-A3B-FP8',
 };
 export function getLaunchInstructions(input: unknown) {
   if (
@@ -20,7 +25,7 @@ export function getLaunchInstructions(input: unknown) {
   return {
     harness: input.harness,
     prerequisites:
-      'Install Rust and the selected client. Serve a tool-capable model with vLLM at http://127.0.0.1:5050. Replace the example model with the one you serve.',
+      'Install agentic-server with Cargo and install the selected client. Serve a tool-capable model with vLLM at http://127.0.0.1:5050. Replace the example model with the one you serve.',
     build: BUILD_COMMAND,
     launch: LAUNCH_COMMANDS[input.harness],
     guide: `${REPO}#agentic-api-cli`,


### PR DESCRIPTION
## Summary

Prepare v0.7.0 by updating all workspace crates and the published core dependency, refreshing Cargo.lock, and aligning installation documentation. Add release notes for the merged changes since v0.6.0, including shell tools, configurable request sizes, Responses ingestion and cancellation-safe delivery, Messages fixes, WebSocket storage, and typed web-search normalization.

Preserve the merged Trusted Publishing workflow, which reads the version from Cargo.toml without a separate version input. Extend the current website installation tabs with standalone Python and Cargo server-start commands.

Resolve conflicts against main through 4784ffc. Package publication remains a separate manual workflow dispatch after merge; this PR does not publish packages or create release tags.

## Test Plan

- `cargo check --workspace --locked`: passed.
- `cargo clippy --all-targets --locked -- -D warnings`: passed.
- `cargo test --workspace --locked`: 1,442 passed, 9 ignored.
- `uv run --no-project --python 3.12 --with pytest==9.1.1 python -m pytest tests/python -q`: 118 passed, 3 skipped.
- Website `npm run build`, `npm run check`, `npm test`: passed (16 tests).
- `cargo publish --dry-run --locked --allow-dirty -p agentic-server-core`: passed, no upload.
- Python tests package the server crate against the local core.
- `uvx --python 3.12 pre-commit run --all-files`: passed.
- Locked Cargo metadata confirms all four workspace crates report 0.7.0.
- `git diff --cached --check` and `git diff --check`: passed.
